### PR TITLE
`outer_iterator()` no longer returns the dimension index

### DIFF
--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -114,7 +114,8 @@ where N: Num,
     assert!(out_indices.len() >= max_nnz);
     let mut nnz = 0;
     out_indptr[0] = 0;
-    for ((dim, lv), (_, rv)) in lhs.outer_iterator().zip(rhs.outer_iterator()) {
+    let iter = lhs.outer_iterator().zip(rhs.outer_iterator()).enumerate();
+    for (dim, (lv, rv)) in iter {
         for elem in lv.iter().nnz_or_zip(rv.iter()) {
             let (ind, binop_val) = match elem {
                 Left((ind, val)) => (ind, binop(val, &N::zero())),
@@ -198,7 +199,7 @@ where N: 'a + Num,
         (_, _, _) => return Err(SprsError::IncompatibleStorages),
     }
     let outer_axis = if rhs.is_standard_layout() { Axis(0) } else { Axis(1) };
-    for ((mut orow, (_, lrow)), rrow) in out.axis_iter_mut(outer_axis)
+    for ((mut orow, lrow), rrow) in out.axis_iter_mut(outer_axis)
                                             .zip(lhs.outer_iterator())
                                             .zip(rhs.axis_iter(outer_axis)) {
         // now some equivalent of nnz_or_zip is needed

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -33,7 +33,7 @@ where N: 'a + Clone,
     res.reserve_outer_dim_exact(outer_dim);
     res.reserve_nnz_exact(nnz);
     for mat in mats {
-        for (_, vec) in mat.outer_iterator() {
+        for vec in mat.outer_iterator() {
             res = res.append_outer_csvec(vec.view());
         }
     }

--- a/src/sparse/linalg/cholesky.rs
+++ b/src/sparse/linalg/cholesky.rs
@@ -414,7 +414,7 @@ pub fn ldl_lsolve<N, V: ?Sized>(l: &CsMatView<N>, x: &mut V)
 where N: Clone + Copy + Num,
       V: IndexMut<usize, Output = N>
 {
-    for (col_ind, vec) in l.outer_iterator() {
+    for (col_ind, vec) in l.outer_iterator().enumerate() {
         let x_col = x[col_ind];
         for (row_ind, &value) in vec.iter() {
             x[row_ind] = x[row_ind] - value * x_col;
@@ -428,7 +428,7 @@ pub fn ldl_ltsolve<N, V: ?Sized>(l: &CsMatView<N>, x: &mut V)
 where N: Clone + Copy + Num,
       V: IndexMut<usize, Output = N>
 {
-    for (outer_ind, vec) in l.outer_iterator().rev() {
+    for (outer_ind, vec) in l.outer_iterator().enumerate().rev() {
         let mut x_outer = x[outer_ind];
         for (inner_ind, &value) in vec.iter() {
             x_outer = x_outer - value * x[inner_ind];

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -48,7 +48,7 @@ where N: Copy + Num,
     // At each step of the algorithm, the x_0 part is known,
     // and x_1 can be computed as x_1 = (b_1 - l_1_0^T.x_0) / l_1_1
 
-    for (row_ind, row) in lower_tri_mat.outer_iterator() {
+    for (row_ind, row) in lower_tri_mat.outer_iterator().enumerate() {
         let mut diag_val = N::zero();
         let mut x = rhs[row_ind];
         for (col_ind, &val) in row.iter() {
@@ -99,7 +99,7 @@ where N: Copy + Num,
     // and the step can be propagated by solving the reduced system
     // L_1_1 x1 = b_1 - x0*l_1_0
 
-    for (col_ind, col) in lower_tri_mat.outer_iterator() {
+    for (col_ind, col) in lower_tri_mat.outer_iterator().enumerate() {
         try!(lspsolve_csc_process_col(col, col_ind, rhs));
     }
     Ok(())
@@ -161,7 +161,7 @@ where N: Copy + Num,
     // and the step can be propagated by solving the reduced system
     // U_0_0 x0 = b_0 - x1*u_0_1
 
-    for (col_ind, col) in upper_tri_mat.outer_iterator().rev() {
+    for (col_ind, col) in upper_tri_mat.outer_iterator().enumerate().rev() {
         if let Some(&diag_val) = col.get(col_ind) {
             if diag_val == N::zero() {
                 return Err(SprsError::SingularMatrix);
@@ -208,7 +208,7 @@ where N: Copy + Num,
     // At each step of the algorithm, the x_1 part is known from previous
     // iterations and x_0 can be computed as
     // x0 = (b_0 - u_0_1^T.x_1) / u_0_0
-    for (row_ind, row) in upper_tri_mat.outer_iterator().rev() {
+    for (row_ind, row) in upper_tri_mat.outer_iterator().enumerate().rev() {
         let mut diag_val = N::zero();
         let mut x = rhs[row_ind];
         for (col_ind, &val) in row.iter() {

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -23,7 +23,7 @@ where N: Num + Copy {
         return Err(SprsError::IncompatibleStorages);
     }
 
-    for (col_ind, vec) in mat.outer_iterator() {
+    for (col_ind, vec) in mat.outer_iterator().enumerate() {
         let multiplier = &in_vec[col_ind];
         for (row_ind, &value) in vec.iter() {
             // TODO: unsafe access to value? needs bench
@@ -47,7 +47,7 @@ where N: Num + Copy {
         return Err(SprsError::IncompatibleStorages);
     }
 
-    for (row_ind, vec) in mat.outer_iterator() {
+    for (row_ind, vec) in mat.outer_iterator().enumerate() {
         for (col_ind, &value) in vec.iter() {
             // TODO: unsafe access to value? needs bench
             res_vec[row_ind] =
@@ -143,7 +143,7 @@ where N: Num + Copy {
 
     let mut res = CsMatOwned::empty(lhs.storage(), res_cols);
     res.reserve_nnz_exact(lhs.nb_nonzero() + rhs.nb_nonzero());
-    for (_, lvec) in lhs.outer_iterator() {
+    for lvec in lhs.outer_iterator() {
         // reset the accumulators
         for wval in workspace.iter_mut() {
             *wval = N::zero();
@@ -176,7 +176,7 @@ where N: Copy + Num {
         return Err(SprsError::IncompatibleDimensions);
     }
     let mut res = CsVecOwned::empty(lhs.rows());
-    for (row_ind, lvec) in lhs.outer_iterator() {
+    for (row_ind, lvec) in lhs.outer_iterator().enumerate() {
         let val = lvec.dot(&rhs);
         if val != N::zero() {
             res.append(row_ind, val);
@@ -221,8 +221,8 @@ where N: 'a + Num + Copy
             let col_start = rblock_size * rcount;
             let col_end = col_start + rblock_size;
 
-            for ((_, line), mut oline) in lblock.outer_iterator()
-                                          .zip(oblock.axis_iter_mut(axis0)) {
+            for (line, mut oline) in lblock.outer_iterator()
+                                           .zip(oblock.axis_iter_mut(axis0)) {
                 'col_block: for (col_ind, &lval) in line.iter() {
                     if col_ind < col_start {
                         continue 'col_block;
@@ -268,7 +268,7 @@ where N: 'a + Num + Copy
         return Err(SprsError::BadStorageType);
     }
 
-    for ((_, lcol), rline) in lhs.outer_iterator().zip(rhs.outer_iter()) {
+    for (lcol, rline) in lhs.outer_iterator().zip(rhs.outer_iter()) {
         for (orow, &lval) in lcol.iter() {
             let mut oline = out.row_mut(orow);
             for (oval, &rval) in oline.iter_mut().zip(rline.iter()) {
@@ -307,7 +307,7 @@ where N: 'a + Num + Copy
 
     let axis1 = Axis(1);
     for (mut ocol, rcol) in out.axis_iter_mut(axis1).zip(rhs.axis_iter(axis1)) {
-        for (rrow, lcol) in lhs.outer_iterator() {
+        for (rrow, lcol) in lhs.outer_iterator().enumerate() {
             let rval = rcol[[rrow]];
             for (orow, &lval) in lcol.iter() {
                 let prev = ocol[[orow]];
@@ -345,7 +345,7 @@ where N: 'a + Num + Copy
     }
     let axis1 = Axis(1);
     for (mut ocol, rcol) in out.axis_iter_mut(axis1).zip(rhs.axis_iter(axis1)) {
-        for (orow, lrow) in lhs.outer_iterator() {
+        for (orow, lrow) in lhs.outer_iterator().enumerate() {
             let mut prev = ocol[[orow]];
             for (rrow, &lval) in lrow.iter() {
                 let rval = rcol[[rrow]];

--- a/src/sparse/symmetric.rs
+++ b/src/sparse/symmetric.rs
@@ -14,7 +14,7 @@ DStorage: Deref<Target=[N]> {
     if mat.rows() != mat.cols() {
         return false;
     }
-    for (outer_ind, vec) in mat.outer_iterator() {
+    for (outer_ind, vec) in mat.outer_iterator().enumerate() {
         for (inner_ind, &value) in vec.iter() {
             match mat.get_outer_inner(inner_ind, outer_ind) {
                 None => return false,

--- a/src/sparse/to_dense.rs
+++ b/src/sparse/to_dense.rs
@@ -23,7 +23,7 @@ where N: Clone
     let outer_axis = if spmat.is_csr() { Axis(0) } else { Axis(1) };
 
     let iterator = spmat.outer_iterator().zip(array.axis_iter_mut(outer_axis));
-    for ((_, sprow), mut drow) in iterator {
+    for (sprow, mut drow) in iterator {
         for (ind, val) in sprow.iter() {
             drow[[ind]] = val.clone();
         }


### PR DESCRIPTION
The old behaviour can be obtained by chaining a call to `enumerate()`.

Fixes #73.