### PR TITLE
Mutable views for sparse matrices and vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /Cargo.lock
 *.pyc
+/doc
+*.bk

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,9 @@ https://vbarrielle.github.io/sprs/doc/sprs/
 Changelog
 ---------
 
+- 0.4.0-alpha.2:
+    - functions in the `at` family will return references **breaking change**
+    - simpler arguments for `at_outer_inner` **breaking change**
 - 0.4.0-alpha.1:
     - depend on ndarray for dense matrices **breaking change**
     - iterators return reference where possible **breaking change**

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -798,8 +798,8 @@ where N: Default,
 impl<N, IptrStorage, IndStorage, DataStorage>
 CsMat<N, IptrStorage, IndStorage, DataStorage>
 where
-IptrStorage: DerefMut<Target=[usize]>,
-IndStorage: DerefMut<Target=[usize]>,
+IptrStorage: Deref<Target=[usize]>,
+IndStorage: Deref<Target=[usize]>,
 DataStorage: DerefMut<Target=[N]> {
 
     /// Mutable access to the non zero values

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1415,4 +1415,30 @@ mod test {
         assert_eq!(mat.nnz_index(7, 7), Some(super::NnzIndex(7)));
         assert_eq!(mat.nnz_index(10, 10), Some(super::NnzIndex(10)));
     }
+
+    #[test]
+    fn at_mut() {
+        // | 0 1 0 |
+        // | 1 0 0 |
+        // | 0 1 1 |
+        let mut mat = CsMatOwned::new_owned(CSC,
+                                            3,
+                                            3,
+                                            vec![0, 1, 3, 4],
+                                            vec![1, 0, 2, 2],
+                                            vec![1.; 4]
+                                           ).unwrap();
+
+        *mat.at_mut(2, 1).unwrap() = 3.;
+
+        let exp = CsMatOwned::new_owned(CSC,
+                                        3,
+                                        3,
+                                        vec![0, 1, 3, 4],
+                                        vec![1, 0, 2, 2],
+                                        vec![1., 1., 3., 1.]
+                                       ).unwrap();
+
+        assert_eq!(mat, exp);
+    }
 }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -863,6 +863,25 @@ DataStorage: DerefMut<Target=[N]> {
         }
     }
 
+    /// Get a mutable reference to the element located at row i and column j.
+    /// Will return None if there is no non-zero element at this location.
+    ///
+    /// This access is logarithmic in the number of non-zeros
+    /// in the corresponding outer slice. It is therefore advisable not to rely
+    /// on this for algorithms, and prefer outer_iterator_mut() which accesses
+    /// elements in storage order.
+    /// TODO: outer_iterator_mut is not yet implemented
+    pub fn at_mut(&mut self, i: usize, j: usize) -> Option<&mut N> {
+        // FIXME: maybe we want to return None for out of bounds
+        assert!(i < self.nrows);
+        assert!(j < self.ncols);
+
+        match self.storage {
+            CSR => self.at_outer_inner_mut(i, j),
+            CSC => self.at_outer_inner_mut(j, i)
+        }
+    }
+
     /// Get a mutable reference to an element given its outer_ind and inner_ind.
     /// Will return None if there is no non-zero element at this location.
     ///

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1403,4 +1403,16 @@ mod test {
         block_iter.next().unwrap();
         assert_eq!(block_iter.next(), None);
     }
+
+    #[test]
+    fn nnz_index() {
+        let mat : CsMatOwned<f64> = CsMat::eye(CSR, 11);
+
+        assert_eq!(mat.nnz_index(2, 3), None);
+        assert_eq!(mat.nnz_index(5, 7), None);
+        assert_eq!(mat.nnz_index(0, 11), None);
+        assert_eq!(mat.nnz_index(0, 0), Some(super::NnzIndex(0)));
+        assert_eq!(mat.nnz_index(7, 7), Some(super::NnzIndex(7)));
+        assert_eq!(mat.nnz_index(10, 10), Some(super::NnzIndex(10)));
+    }
 }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -539,15 +539,13 @@ where IptrStorage: Deref<Target=[usize]>,
     /// in the corresponding outer slice. It is therefore advisable not to rely
     /// on this for algorithms, and prefer outer_iterator() which accesses
     /// elements in storage order.
