### PR TITLE
Allow to solve for vector valued matrix products

### DIFF
--- a/src/sparse/linalg/mod.rs
+++ b/src/sparse/linalg/mod.rs
@@ -3,6 +3,7 @@
 
 pub use self::cholesky::ldl_symbolic;
 use num::traits::Num;
+use std::ops::{Add, Sub, Mul, Div};
 use std::iter::IntoIterator;
 
 pub mod cholesky;
@@ -10,10 +11,11 @@ pub mod trisolve;
 pub mod etree;
 
 /// Diagonal solve
-pub fn diag_solve<'a, N, I1, I2>(diag: I1, x: I2)
+pub fn diag_solve<'a, N, M, I1, I2>(diag: I1, x: I2)
 where N: 'a + Copy + Num,
+      M: 'a + Copy + Add<Output=M> + Sub<Output=M> + Mul<N, Output=M> + Div<N, Output=M>,
       I1: IntoIterator<Item = &'a N>,
-      I2: IntoIterator<Item = &'a mut N>
+      I2: IntoIterator<Item = &'a mut M>
 {
 
     for (xv, dv) in x.into_iter().zip(diag.into_iter()) {


### PR DESCRIPTION
This pull request is inspired by wanting to solve matrix equations that are like
A x = b
When x and b are vectors of points in R^n. This is a first pass to get basic functionality, but there might be more places in the library where vector spaces could be used like this. Do you have anywhere else you think this could be useful?