### PR TITLE
Matrix traits

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,7 +3,9 @@
 #[derive(PartialEq, Debug)]
 pub enum SprsError {
     IncompatibleDimensions,
+    BadWorkspaceDimensions,
     IncompatibleStorages,
+    BadStorageType,
     EmptyStackingList,
     NotImplemented,
     EmptyBmatRow,

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -1,0 +1,24 @@
+///! Traits to generalize over compressed sparse matrices storages
+
+
+use sparse::csmat::{CsMat, CsMatView};
+use std::ops::{Deref};
+
+/// The SpMatView trait describes data that can be seen as a view
+/// into a CsMat
+pub trait SpMatView<N> {
+    /// Return a view into the current matrix
+    fn borrowed(&self) -> CsMatView<N>;
+}
+
+
+impl<N, IndStorage, DataStorage> SpMatView<N>
+for CsMat<N, IndStorage, DataStorage>
+where N: Copy,
+      IndStorage: Deref<Target=[usize]>,
+      DataStorage: Deref<Target=[N]> {
+
+    fn borrowed(&self) -> CsMatView<N> {
+        self.borrowed()
+    }
+}

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -1,9 +1,8 @@
 //! High level construction of sparse matrices by stacking, by block, ...
 
-use std::ops::{Deref};
 use std::default::Default;
 use std::cmp;
-use sparse::csmat::{CsMatVec, CsMatView, CompressedStorage};
+use sparse::csmat::{CsMatVec, CsMatView};
 use errors::SprsError;
 
 /// Stack the given matrices into a new one, using the most efficient stacking

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -564,6 +564,13 @@ DataStorage: DerefMut<Target=[N]> {
         &mut self.data[..]
     }
 
+    /// Sparse matrix self-multiplication by a scalar
+    pub fn scale(&mut self, val: N) where N: Num + Copy {
+        for data in self.data_mut() {
+            *data = *data * val;
+        }
+    }
+
 }
 
 mod raw {
@@ -625,7 +632,7 @@ mod raw {
 mod test {
     use super::{CsMat};
     use super::CompressedStorage::{CSC, CSR};
-    use test_data::{mat1, mat1_csc};
+    use test_data::{mat1, mat1_csc, mat1_times_2};
 
     #[test]
     fn test_new_csr_success() {
@@ -770,5 +777,15 @@ mod test {
         let a_csc_ground_truth = mat1_csc();
         let a_csc = a.to_other_storage();
         assert_eq!(a_csc, a_csc_ground_truth);
+    }
+
+    #[test]
+    fn test_self_smul() {
+        let mut a = mat1();
+        a.scale(2.);
+        let c_true = mat1_times_2();
+        assert_eq!(a.indptr(), c_true.indptr());
+        assert_eq!(a.indices(), c_true.indices());
+        assert_eq!(a.data(), c_true.data());
     }
 }

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -15,4 +15,5 @@ pub mod binop;
 pub mod construct;
 pub mod linalg;
 pub mod symmetric;
+pub mod compressed;
 

--- a/src/test_data.rs
+++ b/src/test_data.rs
@@ -38,3 +38,10 @@ pub fn mat4() -> CsMat<f64, Vec<usize>, Vec<f64>> {
     CsMat::from_vecs(CSC, 5, 5, indptr, indices, data).unwrap()
 }
 
+pub fn mat1_times_2() -> CsMat<f64, Vec<usize>, Vec<f64>> {
+    let indptr = vec![0, 2, 4, 5, 6, 7];
+    let indices = vec![2, 3, 3, 4, 2, 1, 3];
+    let data = vec![6., 8., 4., 10., 10., 16., 14.];
+    CsMat::from_vecs(CSR, 5, 5, indptr, indices, data).unwrap()
+}
+


### PR DESCRIPTION
Add a trait to represent types that can be borrowed as a CsMatView, and use it as a bound for most algorithms.