-    pub fn at(&self, &(i,j) : &(usize, usize)) -> Option<N>
-    where N: Clone
-    {
+    pub fn at(&self, &(i,j) : &(usize, usize)) -> Option<&N> {
         assert!(i < self.nrows);
         assert!(j < self.ncols);
 
         match self.storage {
-            CSR => self.at_outer_inner(&(i,j)),
-            CSC => self.at_outer_inner(&(j,i))
+            CSR => self.at_outer_inner(i, j),
+            CSC => self.at_outer_inner(j, i)
         }
     }
 
@@ -683,11 +681,10 @@ where IptrStorage: Deref<Target=[usize]>,
     /// on this for algorithms, and prefer outer_iterator() which accesses
     /// elements in storage order.
     pub fn at_outer_inner(&self,
-                          &(outer_ind, inner_ind): &(usize, usize)
-                         ) -> Option<N>
-    where N: Clone
-    {
-        self.outer_view(outer_ind).and_then(|vec| vec.at(inner_ind))
+                          outer_ind: usize,
+                          inner_ind: usize
+                         ) -> Option<&N> {
+        self.outer_view(outer_ind).and_then(|vec| vec.at_(inner_ind))
     }
 
     /// Check the structure of CsMat components

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -702,6 +702,17 @@ where IptrStorage: Deref<Target=[usize]>,
         self.outer_view(outer_ind).and_then(|vec| vec.at_(inner_ind))
     }
 
+    /// Find the non-zero index of the element specified by row and col
+    ///
+    /// Searching this index is logarithmic in the number of non-zeros
+    /// in the corresponding outer slice.
+    pub fn nnz_index(&self, row: usize, col: usize) -> Option<NnzIndex> {
+        match self.storage() {
+            CSR => self.nnz_index_outer_inner(row, col),
+            CSC => self.nnz_index_outer_inner(col, row),
+        }
+    }
+
     /// Find the non-zero index of the element specified by outer_ind and
     /// inner_ind.
     ///

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -554,10 +554,7 @@ where IptrStorage: Deref<Target=[usize]>,
     /// in the corresponding outer slice. It is therefore advisable not to rely
     /// on this for algorithms, and prefer outer_iterator() which accesses
     /// elements in storage order.
