### PR TITLE
Per non-zero elements  functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,9 @@ Changelog
       scheme in standard library. **breaking change**
     - move cholesky factorization behind the "lgpl" feature flag
       **rbeaking change**
+    - per-nnz-element function application (`map`, `map_inplace`).
+    - binary operations operating on matching non-zero elements
+      (`csvec_binop`, `csmat_binop`).
 - 0.4.0-alpha.2:
     - functions in the `at` family will return references **breaking change**
     - simpler arguments for `at_outer_inner` **breaking change**

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,8 @@
 use std::error::Error;
 use std::fmt;
 
+pub type SpRes<T> = Result<T, SprsError>;
+
 #[derive(PartialEq, Debug)]
 pub enum SprsError {
     IncompatibleDimensions,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,8 +3,6 @@
 use std::error::Error;
 use std::fmt;
 
-pub type SpRes<T> = Result<T, SprsError>;
-
 #[derive(PartialEq, Debug)]
 pub enum SprsError {
     IncompatibleDimensions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,17 @@ pub mod sparse;
 pub mod errors;
 pub mod stack;
 
+pub use ndarray::Ix as Ix_;
+
 pub use sparse::{CsMat, CsMatOwned, CsMatView,
                  CsVec, CsVecView, CsVecOwned};
 pub use sparse::CompressedStorage::{CSR, CSC};
 pub use sparse::construct::{vstack, hstack, bmat};
+
+pub type Ix2 = (Ix_, Ix_);
+pub type SpRes<T> = Result<T, errors::SprsError>;
+
+
 
 mod utils {
     use sparse::csmat::{self, CsMatView};

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -5,10 +5,11 @@ use num::traits::Num;
 use sparse::vec::NnzEither::{Left, Right, Both};
 use sparse::vec::{CsVec, CsVecView, CsVecOwned, SparseIterTools};
 use sparse::compressed::SpMatView;
-use errors::{SprsError, SpRes};
-use ndarray::{self, OwnedArray, ArrayBase, ArrayView, ArrayViewMut, Ix};
+use errors::SprsError;
+use ndarray::{self, OwnedArray, ArrayBase, ArrayView, ArrayViewMut};
 
-pub type Ix2 = (Ix, Ix);
+use ::Ix2;
+use ::SpRes;
 
 /// Sparse matrix addition, with matrices sharing the same storage type
 pub fn add_mat_same_storage<N, Mat1, Mat2>(

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -8,6 +8,8 @@ use sparse::compressed::SpMatView;
 use errors::SprsError;
 use ndarray::{self, OwnedArray, ArrayBase, ArrayView, ArrayViewMut, Ix};
 
+pub type Ix2 = (Ix, Ix);
+
 /// Sparse matrix addition, with matrices sharing the same storage type
 pub fn add_mat_same_storage<N, Mat1, Mat2>(
     lhs: &Mat1, rhs: &Mat2) -> Result<CsMatOwned<N>, SprsError>
@@ -133,10 +135,10 @@ where N: Num,
 /// and alpha and beta scalars
 pub fn add_dense_mat_same_ordering<N, Mat, DenseStorage>(
     lhs: &Mat,
-    rhs: &ArrayBase<DenseStorage, (Ix, Ix)>,
+    rhs: &ArrayBase<DenseStorage, Ix2>,
     alpha: N,
     beta: N)
--> Result<OwnedArray<N, (Ix, Ix)>, SprsError>
+-> Result<OwnedArray<N, Ix2>, SprsError>
 where N: Num + Copy,
       Mat: SpMatView<N>,
       DenseStorage: ndarray::Data<Elem=N> {
@@ -156,9 +158,9 @@ where N: Num + Copy,
 /// Compute coeff wise alpha * lhs * rhs with lhs a sparse matrix and rhs dense
 /// and alpha a scalar
 pub fn mul_dense_mat_same_ordering<N, Mat, DenseStorage>(
-    lhs: &Mat, rhs: &ArrayBase<DenseStorage, (Ix, Ix)>,
+    lhs: &Mat, rhs: &ArrayBase<DenseStorage, Ix2>,
     alpha: N)
--> Result<OwnedArray<N, (Ix, Ix)>, SprsError>
+-> Result<OwnedArray<N, Ix2>, SprsError>
 where N: Num + Copy, Mat: SpMatView<N>, DenseStorage: ndarray::Data<Elem=N> {
     let binop = |x, y| alpha * x * y;
     let shape = (rhs.shape()[0], rhs.shape()[1]);
@@ -177,9 +179,9 @@ where N: Num + Copy, Mat: SpMatView<N>, DenseStorage: ndarray::Data<Elem=N> {
 /// Raw implementation of sparse/dense binary operations with the same
 /// ordering
 pub fn csmat_binop_dense_same_ordering_raw<'a, N, F>(lhs: CsMatView<'a, N>,
-                                                     rhs: ArrayView<'a, N, (Ix, Ix)>,
+                                                     rhs: ArrayView<'a, N, Ix2>,
                                                      binop: F,
-                                                     mut out: ArrayViewMut<'a, N, (Ix, Ix)>
+                                                     mut out: ArrayViewMut<'a, N, Ix2>
                                                     ) -> Result<(), SprsError>
 where N: 'a + Copy + Num,
       F: Fn(N, N) -> N {

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -34,41 +34,7 @@ pub fn scalar_mul_mat<N, Mat>(
     mat: &Mat, val: N) -> CsMatOwned<N>
 where N: Num + Copy, Mat: SpMatView<N> {
     let mat = mat.borrowed();
-    let mut out_indptr = vec![0; mat.outer_dims() + 1];
-    let mut out_indices = vec![0; mat.nb_nonzero()];
-    let mut out_data = vec![N::zero(); mat.nb_nonzero()];
-    let nrows = mat.rows();
-    let ncols = mat.cols();
-    let storage_type = mat.storage();
-    scalar_mul_mat_raw(mat, val, &mut out_indptr[..],
-                       &mut out_indices[..], &mut out_data[..]);
-    CsMat::new_owned(storage_type, nrows, ncols,
-                     out_indptr, out_indices, out_data).unwrap()
-}
-
-/// Sparse matrix multiplication by a scalar, raw version
-///
-/// Writes into the provided output.
-/// Panics if the sizes don't match
-pub fn scalar_mul_mat_raw<N>(
-    mat: CsMatView<N>,
-    val: N,
-    out_indptr: &mut [usize],
-    out_indices: &mut [usize],
-    out_data: &mut [N])
-where N: Num + Copy {
-    assert_eq!(out_indptr.len(), mat.outer_dims() + 1);
-    assert!(out_data.len() >= mat.nb_nonzero());
-    assert!(out_indices.len() >= mat.nb_nonzero());
-    for (optr, iptr) in out_indptr.iter_mut().zip(mat.indptr()) {
-        *optr = *iptr;
-    }
-    for (oind, iind) in out_indices.iter_mut().zip(mat.indices()) {
-        *oind = *iind;
-    }
-    for (odata, idata) in out_data.iter_mut().zip(mat.data()) {
-        *odata = *idata * val;
-    }
+    mat.map(|&x| x * val)
 }
 
 /// Applies a binary operation to matching non-zero elements

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -132,7 +132,7 @@ where IndStorage: 'b + Deref<Target=[usize]>,
 
 
 mod test {
-    
+
     #[test]
     fn perm_mul() {
         // |0 0 1 0 0| |5|   |2|

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -742,8 +742,10 @@ where N: Copy + Num,
     type Output = CsVecOwned<N>;
 
     fn add(self, rhs: &CsVec<N, IS2, DS2>) -> CsVecOwned<N> {
-        let binop = |x, y| x + y;
-        binop::csvec_binop(self.borrowed(), rhs.borrowed(), binop).unwrap()
+        binop::csvec_binop(self.borrowed(),
+                           rhs.borrowed(),
+                           |&x, &y| x + y
+                          ).unwrap()
     }
 }
 
@@ -758,8 +760,10 @@ where N: Copy + Num,
     type Output = CsVecOwned<N>;
 
     fn sub(self, rhs: &CsVec<N, IS2, DS2>) -> CsVecOwned<N> {
-        let binop = |x, y| x - y;
-        binop::csvec_binop(self.borrowed(), rhs.borrowed(), binop).unwrap()
+        binop::csvec_binop(self.borrowed(),
+                           rhs.borrowed(),
+                           |&x, &y| x - y
+                          ).unwrap()
     }
 }
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -626,6 +626,17 @@ where IStorage: Deref<Target=[usize]>,
     where N: Hash + Eq + Clone {
         self.indices().iter().cloned().zip(self.data.iter().cloned()).collect()
     }
+
+    /// Apply a function to each non-zero element, yielding a new matrix
+    /// with the same sparsity structure.
+    pub fn map<F>(&self, f: F) -> CsVecOwned<N>
+    where F: FnMut(&N) -> N,
+          N: Clone
+    {
+        let mut res = self.to_owned();
+        res.map_inplace(f);
+        res
+    }
 }
 
 impl<'a, N, IStorage, DStorage> CsVec<N, IStorage, DStorage>
@@ -650,6 +661,16 @@ where N: 'a,
             None
         }
     }
+
+    /// Apply a function to each non-zero element, mutating it
+    pub fn map_inplace<F>(&mut self, mut f: F)
+    where F: FnMut(&N) -> N
+    {
+        for val in &mut self.data[..] {
+            *val = f(val);
+        }
+    }
+
 }
 
 impl<'a, N> CsVecViewMut<'a, N>
@@ -893,5 +914,33 @@ mod test {
         assert_eq!(vec[2], 2.);
         assert_eq!(vec[4], 3.);
         assert_eq!(vec[6], 4.);
+    }
+
+    #[test]
+    fn map_inplace() {
+        let mut vec = CsVec::new_owned(8,
+                                       vec![0, 2, 4, 6],
+                                       vec![1., 2., 3., 4.]
+                                      ).unwrap();
+        vec.map_inplace(|&x| x + 1.);
+        let expected = CsVec::new_owned(8,
+                                        vec![0, 2, 4, 6],
+                                        vec![2., 3., 4., 5.]
+                                       ).unwrap();
+        assert_eq!(vec, expected);
+    }
+
+    #[test]
+    fn map() {
+        let vec = CsVec::new_owned(8,
+                                   vec![0, 2, 4, 6],
+                                   vec![1., 2., 3., 4.]
+                                  ).unwrap();
+        let res = vec.map(|&x| x * 2.);
+        let expected = CsVec::new_owned(8,
+                                        vec![0, 2, 4, 6],
+                                        vec![2., 4., 6., 8.]
+                                       ).unwrap();
+        assert_eq!(res, expected);
     }
 }


### PR DESCRIPTION
Add `map()`, `map_inplace()` to apply a function to all non-zero elements of a sparse matrix or vector.

Expose the `csmat_binop` and `csvec_binop` functions, which allow applying a function to corresponding non-zero elements of two sparse matrices/vectors.

Fixes #59. For the time being, function application with 3 matrices won't be supported, as it can be emulated by repeated applications of e.g. `csmat_binop`. This has the downside of requiring an extra allocation, but support for function application with 3 matrices would be complicated.