### PR TITLE
Remove unnecessary copy bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "sprs"
 description = "A sparse matrix library"
-version = "0.4.0"
+version = "0.4.0-alpha.1"
 authors = ["Vincent Barrielle <vincent.barrielle@m4x.org>"]
 
 readme = "README.rst"

--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,10 @@ https://vbarrielle.github.io/sprs/doc/sprs/
 Changelog
 ---------
 
-- 0.4.0:
+- 0.4.0-alpha.1:
     - depend on ndarray for dense matrices **breaking change**
+    - iterators return reference where possible **breaking change**
+    - remove unnecessary copy bounds
     - constructors to build sparse matrices from dense matrices
     - forward some LdlSymbolic methods in LdlNumeric
 - 0.3.3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,12 +64,12 @@ mod utils {
 
     /// Create a borrowed CsMat matrix from sliced data without
     /// checking validity. Intended for internal use only.
-    pub fn csmat_borrowed_uchk<'a, N: Copy>(storage: csmat::CompressedStorage,
-                                            nrows : usize, ncols: usize,
-                                            indptr : &'a [usize],
-                                            indices : &'a [usize],
-                                            data : &'a [N]
-                                           ) -> CsMatView<'a, N> {
+    pub fn csmat_borrowed_uchk<'a, N>(storage: csmat::CompressedStorage,
+                                      nrows : usize, ncols: usize,
+                                      indptr : &'a [usize],
+                                      indices : &'a [usize],
+                                      data : &'a [N]
+                                     ) -> CsMatView<'a, N> {
         // not actually memory unsafe here since data comes from slices
         unsafe {
             CsMatView::new_raw(storage, nrows, ncols,

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -131,9 +131,9 @@ F: Fn(N, N) -> N {
     for ((dim, lv), (_, rv)) in lhs.outer_iterator().zip(rhs.outer_iterator()) {
         for elem in lv.iter().nnz_or_zip(rv.iter()) {
             let (ind, binop_val) = match elem {
-                Left((ind, val)) => (ind, binop(val, N::zero())),
-                Right((ind, val)) => (ind, binop(N::zero(), val)),
-                Both((ind, lval, rval)) => (ind, binop(lval, rval)),
+                Left((ind, &val)) => (ind, binop(val, N::zero())),
+                Right((ind, &val)) => (ind, binop(N::zero(), val)),
+                Both((ind, &lval, &rval)) => (ind, binop(lval, rval)),
             };
             if binop_val != N::zero() {
                 out_indices[nnz] = ind;
@@ -220,8 +220,8 @@ where N: 'a + Copy + Num,
             let (mut oval, lr_elems) = items;
             let binop_val = match lr_elems {
                 Left((_, &val)) => binop(val, N::zero()),
-                Right((_, val)) => binop(N::zero(), val),
-                Both((_, &lval, rval)) => binop(lval, rval),
+                Right((_, &val)) => binop(N::zero(), val),
+                Both((_, &lval, &rval)) => binop(lval, rval),
             };
             *oval = binop_val;
         }
@@ -242,9 +242,9 @@ where N: Num + Copy, F: Fn(N, N) -> N {
     res.reserve_exact(max_nnz);
     for elem in lhs.iter().nnz_or_zip(rhs.iter()) {
         let (ind, binop_val) = match elem {
-            Left((ind, val)) => (ind, binop(val, N::zero())),
-            Right((ind, val)) => (ind, binop(N::zero(), val)),
-            Both((ind, lval, rval)) => (ind, binop(lval, rval)),
+            Left((ind, &val)) => (ind, binop(val, N::zero())),
+            Right((ind, &val)) => (ind, binop(N::zero(), val)),
+            Both((ind, &lval, &rval)) => (ind, binop(lval, rval)),
         };
         res.append(ind, binop_val);
     }

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -18,8 +18,7 @@ pub trait SpMatView<N> {
 
 impl<N, IpStorage, IndStorage, DataStorage> SpMatView<N>
 for CsMat<N, IpStorage, IndStorage, DataStorage>
-where N: Copy,
-      IpStorage: Deref<Target=[usize]>,
+where IpStorage: Deref<Target=[usize]>,
       IndStorage: Deref<Target=[usize]>,
       DataStorage: Deref<Target=[N]> {
 
@@ -41,8 +40,7 @@ pub trait SpVecView<N> {
 
 impl<N, IndStorage, DataStorage> SpVecView<N>
 for CsVec<N, IndStorage, DataStorage>
-where N: Copy,
-      IndStorage: Deref<Target=[usize]>,
+where IndStorage: Deref<Target=[usize]>,
       DataStorage: Deref<Target=[N]> {
 
     fn borrowed(&self) -> CsVecView<N> {

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -11,7 +11,7 @@ use num::traits::{Num, Signed};
 /// direction (ie vertical stack for CSR matrices, horizontal stack for CSC)
 pub fn same_storage_fast_stack<'a, N, MatArray>(
     mats: &MatArray) -> Result<CsMatOwned<N>, SprsError>
-where N: 'a + Copy,
+where N: 'a + Clone,
       MatArray: AsRef<[CsMatView<'a, N>]> {
     let mats = mats.as_ref();
     if mats.len() == 0 {
@@ -43,7 +43,7 @@ where N: 'a + Copy,
 
 /// Construct a sparse matrix by vertically stacking other matrices
 pub fn vstack<'a, N, MatArray>(mats: &MatArray) -> Result<CsMatOwned<N>, SprsError>
-where N: 'a + Copy + Default,
+where N: 'a + Clone + Default,
       MatArray: AsRef<[CsMatView<'a, N>]> {
     let mats = mats.as_ref();
     if mats.iter().all(|x| x.is_csr()) {
@@ -57,7 +57,7 @@ where N: 'a + Copy + Default,
 
 /// Construct a sparse matrix by horizontally stacking other matrices
 pub fn hstack<'a, N, MatArray>(mats: &MatArray) -> Result<CsMatOwned<N>, SprsError>
-where N: 'a + Copy + Default,
+where N: 'a + Clone + Default,
       MatArray: AsRef<[CsMatView<'a, N>]> {
     let mats = mats.as_ref();
     if mats.iter().all(|x| x.is_csc()) {
@@ -83,7 +83,7 @@ where N: 'a + Copy + Default,
 /// ```
 pub fn bmat<'a, N, OuterArray, InnerArray>(mats: &OuterArray)
 -> Result<CsMatOwned<N>, SprsError>
-where N: 'a + Copy + Default,
+where N: 'a + Clone + Default,
       OuterArray: 'a + AsRef<[InnerArray]>,
       InnerArray: 'a + AsRef<[Option<CsMatView<'a, N>>]> {
     let mats = mats.as_ref();
@@ -140,7 +140,7 @@ where N: 'a + Copy + Default,
 ///
 /// If epsilon is negative, it will be clamped to zero.
 pub fn csr_from_dense<N>(m: ArrayView<N, (Ix, Ix)>, epsilon: N) -> CsMatOwned<N>
-where N: Num + Copy + cmp::PartialOrd + Signed
+where N: Num + Clone + cmp::PartialOrd + Signed
 {
     let epsilon = if epsilon > N::zero() { epsilon } else { N::zero() };
     let rows = m.shape()[0];
@@ -156,10 +156,10 @@ where N: Num + Copy + cmp::PartialOrd + Signed
     let mut indices = Vec::with_capacity(nnz);
     let mut data = Vec::with_capacity(nnz);
     for row in m.outer_iter() {
-        for (col_ind, &x) in row.iter().enumerate() {
+        for (col_ind, x) in row.iter().enumerate() {
             if x.abs() > epsilon {
                 indices.push(col_ind);
-                data.push(x);
+                data.push(x.clone());
             }
         }
     }
@@ -179,7 +179,7 @@ where N: Num + Copy + cmp::PartialOrd + Signed
 pub fn csc_from_dense<N>(m: ArrayView<N, (Ix, Ix)>,
                          epsilon: N
                         ) -> CsMatOwned<N>
-where N: Num + Copy + cmp::PartialOrd + Signed
+where N: Num + Clone + cmp::PartialOrd + Signed
 {
     csr_from_dense(m.reversed_axes(), epsilon).transpose_into()
 }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -117,7 +117,7 @@ for OuterIterator<'iter, N> {
 /// Permuted outer iteration on a compressed matrix yields
 /// a tuple consisting of the outer index and of a sparse vector
 /// containing the associated inner dimension
-impl <'iter, 'perm: 'iter, N: 'iter + Copy>
+impl <'iter, 'perm: 'iter, N: 'iter>
 Iterator
 for OuterIteratorPerm<'iter, 'perm, N> {
     type Item = (usize, CsVec<N, &'iter[usize], &'iter[N]>);
@@ -153,7 +153,7 @@ for OuterIteratorPerm<'iter, 'perm, N> {
 /// Only the outer dimension iteration is reverted. If you wish to also
 /// revert the inner dimension, you should call rev() again when iterating
 /// the vector.
-impl <'iter, N: 'iter + Copy>
+impl <'iter, N: 'iter>
 DoubleEndedIterator
 for OuterIterator<'iter, N> {
     #[inline]
@@ -176,7 +176,7 @@ for OuterIterator<'iter, N> {
     }
 }
 
-impl <'iter, N: 'iter + Copy> ExactSizeIterator for OuterIterator<'iter, N> {
+impl <'iter, N: 'iter> ExactSizeIterator for OuterIterator<'iter, N> {
     fn len(&self) -> usize {
         self.indptr_iter.len()
     }
@@ -299,7 +299,7 @@ impl<'a, N:'a> CsMat<N, &'a [usize], &'a [usize], &'a [N]> {
 
 }
 
-impl<N: Copy> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
+impl<N> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
     /// Create an empty CsMat for building purposes
     pub fn empty(storage: CompressedStorage, inner_size: usize
                 ) -> CsMatOwned<N> {
@@ -374,11 +374,12 @@ impl<N: Copy> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
     }
 
     /// Append an outer dim to an existing matrix, compressing it in the process
-    pub fn append_outer(mut self, data: &[N]) -> Self where N: Num {
+    pub fn append_outer(mut self, data: &[N]) -> Self
+    where N: Clone + Num {
         for (inner_ind, val) in data.iter().enumerate() {
             if *val != N::zero() {
                 self.indices.push(inner_ind);
-                self.data.push(*val);
+                self.data.push(val.clone());
                 self.nnz += 1;
             }
         }
@@ -391,11 +392,13 @@ impl<N: Copy> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
     }
 
     /// Append an outer dim to an existing matrix, provided by a sparse vector
-    pub fn append_outer_csvec(mut self, vec: CsVec<N,&[usize],&[N]>) -> Self {
+    pub fn append_outer_csvec(mut self, vec: CsVec<N,&[usize],&[N]>) -> Self
+    where N: Clone
+    {
         assert_eq!(self.inner_dims(), vec.dim());
         for (ind, val) in vec.indices().iter().zip(vec.data()) {
             self.indices.push(*ind);
-            self.data.push(*val);
+            self.data.push(val.clone());
         }
         match self.storage {
             CSR => self.nrows += 1,
@@ -407,7 +410,7 @@ impl<N: Copy> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
     }
 }
 
-impl<N: Num + Copy> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
+impl<N: Num> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
     /// Identity matrix
     ///
     /// ```rust
@@ -418,7 +421,9 @@ impl<N: Num + Copy> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
     /// assert_eq!(x, y);
     /// ```
     pub fn eye(storage: CompressedStorage, dim: usize
-              ) -> CsMatOwned<N> {
+              ) -> CsMatOwned<N>
+    where N: Clone
+    {
         let n = dim;
         let indptr = (0..n+1).collect();
         let indices = (0..n).collect();
@@ -747,14 +752,16 @@ where IptrStorage: Deref<Target=[usize]>,
 
 impl<N, IptrStorage, IndStorage, DataStorage>
 CsMat<N, IptrStorage, IndStorage, DataStorage>
-where N: Copy + Default,
+where N: Default,
       IptrStorage: Deref<Target=[usize]>,
       IndStorage: Deref<Target=[usize]>,
       DataStorage: Deref<Target=[N]> {
 
     /// Create a matrix mathematically equal to this one, but with the
     /// opposed storage (a CSC matrix will be converted to CSR, and vice versa)
-    pub fn to_other_storage(&self) -> CsMatOwned<N> {
+    pub fn to_other_storage(&self) -> CsMatOwned<N>
+    where N: Clone
+    {
         let mut indptr = vec![0; self.inner_dims() + 1];
         let mut indices = vec![0; self.nb_nonzero()];
         let mut data = vec![N::default(); self.nb_nonzero()];
@@ -768,7 +775,9 @@ where N: Copy + Default,
 
     /// Create a new CSC matrix equivalent to this one.
     /// A new matrix will be created even if this matrix was already CSC.
-    pub fn to_csc(&self) -> CsMatOwned<N> {
+    pub fn to_csc(&self) -> CsMatOwned<N>
+    where N: Clone
+    {
         match self.storage {
             CSR => self.to_other_storage(),
             CSC => self.to_owned()
@@ -777,7 +786,9 @@ where N: Copy + Default,
 
     /// Create a new CSR matrix equivalent to this one.
     /// A new matrix will be created even if this matrix was already CSR.
-    pub fn to_csr(&self) -> CsMatOwned<N> {
+    pub fn to_csr(&self) -> CsMatOwned<N>
+    where N: Clone
+    {
         match self.storage {
             CSR => self.to_owned(),
             CSC => self.to_other_storage()
@@ -789,7 +800,6 @@ where N: Copy + Default,
 impl<N, IptrStorage, IndStorage, DataStorage>
 CsMat<N, IptrStorage, IndStorage, DataStorage>
 where
-N: Copy,
 IptrStorage: DerefMut<Target=[usize]>,
 IndStorage: DerefMut<Target=[usize]>,
 DataStorage: DerefMut<Target=[N]> {
@@ -827,15 +837,15 @@ pub mod raw {
     ///
     /// Panics if the output slices don't match the input matrices'
     /// corresponding slices.
-    pub fn convert_storage<N: Copy>(in_storage: super::CompressedStorage,
-                                    in_rows: usize,
-                                    in_cols: usize,
-                                    in_indtpr: &[usize],
-                                    in_indices: &[usize],
-                                    in_data: &[N],
-                                    indptr: &mut [usize],
-                                    indices: &mut[usize],
-                                    data: &mut [N]) {
+    pub fn convert_storage<N: Clone>(in_storage: super::CompressedStorage,
+                                     in_rows: usize,
+                                     in_cols: usize,
+                                     in_indtpr: &[usize],
+                                     in_indices: &[usize],
+                                     in_data: &[N],
+                                     indptr: &mut [usize],
+                                     indices: &mut[usize],
+                                     data: &mut [N]) {
         // we're building a csmat even though the indices are not sorted,
         // but it's not a problem since we don't rely on this property.
         // FIXME: this would be better with an explicit unsorted matrix type
@@ -855,7 +865,7 @@ pub mod raw {
     ///
     /// Panics if the output slices don't match the input matrices'
     /// corresponding slices.
-    pub fn convert_mat_storage<N: Copy>(mat: CsMatView<N>,
+    pub fn convert_mat_storage<N: Clone>(mat: CsMatView<N>,
                                         indptr: &mut [usize],
                                         indices: &mut[usize],
                                         data: &mut [N]) {
@@ -882,9 +892,9 @@ pub mod raw {
         }
 
         for (outer_dim, vec) in mat.outer_iterator() {
-            for (inner_dim, &val) in vec.iter() {
+            for (inner_dim, val) in vec.iter() {
                 let dest = indptr[inner_dim];
-                data[dest] = val;
+                data[dest] = val.clone();
                 indices[dest] = outer_dim;
                 indptr[inner_dim] += 1;
             }
@@ -1102,7 +1112,7 @@ pub struct ChunkOuterBlocks<'a, N: 'a> {
     bloc_count: usize,
 }
 
-impl<'a, N: 'a + Copy> Iterator for ChunkOuterBlocks<'a, N> {
+impl<'a, N: 'a> Iterator for ChunkOuterBlocks<'a, N> {
     type Item = CsMatView<'a, N>;
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         let cur_dim = self.dims_in_bloc * self.bloc_count;

--- a/src/sparse/linalg/cholesky.rs
+++ b/src/sparse/linalg/cholesky.rs
@@ -331,8 +331,8 @@ where N: Clone + Copy + PartialEq + Num + PartialOrd,
         l_nz[k] = 0;
         pattern_workspace.clear_right();
 
-        for (inner_ind, val) in vec.iter_perm(perm.inv())
-                                   .filter(|&(i, _)| i <= k) {
+        for (inner_ind, &val) in vec.iter_perm(perm.inv())
+                                    .filter(|&(i, _)| i <= k) {
             y_workspace[inner_ind] = y_workspace[inner_ind] + val;
             let mut i = inner_ind;
             pattern_workspace.clear_left();
@@ -382,7 +382,7 @@ where N: Clone + Copy + Num,
 {
     for (col_ind, vec) in l.outer_iterator() {
         let x_col = x[col_ind];
-        for (row_ind, value) in vec.iter() {
+        for (row_ind, &value) in vec.iter() {
             x[row_ind] = x[row_ind] - value * x_col;
         }
     }
@@ -396,7 +396,7 @@ where N: Clone + Copy + Num,
 {
     for (outer_ind, vec) in l.outer_iterator().rev() {
         let mut x_outer = x[outer_ind];
-        for (inner_ind, value) in vec.iter() {
+        for (inner_ind, &value) in vec.iter() {
             x_outer = x_outer - value * x[inner_ind];
         }
         x[outer_ind] = x_outer;

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -51,7 +51,7 @@ where N: Copy + Num,
     for (row_ind, row) in lower_tri_mat.outer_iterator() {
         let mut diag_val = N::zero();
         let mut x = rhs[row_ind];
-        for (col_ind, val) in row.iter() {
+        for (col_ind, &val) in row.iter() {
             if col_ind == row_ind {
                 diag_val = val;
                 continue;
@@ -119,7 +119,7 @@ where V: vec::VecDim<N> + IndexMut<usize, Output = N>
         let b = rhs[col_ind];
         let x = b / diag_val;
         rhs[col_ind] = x;
-        for (row_ind, val) in col.iter() {
+        for (row_ind, &val) in col.iter() {
             if row_ind <= col_ind {
                 continue;
             }
@@ -169,7 +169,7 @@ where N: Copy + Num,
             let b = rhs[col_ind];
             let x = b / diag_val;
             rhs[col_ind] = x;
-            for (row_ind, val) in col.iter() {
+            for (row_ind, &val) in col.iter() {
                 if row_ind >= col_ind {
                     continue;
                 }
@@ -211,7 +211,7 @@ where N: Copy + Num,
     for (row_ind, row) in upper_tri_mat.outer_iterator().rev() {
         let mut diag_val = N::zero();
         let mut x = rhs[row_ind];
-        for (col_ind, val) in row.iter() {
+        for (col_ind, &val) in row.iter() {
             if col_ind == row_ind {
                 diag_val = val;
                 continue;

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -23,7 +23,7 @@ where N: Num + Copy {
 
     for (col_ind, vec) in mat.outer_iterator() {
         let multiplier = &in_vec[col_ind];
-        for (row_ind, value) in vec.iter() {
+        for (row_ind, &value) in vec.iter() {
             // TODO: unsafe access to value? needs bench
             res_vec[row_ind] =
                 res_vec[row_ind] + *multiplier * value;
@@ -46,7 +46,7 @@ where N: Num + Copy {
     }
 
     for (row_ind, vec) in mat.outer_iterator() {
-        for (col_ind, value) in vec.iter() {
+        for (col_ind, &value) in vec.iter() {
             // TODO: unsafe access to value? needs bench
             res_vec[row_ind] =
                 res_vec[row_ind] + in_vec[col_ind] * value;
@@ -147,12 +147,12 @@ where N: Num + Copy {
             *wval = N::zero();
         }
         // accumulate the resulting row
-        for (lcol, lval) in lvec.iter() {
+        for (lcol, &lval) in lvec.iter() {
             // we can't be out of bounds thanks to the checks of dimension
             // compatibility and the structure check of CsMat. Therefore it
             // should be safe to call into an unsafe version of outer_view
             let rvec = rhs.outer_view(lcol).unwrap();
-            for (rcol, rval) in rvec.iter() {
+            for (rcol, &rval) in rvec.iter() {
                 let wval = &mut workspace[rcol];
                 let prod = lval * rval;
                 *wval = *wval + prod;
@@ -220,7 +220,7 @@ pub fn csr_mulacc_dense_rowmaj<'a, N: 'a + Num + Copy>(
             let axis0 = 0;
             for ((_, line), mut oline) in lblock.outer_iterator()
                                           .zip(oblock.axis_iter_mut(axis0)) {
-                'col_block: for (col_ind, lval) in line.iter() {
+                'col_block: for (col_ind, &lval) in line.iter() {
                     if col_ind < col_start {
                         continue 'col_block;
                     }
@@ -265,7 +265,7 @@ pub fn csc_mulacc_dense_rowmaj<'a, N: 'a + Num + Copy>(
     }
 
     for ((_, lcol), rline) in lhs.outer_iterator().zip(rhs.outer_iter()) {
-        for (orow, lval) in lcol.iter() {
+        for (orow, &lval) in lcol.iter() {
             let mut oline = out.row_mut(orow);
             for (oval, &rval) in oline.iter_mut().zip(rline.iter()) {
                 let prev = *oval;
@@ -304,7 +304,7 @@ pub fn csc_mulacc_dense_colmaj<'a, N: 'a + Num + Copy>(
     for (mut ocol, rcol) in out.axis_iter_mut(axis1).zip(rhs.axis_iter(axis1)) {
         for (rrow, lcol) in lhs.outer_iterator() {
             let rval = rcol[[rrow]];
-            for (orow, lval) in lcol.iter() {
+            for (orow, &lval) in lcol.iter() {
                 let prev = ocol[[orow]];
                 ocol[[orow]] = prev + lval * rval;
             }
@@ -341,7 +341,7 @@ pub fn csr_mulacc_dense_colmaj<'a, N: 'a + Num + Copy>(
     for (mut ocol, rcol) in out.axis_iter_mut(axis1).zip(rhs.axis_iter(axis1)) {
         for (orow, lrow) in lhs.outer_iterator() {
             let mut prev = ocol[[orow]];
-            for (rrow, lval) in lrow.iter() {
+            for (rrow, &lval) in lrow.iter() {
                 let rval = rcol[[rrow]];
                 prev = prev + lval * rval;
             }

--- a/src/sparse/symmetric.rs
+++ b/src/sparse/symmetric.rs
@@ -7,7 +7,7 @@ use sparse::csmat::CsMat;
 pub fn is_symmetric<N, IpStorage, IStorage, DStorage>(
     mat: &CsMat<N, IpStorage, IStorage, DStorage>) -> bool
 where
-N: Clone + Copy + PartialEq,
+N: Copy + PartialEq,
 IpStorage: Deref<Target=[usize]>,
 IStorage: Deref<Target=[usize]>,
 DStorage: Deref<Target=[N]> {
@@ -15,7 +15,7 @@ DStorage: Deref<Target=[N]> {
         return false;
     }
     for (outer_ind, vec) in mat.outer_iterator() {
-        for (inner_ind, value) in vec.iter() {
+        for (inner_ind, &value) in vec.iter() {
             match mat.at_outer_inner(&(inner_ind, outer_ind)) {
                 None => return false,
                 Some(transposed_val) => if transposed_val != value {

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -183,14 +183,14 @@ impl<N> TripletMat<N> {
 
     /// Create a CSC matrix from this triplet matrix
     pub fn to_csc(&self) -> csmat::CsMatOwned<N>
-    where N: Copy + Num
+    where N: Clone + Num
     {
         self.borrowed().to_csc()
     }
 
     /// Create a CSR matrix from this triplet matrix
     pub fn to_csr(&self) -> csmat::CsMatOwned<N>
-    where N: Copy + Num
+    where N: Clone + Num
     {
         self.borrowed().to_csr()
     }
@@ -265,7 +265,7 @@ impl<'a, N> TripletView<'a, N> {
 
     /// Create a CSC matrix from this triplet matrix
     pub fn to_csc(&self) -> csmat::CsMatOwned<N>
-    where N: Copy + Num
+    where N: Clone + Num
     {
         let mut row_counts = vec![0; self.rows() + 1];
         for &i in self.row_inds.iter() {
@@ -285,11 +285,11 @@ impl<'a, N> TripletView<'a, N> {
             *count = 0;
         }
 
-        for (&val, (&i, &j)) in self.data
-                                    .iter()
-                                    .zip(self.row_inds
-                                             .iter()
-                                             .zip(self.col_inds.iter())) {
+        for (val, (&i, &j)) in self.data
+                                   .iter()
+                                   .zip(self.row_inds
+                                            .iter()
+                                            .zip(self.col_inds.iter())) {
             let start = indptr[i];
             let stop = start + row_counts[i];
             let col_exists = {
@@ -299,7 +299,7 @@ impl<'a, N> TripletView<'a, N> {
                                .zip(data[start..stop].iter_mut());
                 for (&col_cell, mut data_cell) in iter {
                     if col_cell == j {
-                        *data_cell = *data_cell + val;
+                        *data_cell = data_cell.clone() + val.clone();
                         col_exists = true;
                         break;
                     }
@@ -308,7 +308,7 @@ impl<'a, N> TripletView<'a, N> {
             };
             if !col_exists {
                 indices[stop] = j;
-                data[stop] = val;
+                data[stop] = val.clone();
                 row_counts[i] += 1;
             }
         }
@@ -321,7 +321,7 @@ impl<'a, N> TripletView<'a, N> {
             if start != dst_start {
                 for k in 0..col_nnz {
                     indices[dst_start + k] = indices[start + k];
-                    data[dst_start + k] = data[start + k];
+                    data[dst_start + k] = data[start + k].clone();
                 }
             }
             indptr[i] = dst_start;
@@ -355,7 +355,7 @@ impl<'a, N> TripletView<'a, N> {
 
     /// Create a CSR matrix from this triplet matrix
     pub fn to_csr(&self) -> csmat::CsMatOwned<N>
-    where N: Copy + Num
+    where N: Clone + Num
     {
         let res = self.transpose_view().to_csc();
         res.transpose_into()
@@ -438,14 +438,14 @@ impl<'a, N> TripletViewMut<'a, N> {
 
     /// Create a CSC matrix from this triplet matrix
     pub fn to_csc(&self) -> csmat::CsMatOwned<N>
-    where N: Copy + Num
+    where N: Clone + Num
     {
         self.borrowed().to_csc()
     }
 
     /// Create a CSR matrix from this triplet matrix
     pub fn to_csr(&self) -> csmat::CsMatOwned<N>
-    where N: Copy + Num
+    where N: Clone + Num
     {
         self.borrowed().to_csr()
     }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -285,7 +285,7 @@ impl<'a, N: 'a> CsVec<N, &'a[usize], &'a[N]> {
     }
 }
 
-impl<N: Copy> CsVec<N, Vec<usize>, Vec<N>> {
+impl<N> CsVec<N, Vec<usize>, Vec<N>> {
     /// Create an owning CsVec from vector data.
     pub fn new_owned(n: usize,
                      indices: Vec<usize>,
@@ -348,9 +348,8 @@ impl<N: Copy> CsVec<N, Vec<usize>, Vec<N>> {
 }
 
 impl<N, IStorage, DStorage> CsVec<N, IStorage, DStorage>
-where N:  Copy,
-IStorage: Deref<Target=[usize]>,
-DStorage: Deref<Target=[N]> {
+where IStorage: Deref<Target=[usize]>,
+      DStorage: Deref<Target=[N]> {
 
     /// Get a view of this vector.
     pub fn borrowed(&self) -> CsVecView<N> {

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -7,12 +7,12 @@
 /// let vec2 = CsVec::new_owned(8, vec![1, 3, 5], vec![2.; 3]).unwrap();
 /// let res = &vec1 + &vec2;
 /// let mut iter = res.iter();
-/// assert_eq!(iter.next(), Some((0, 1.)));
-/// assert_eq!(iter.next(), Some((1, 2.)));
-/// assert_eq!(iter.next(), Some((2, 1.)));
-/// assert_eq!(iter.next(), Some((3, 2.)));
-/// assert_eq!(iter.next(), Some((5, 3.)));
-/// assert_eq!(iter.next(), Some((6, 1.)));
+/// assert_eq!(iter.next(), Some((0, &1.)));
+/// assert_eq!(iter.next(), Some((1, &2.)));
+/// assert_eq!(iter.next(), Some((2, &1.)));
+/// assert_eq!(iter.next(), Some((3, &2.)));
+/// assert_eq!(iter.next(), Some((5, &3.)));
+/// assert_eq!(iter.next(), Some((6, &1.)));
 /// assert_eq!(iter.next(), None);
 /// ```
 
@@ -76,15 +76,15 @@ pub struct VectorIteratorPerm<'a, N: 'a> {
 }
 
 
-impl <'a, N: 'a + Copy>
+impl <'a, N: 'a>
 Iterator
 for VectorIterator<'a, N> {
-    type Item = (usize, N);
+    type Item = (usize, &'a N);
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         match self.ind_data.next() {
             None => None,
-            Some((inner_ind, data)) => Some((*inner_ind, *data))
+            Some((inner_ind, data)) => Some((*inner_ind, data))
         }
     }
 
@@ -93,16 +93,16 @@ for VectorIterator<'a, N> {
     }
 }
 
-impl <'a, N: 'a + Copy>
+impl <'a, N: 'a>
 Iterator
 for VectorIteratorPerm<'a, N> {
-    type Item = (usize, N);
+    type Item = (usize, &'a N);
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         match self.ind_data.next() {
             None => None,
             Some((inner_ind, data)) => Some(
-                (self.perm.at(*inner_ind), *data))
+                (self.perm.at(*inner_ind), data))
         }
     }
 
@@ -125,11 +125,11 @@ pub trait SparseIterTools: Iterator {
     /// let v1 = CsVec::new_owned(5, vec![1, 2, 3], vec![-1., -2., -3.]
     ///                          ).unwrap();
     /// let mut nnz_or_iter = v0.iter().nnz_or_zip(v1.iter());
-    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Left((0, 1.))));
-    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Right((1, -1.))));
-    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Both((2, 2., -2.))));
-    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Right((3, -3.))));
-    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Left((4, 3.))));
+    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Left((0, &1.))));
+    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Right((1, &-1.))));
+    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Both((2, &2., &-2.))));
+    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Right((3, &-3.))));
+    /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Left((4, &3.))));
     /// assert_eq!(nnz_or_iter.next(), None);
     /// ```
     fn nnz_or_zip<I, N1: Copy, N2: Copy>(self, other: I)
@@ -154,7 +154,7 @@ pub trait SparseIterTools: Iterator {
     /// let v1 = CsVec::new_owned(5, vec![1, 2, 3], vec![-1., -2., -3.]
     ///                          ).unwrap();
     /// let mut nnz_zip = v0.iter().nnz_zip(v1.iter());
-    /// assert_eq!(nnz_zip.next(), Some((2, 2., -2.)));
+    /// assert_eq!(nnz_zip.next(), Some((2, &2., &-2.)));
     /// assert_eq!(nnz_zip.next(), None);
     /// ```
     fn nnz_zip<I, N1: Copy, N2: Copy>(self, other: I)
@@ -251,7 +251,7 @@ where Ite1: Iterator<Item=(usize, N1)>,
     }
 }
 
-impl<'a, N: 'a + Copy> CsVec<N, &'a[usize], &'a[N]> {
+impl<'a, N: 'a> CsVec<N, &'a[usize], &'a[N]> {
 
     /// Create a borrowed CsVec over slice data.
     pub fn new_borrowed(
@@ -273,10 +273,10 @@ impl<'a, N: 'a + Copy> CsVec<N, &'a[usize], &'a[N]> {
     /// For instance, non out-of-bounds indices can be relied upon to
     /// perform unchecked slice access.
     pub unsafe fn new_raw(n: usize,
-                                         nnz: usize,
-                                         indices: *const usize,
-                                         data: *const N,
-                                        ) -> CsVec<N, &'a[usize], &'a[N]> {
+                          nnz: usize,
+                          indices: *const usize,
+                          data: *const N,
+                          ) -> CsVec<N, &'a[usize], &'a[N]> {
         CsVec {
             dim: n,
             indices: slice::from_raw_parts(indices, nnz),
@@ -363,9 +363,9 @@ DStorage: Deref<Target=[N]> {
 }
 
 impl<'a, N, IStorage, DStorage> CsVec<N, IStorage, DStorage>
-where N: 'a + Copy,
-IStorage: 'a + Deref<Target=[usize]>,
-DStorage: Deref<Target=[N]> {
+where N: 'a,
+      IStorage: 'a + Deref<Target=[usize]>,
+      DStorage: Deref<Target=[N]> {
 
     /// Iterate over the non zero values.
     ///
@@ -375,9 +375,9 @@ DStorage: Deref<Target=[N]> {
     /// use sprs::CsVec;
     /// let v = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
     /// let mut iter = v.iter();
-    /// assert_eq!(iter.next(), Some((0, 1.)));
-    /// assert_eq!(iter.next(), Some((2, 2.)));
-    /// assert_eq!(iter.next(), Some((4, 3.)));
+    /// assert_eq!(iter.next(), Some((0, &1.)));
+    /// assert_eq!(iter.next(), Some((2, &2.)));
+    /// assert_eq!(iter.next(), Some((4, &3.)));
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn iter(&self) -> VectorIterator<N> {
@@ -433,7 +433,9 @@ DStorage: Deref<Target=[N]> {
     }
 
     /// Allocate a new vector equal to this one.
-    pub fn to_owned(&self) -> CsVecOwned<N> {
+    pub fn to_owned(&self) -> CsVecOwned<N>
+    where N: Clone
+    {
         CsVec {
             dim: self.dim,
             indices: self.indices.to_vec(),
@@ -470,13 +472,14 @@ DStorage: Deref<Target=[N]> {
     /// Access element at given index, with logarithmic complexity
     ///
     /// TODO: use this for CsMat::at_outer_inner
-    pub fn at(&self, index: usize) -> Option<N> {
+    pub fn at(&self, index: usize) -> Option<N>
+    where N: Clone {
         let position = match self.indices.binary_search(&index) {
             Ok(ind) => ind,
             _ => return None
         };
 
-        Some(self.data[position])
+        Some(self.data[position].clone())
     }
 
     /// Vector dot product
@@ -492,21 +495,22 @@ DStorage: Deref<Target=[N]> {
     /// assert_eq!(16., v2.dot(&v2));
     /// ```
     pub fn dot<IS2, DS2>(&self, rhs: &CsVec<N, IS2, DS2>) -> N
-    where N: Num, IS2: Deref<Target=[usize]>, DS2: Deref<Target=[N]> {
-        self.iter().nnz_zip(rhs.iter()).map(|(_, lval, rval)| lval * rval)
+    where N: Num + Copy, IS2: Deref<Target=[usize]>, DS2: Deref<Target=[N]> {
+        self.iter().nnz_zip(rhs.iter()).map(|(_, &lval, &rval)| lval * rval)
                                        .fold(N::zero(), |x, y| x + y)
     }
 
     /// Fill a dense vector with our values
-    pub fn scatter(&self, out: &mut [N]) {
+    pub fn scatter(&self, out: &mut [N])
+    where N: Clone {
         for (ind, val) in self.iter() {
-            out[ind] = val;
+            out[ind] = val.clone();
         }
     }
 
     /// Transform this vector into a set of (index, value) tuples
     pub fn to_set(self) -> HashSet<(usize, N)>
-    where N: Hash + Eq {
+    where N: Hash + Eq + Clone {
         self.indices().iter().cloned().zip(self.data.iter().cloned()).collect()
     }
 }
@@ -607,9 +611,9 @@ mod test {
         let vec1 = test_vec1();
         let vec2 = test_vec2();
         let mut iter = vec1.iter().nnz_zip(vec2.iter());
-        assert_eq!(iter.next().unwrap(), (0, 0., 0.5));
-        assert_eq!(iter.next().unwrap(), (4, 4., 4.5));
-        assert_eq!(iter.next().unwrap(), (7, 7., 7.5));
+        assert_eq!(iter.next().unwrap(), (0, &0., &0.5));
+        assert_eq!(iter.next().unwrap(), (4, &4., &4.5));
+        assert_eq!(iter.next().unwrap(), (7, &7., &7.5));
         assert!(iter.next().is_none());
     }
 
@@ -619,13 +623,13 @@ mod test {
         let vec1 = test_vec1();
         let vec2 = test_vec2();
         let mut iter = vec1.iter().nnz_or_zip(vec2.iter());
-        assert_eq!(iter.next().unwrap(), Both((0, 0., 0.5)));
-        assert_eq!(iter.next().unwrap(), Left((1, 1.)));
-        assert_eq!(iter.next().unwrap(), Right((2, 2.5)));
-        assert_eq!(iter.next().unwrap(), Both((4, 4., 4.5)));
-        assert_eq!(iter.next().unwrap(), Left((5, 5.)));
-        assert_eq!(iter.next().unwrap(), Right((6, 6.5)));
-        assert_eq!(iter.next().unwrap(), Both((7, 7., 7.5)));
+        assert_eq!(iter.next().unwrap(), Both((0, &0., &0.5)));
+        assert_eq!(iter.next().unwrap(), Left((1, &1.)));
+        assert_eq!(iter.next().unwrap(), Right((2, &2.5)));
+        assert_eq!(iter.next().unwrap(), Both((4, &4., &4.5)));
+        assert_eq!(iter.next().unwrap(), Left((5, &5.)));
+        assert_eq!(iter.next().unwrap(), Right((6, &6.5)));
+        assert_eq!(iter.next().unwrap(), Both((7, &7., &7.5)));
     }
 
     #[test]


### PR DESCRIPTION
Most impls had an unneeded Copy bound, now only the methods really requiring it are marked.

Also, where convenient, Copy has been replaced by Clone.