-    pub fn at(&self, &(i,j) : &(usize, usize)) -> Option<&N> {
-        assert!(i < self.nrows);
-        assert!(j < self.ncols);
-
+    pub fn at(&self, i: usize, j: usize) -> Option<&N> {
         match self.storage {
             CSR => self.at_outer_inner(i, j),
             CSC => self.at_outer_inner(j, i)
@@ -883,10 +880,6 @@ DataStorage: DerefMut<Target=[N]> {
     /// elements in storage order.
     /// TODO: outer_iterator_mut is not yet implemented
     pub fn at_mut(&mut self, i: usize, j: usize) -> Option<&mut N> {
-        // FIXME: maybe we want to return None for out of bounds
-        assert!(i < self.nrows);
-        assert!(j < self.ncols);
-
         match self.storage {
             CSR => self.at_outer_inner_mut(i, j),
             CSC => self.at_outer_inner_mut(j, i)

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -112,7 +112,7 @@ fn lspsolve_csc_process_col<N: Copy + Num, V: ?Sized>
                                                        -> Result<(), SprsError>
 where V: vec::VecDim<N> + IndexMut<usize, Output = N>
 {
-    if let Some(diag_val) = col.at(col_ind) {
+    if let Some(&diag_val) = col.at(col_ind) {
         if diag_val == N::zero() {
             return Err(SprsError::SingularMatrix);
         }
@@ -162,7 +162,7 @@ where N: Copy + Num,
     // U_0_0 x0 = b_0 - x1*u_0_1
 
     for (col_ind, col) in upper_tri_mat.outer_iterator().rev() {
-        if let Some(diag_val) = col.at(col_ind) {
+        if let Some(&diag_val) = col.at(col_ind) {
             if diag_val == N::zero() {
                 return Err(SprsError::SingularMatrix);
             }

--- a/src/sparse/symmetric.rs
+++ b/src/sparse/symmetric.rs
@@ -16,9 +16,9 @@ DStorage: Deref<Target=[N]> {
     }
     for (outer_ind, vec) in mat.outer_iterator() {
         for (inner_ind, &value) in vec.iter() {
-            match mat.at_outer_inner(&(inner_ind, outer_ind)) {
+            match mat.at_outer_inner(inner_ind, outer_ind) {
                 None => return false,
-                Some(transposed_val) => if transposed_val != value {
+                Some(&transposed_val) => if transposed_val != value {
                     return false;
                 }
             }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -17,7 +17,7 @@
 /// ```
 
 use std::iter::{Zip, Peekable, FilterMap, IntoIterator, Enumerate};
-use std::ops::{Deref, DerefMut, Mul, Add, Sub, Index};
+use std::ops::{Deref, DerefMut, Mul, Add, Sub, Index, IndexMut};
 use std::convert::AsRef;
 use std::cmp;
 use std::slice::{self, Iter};
@@ -654,6 +654,15 @@ where IS: Deref<Target=[usize]>,
     }
 }
 
+impl<N, IS, DS> IndexMut<usize> for CsVec<N, IS, DS>
+where IS: Deref<Target=[usize]>,
+      DS: DerefMut<Target=[N]> {
+
+    fn index_mut(&mut self, index: usize) -> &mut N {
+        self.at_mut(index).unwrap()
+    }
+}
+
 
 #[cfg(test)]
 mod test {
@@ -731,11 +740,20 @@ mod test {
                                        vec![1.; 4]
                                       ).unwrap();
 
-        *vec.at_mut(4).unwrap() = 0.;
+        *vec.at_mut(4).unwrap() = 2.;
 
         let expected = CsVec::new_owned(8,
                                         vec![0, 2, 4, 6],
-                                        vec![1., 1., 0., 1.],
+                                        vec![1., 1., 2., 1.],
+                                       ).unwrap();
+
+        assert_eq!(vec, expected);
+
+        vec[6] = 3.;
+
+        let expected = CsVec::new_owned(8,
+                                        vec![0, 2, 4, 6],
+                                        vec![1., 1., 2., 3.],
                                        ).unwrap();
 
         assert_eq!(vec, expected);

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -257,7 +257,7 @@ where Ite1: Iterator<Item=(usize, &'a N1)>,
     }
 }
 
-impl<'a, N: 'a> CsVec<N, &'a[usize], &'a[N]> {
+impl<'a, N: 'a> CsVecView<'a, N> {
 
     /// Create a borrowed CsVec over slice data.
     pub fn new_borrowed(
@@ -271,6 +271,15 @@ impl<'a, N: 'a> CsVec<N, &'a[usize], &'a[N]> {
             data: data,
         };
         v.check_structure().and(Ok(v))
+    }
+
+    /// Access element at given index, with logarithmic complexity
+    ///
+    /// Re-borrowing version of `at()`.
+    pub fn at_(&self, index: usize) -> Option<&'a N> {
+        self.nnz_index(index).map(|NnzIndex(position)| {
+            &self.data[position]
+        })
     }
 
     /// Create a borrowed CsVec over slice data without checking the structure
@@ -475,13 +484,8 @@ where N: 'a,
     }
 
     /// Access element at given index, with logarithmic complexity
-    ///
-    /// TODO: use this for CsMat::at_outer_inner
-    pub fn at(&self, index: usize) -> Option<N>
-    where N: Clone {
-        self.nnz_index(index).map(|NnzIndex(position)| {
-            self.data[position].clone()
-        })
+    pub fn at(&self, index: usize) -> Option<&N> {
+        self.borrowed().at_(index)
     }
 
     /// Find the non-zero index of the requested dimension index,

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -44,6 +44,7 @@ where DStorage: Deref<Target=[N]> {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+/// Hold the index of a non-zero element in the compressed storage
 pub struct NnzIndex(pub usize);
 
 pub type CsVecView<'a, N> = CsVec<N, &'a [usize], &'a [N]>;

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -703,4 +703,30 @@ mod test {
         assert_eq!(6., vec1.dot(&vec3));
         assert_eq!(12., vec2.dot(&vec3));
     }
+
+    #[test]
+    fn nnz_index() {
+        let vec = CsVec::new_owned(8, vec![0, 2, 4, 6], vec![1.; 4]).unwrap();
+        assert_eq!(vec.nnz_index(1), None);
+        assert_eq!(vec.nnz_index(9), None);
+        assert_eq!(vec.nnz_index(0), Some(super::NnzIndex(0)));
+        assert_eq!(vec.nnz_index(4), Some(super::NnzIndex(2)));
+    }
+
+    #[test]
+    fn at_mut() {
+        let mut vec = CsVec::new_owned(8,
+                                       vec![0, 2, 4, 6],
+                                       vec![1.; 4]
+                                      ).unwrap();
+
+        *vec.at_mut(4).unwrap() = 0.;
+
+        let expected = CsVec::new_owned(8,
+                                        vec![0, 2, 4, 6],
+                                        vec![1., 1., 0., 1.],
+                                       ).unwrap();
+
+        assert_eq!(vec, expected);
+    }
 }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -17,7 +17,7 @@
 /// ```
 
 use std::iter::{Zip, Peekable, FilterMap, IntoIterator, Enumerate};
-use std::ops::{Deref, DerefMut, Mul, Add, Sub};
+use std::ops::{Deref, DerefMut, Mul, Add, Sub, Index};
 use std::convert::AsRef;
 use std::cmp;
 use std::slice::{self, Iter};
@@ -643,6 +643,17 @@ where N: Copy + Num,
     }
 }
 
+impl<N, IS, DS> Index<usize> for CsVec<N, IS, DS>
+where IS: Deref<Target=[usize]>,
+      DS: Deref<Target=[N]> {
+
+    type Output = N;
+
+    fn index(&self, index: usize) -> &N {
+        self.at(index).unwrap()
+    }
+}
+
 
 #[cfg(test)]
 mod test {
@@ -728,5 +739,17 @@ mod test {
                                        ).unwrap();
 
         assert_eq!(vec, expected);
+    }
+
+    #[test]
+    fn indexing() {
+        let vec = CsVec::new_owned(8,
+                                   vec![0, 2, 4, 6],
+                                   vec![1., 2., 3., 4.]
+                                  ).unwrap();
+        assert_eq!(vec[0], 1.);
+        assert_eq!(vec[2], 2.);
+        assert_eq!(vec[4], 3.);
+        assert_eq!(vec[6], 4.);
     }
 }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -542,10 +542,13 @@ where N: 'a,
     }
 
     /// Access element at given index, with logarithmic complexity
-    pub fn at_mut(&self, index: usize) -> Option<&mut N> {
-        self.nnz_index(index).map(|NnzIndex(position)| {
-            &mut self.data[position]
-        })
+    pub fn at_mut(&mut self, index: usize) -> Option<&mut N> {
+        if let Some(NnzIndex(position)) = self.nnz_index(index) {
+            Some(&mut self.data[position])
+        }
+        else {
+            None
+        }
     }
 }
 
@@ -565,7 +568,7 @@ where N: 'a {
         CsVec {
             dim: n,
             indices: slice::from_raw_parts(indices, nnz),
-            data: slice::from_raw_parts(data, nnz),
+            data: slice::from_raw_parts_mut(data, nnz),
         }
     }
 }


### PR DESCRIPTION
Add indexing capabilities for sparse matrices and sparse vectors, allowing one to modify non-zero values. Due to the sparse compression, indexing is not in constant time (logarithmic).

Fixes #62.