### PR TITLE
Constructor refactor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Matrix construction
 
   use sprs::{CsMat, CsMatOwned, CsVec};
   let eye : CsMatOwned<f64> = CsMat::eye(3);
-  let a = CsMat::new_csc(3, 3,
+  let a = CsMat::new_csc((3, 3),
                          vec![0, 2, 4, 5],
                          vec![0, 1, 0, 2, 2],
                          vec![1., 2., 3., 4., 5.]);
@@ -68,7 +68,7 @@ Matrix matrix multiplication, addition
 
   use sprs::{CsMat, CsVec};
   let eye = CsMat::eye(3);
-  let a = CsMat::new_csc(3, 3,
+  let a = CsMat::new_csc((3, 3),
                          vec![0, 2, 4, 5],
                          vec![0, 1, 0, 2, 2],
                          vec![1., 2., 3., 4., 5.]);

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Matrix construction
 .. code-block:: rust
 
   use sprs::{CsMat, CsMatOwned, CsVec};
-  let eye : CsMatOwned<f64> = CsMat::eye(sprs::CSR, 3);
+  let eye : CsMatOwned<f64> = CsMat::eye(3);
   let a = CsMat::new_owned(sprs::CSC, 3, 3,
                            vec![0, 2, 4, 5],
                            vec![0, 1, 0, 2, 2],
@@ -57,7 +57,7 @@ Matrix vector multiplication
 .. code-block:: rust
 
   use sprs::{CsMat, CsVec};
-  let eye = CsMat::eye(sprs::CSR, 5);
+  let eye = CsMat::eye(5);
   let x = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
   let y = &eye * &x;
   assert_eq!(x, y);
@@ -67,7 +67,7 @@ Matrix matrix multiplication, addition
 .. code-block:: rust
 
   use sprs::{CsMat, CsVec};
-  let eye = CsMat::eye(sprs::CSR, 3);
+  let eye = CsMat::eye(3);
   let a = CsMat::new_owned(sprs::CSC, 3, 3,
                            vec![0, 2, 4, 5],
                            vec![0, 1, 0, 2, 2],

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,7 @@ Changelog
     - rename ``new_raw()`` into ``new_view_raw()``.
     - rename ``new_owned()`` into ``new()`` or ``new_csc()`` depending on the
       desired ordering, and have the ownning constructors panic on bad input.
+    - constructors now take a tuple for shape information
 - 0.4.0-alpha.3:
     - rename ``at`` family of functions into ``get``, consistent with the naming
       scheme in standard library. **breaking change**

--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,9 @@ Changelog
 - next version:
     - add ``to_dense()`` method for sparse matrices
     - rename ``borrowed()`` into ``view()`` **breaking change**
+    - ``outer_iterator()`` no longer returns the index of the dimension we're
+      iterating. The old behavior can be obtained by chaining a call
+      to ``enumerate()``.
 - 0.4.0-alpha.3:
     - rename ``at`` family of functions into ``get``, consistent with the naming
       scheme in standard library. **breaking change**

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,9 @@ Changelog
     - ``outer_iterator()`` no longer returns the index of the dimension we're
       iterating. The old behavior can be obtained by chaining a call
       to ``enumerate()``.
+    - ``eye()`` returns a csr matrix by default, a csc matrix can be obtained
+      using ``eye_csc()``.
+    - rename ``new_borrowed()`` into ``new_view()``.
 - 0.4.0-alpha.3:
     - rename ``at`` family of functions into ``get``, consistent with the naming
       scheme in standard library. **breaking change**

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Matrix vector multiplication
 
   use sprs::{CsMat, CsVec};
   let eye = CsMat::eye(5);
-  let x = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
+  let x = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
   let y = &eye * &x;
   assert_eq!(x, y);
 

--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,10 @@ Matrix construction
 
   use sprs::{CsMat, CsMatOwned, CsVec};
   let eye : CsMatOwned<f64> = CsMat::eye(3);
-  let a = CsMat::new_owned(sprs::CSC, 3, 3,
-                           vec![0, 2, 4, 5],
-                           vec![0, 1, 0, 2, 2],
-                           vec![1., 2., 3., 4., 5.]).unwrap();
+  let a = CsMat::new_csc(3, 3,
+                         vec![0, 2, 4, 5],
+                         vec![0, 1, 0, 2, 2],
+                         vec![1., 2., 3., 4., 5.]);
 
 Matrix vector multiplication
 
@@ -68,10 +68,10 @@ Matrix matrix multiplication, addition
 
   use sprs::{CsMat, CsVec};
   let eye = CsMat::eye(3);
-  let a = CsMat::new_owned(sprs::CSC, 3, 3,
-                           vec![0, 2, 4, 5],
-                           vec![0, 1, 0, 2, 2],
-                           vec![1., 2., 3., 4., 5.]).unwrap();
+  let a = CsMat::new_csc(3, 3,
+                         vec![0, 2, 4, 5],
+                         vec![0, 1, 0, 2, 2],
+                         vec![1., 2., 3., 4., 5.]);
   let b = &eye * &a;
   assert_eq!(a, b.to_csr());
 
@@ -97,6 +97,8 @@ Changelog
       using ``eye_csc()``.
     - rename ``new_borrowed()`` into ``new_view()``.
     - rename ``new_raw()`` into ``new_view_raw()``.
+    - rename ``new_owned()`` into ``new()`` or ``new_csc()`` depending on the
+      desired ordering, and have the ownning constructors panic on bad input.
 - 0.4.0-alpha.3:
     - rename ``at`` family of functions into ``get``, consistent with the naming
       scheme in standard library. **breaking change**

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,7 @@ Changelog
     - ``eye()`` returns a csr matrix by default, a csc matrix can be obtained
       using ``eye_csc()``.
     - rename ``new_borrowed()`` into ``new_view()``.
+    - rename ``new_raw()`` into ``new_view_raw()``.
 - 0.4.0-alpha.3:
     - rename ``at`` family of functions into ``get``, consistent with the naming
       scheme in standard library. **breaking change**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ Matrix construction
 
 ```rust
 use sprs::{CsMat, CsMatOwned, CsVec};
-let eye : CsMatOwned<f64> = CsMat::eye(sprs::CSR, 3);
+let eye : CsMatOwned<f64> = CsMat::eye(3);
 let a = CsMat::new_owned(sprs::CSC, 3, 3,
                          vec![0, 2, 4, 5],
                          vec![0, 1, 0, 2, 2],
@@ -26,7 +26,7 @@ Matrix vector multiplication
 
 ```rust
 use sprs::{CsMat, CsVec};
-let eye = CsMat::eye(sprs::CSR, 5);
+let eye = CsMat::eye(5);
 let x = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
 let y = &eye * &x;
 assert_eq!(x, y);
@@ -36,7 +36,7 @@ Matrix matrix multiplication, addition
 
 ```rust
 use sprs::{CsMat, CsVec};
-let eye = CsMat::eye(sprs::CSR, 3);
+let eye = CsMat::eye(3);
 let a = CsMat::new_owned(sprs::CSC, 3, 3,
                          vec![0, 2, 4, 5],
                          vec![0, 1, 0, 2, 2],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ Matrix construction
 ```rust
 use sprs::{CsMat, CsMatOwned, CsVec};
 let eye : CsMatOwned<f64> = CsMat::eye(3);
-let a = CsMat::new_csc(3, 3,
+let a = CsMat::new_csc((3, 3),
                        vec![0, 2, 4, 5],
                        vec![0, 1, 0, 2, 2],
                        vec![1., 2., 3., 4., 5.]);
@@ -37,7 +37,7 @@ Matrix matrix multiplication, addition
 ```rust
 use sprs::{CsMat, CsVec};
 let eye = CsMat::eye(3);
-let a = CsMat::new_csc(3, 3,
+let a = CsMat::new_csc((3, 3),
                        vec![0, 2, 4, 5],
                        vec![0, 1, 0, 2, 2],
                        vec![1., 2., 3., 4., 5.]);
@@ -62,6 +62,14 @@ pub use sparse::CompressedStorage::{CSR, CSC};
 pub use sparse::construct::{vstack, hstack, bmat};
 
 pub type Ix2 = (Ix_, Ix_);
+
+
+/// The shape of a matrix. This a 2-tuple with the first element indicating
+/// the number of rows, and the second element indicating the number of
+/// columns.
+pub type Shape = (usize, usize); // FIXME: maybe we could use Ix2 here?
+
+
 pub type SpRes<T> = Result<T, errors::SprsError>;
 
 
@@ -69,18 +77,19 @@ pub type SpRes<T> = Result<T, errors::SprsError>;
 mod utils {
 
     use sparse::{csmat, CsMatView};
+    use ::Shape;
 
     /// Create a borrowed CsMat matrix from sliced data without
     /// checking validity. Intended for internal use only.
     pub fn csmat_borrowed_uchk<'a, N>(storage: csmat::CompressedStorage,
-                                      nrows : usize, ncols: usize,
+                                      shape: Shape,
                                       indptr : &'a [usize],
                                       indices : &'a [usize],
                                       data : &'a [N]
                                      ) -> CsMatView<'a, N> {
         // not actually memory unsafe here since data comes from slices
         unsafe {
-            CsMatView::new_view_raw(storage, nrows, ncols,
+            CsMatView::new_view_raw(storage, shape,
                                     indptr.as_ptr(),
                                     indices.as_ptr(),
                                     data.as_ptr())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,10 @@ mod utils {
                                      ) -> CsMatView<'a, N> {
         // not actually memory unsafe here since data comes from slices
         unsafe {
-            CsMatView::new_raw(storage, nrows, ncols,
-                               indptr.as_ptr(),
-                               indices.as_ptr(),
-                               data.as_ptr())
+            CsMatView::new_view_raw(storage, nrows, ncols,
+                                    indptr.as_ptr(),
+                                    indices.as_ptr(),
+                                    data.as_ptr())
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@ Matrix construction
 ```rust
 use sprs::{CsMat, CsMatOwned, CsVec};
 let eye : CsMatOwned<f64> = CsMat::eye(3);
-let a = CsMat::new_owned(sprs::CSC, 3, 3,
-                         vec![0, 2, 4, 5],
-                         vec![0, 1, 0, 2, 2],
-                         vec![1., 2., 3., 4., 5.]).unwrap();
+let a = CsMat::new_csc(3, 3,
+                       vec![0, 2, 4, 5],
+                       vec![0, 1, 0, 2, 2],
+                       vec![1., 2., 3., 4., 5.]);
 ```
 
 Matrix vector multiplication
@@ -37,10 +37,10 @@ Matrix matrix multiplication, addition
 ```rust
 use sprs::{CsMat, CsVec};
 let eye = CsMat::eye(3);
-let a = CsMat::new_owned(sprs::CSC, 3, 3,
-                         vec![0, 2, 4, 5],
-                         vec![0, 1, 0, 2, 2],
-                         vec![1., 2., 3., 4., 5.]).unwrap();
+let a = CsMat::new_csc(3, 3,
+                       vec![0, 2, 4, 5],
+                       vec![0, 1, 0, 2, 2],
+                       vec![1., 2., 3., 4., 5.]);
 let b = &eye * &a;
 assert_eq!(a, b.to_csc());
 ```
@@ -67,7 +67,8 @@ pub type SpRes<T> = Result<T, errors::SprsError>;
 
 
 mod utils {
-    use sparse::csmat::{self, CsMatView};
+
+    use sparse::{csmat, CsMatView};
 
     /// Create a borrowed CsMat matrix from sliced data without
     /// checking validity. Intended for internal use only.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ Matrix vector multiplication
 ```rust
 use sprs::{CsMat, CsVec};
 let eye = CsMat::eye(5);
-let x = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
+let x = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
 let y = &eye * &x;
 assert_eq!(x, y);
 ```

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -369,7 +369,7 @@ mod test {
     #[test]
     fn csr_add_dense_rowmaj() {
         let a = OwnedArray::zeros((3,3));
-        let b = CsMatOwned::eye(CSR, 3);
+        let b = CsMatOwned::eye(3);
 
         let c = super::add_dense_mat_same_ordering(&b, &a, 1., 1.).unwrap();
 
@@ -397,7 +397,7 @@ mod test {
     #[test]
     fn csr_mul_dense_rowmaj() {
         let a = OwnedArray::from_elem((3,3), 1.);
-        let b = CsMatOwned::eye(CSR, 3);
+        let b = CsMatOwned::eye(3);
 
         let c = super::mul_dense_mat_same_ordering(&b, &a, 1.).unwrap();
 

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -268,7 +268,7 @@ mod test {
         let data = vec![6.,  7.,  6.,  4.,  3.,
                         8.,  11.,  5.,  5.,  8.,
                         2.,  4.,  4.,  4.,  7.];
-        CsMat::new(5, 5, indptr, indices, data)
+        CsMat::new((5, 5), indptr, indices, data)
     }
 
     fn mat1_minus_mat2() -> CsMatOwned<f64> {
@@ -277,14 +277,14 @@ mod test {
         let data = vec![-6., -7.,  4., -3., -8.,
                         -7.,  5.,  5.,  8., -2.,
                         -4., -4., -4.,  7.];
-        CsMat::new(5, 5, indptr, indices, data)
+        CsMat::new((5, 5), indptr, indices, data)
     }
 
     fn mat1_times_mat2() -> CsMatOwned<f64> {
         let indptr = vec![0,  1,  2,  2, 2, 2];
         let indices = vec![2, 3];
         let data = vec![9., 18.];
-        CsMat::new(5, 5, indptr, indices, data)
+        CsMat::new((5, 5), indptr, indices, data)
     }
 
 
@@ -301,15 +301,15 @@ mod test {
         assert_eq!(c, c_true);
 
         // test with CSR matrices having differ row patterns
-        let a = CsMatOwned::new(3, 3,
+        let a = CsMatOwned::new((3, 3),
                                 vec![0, 1, 1, 2],
                                 vec![0, 2],
                                 vec![1., 1.]);
-        let b = CsMatOwned::new(3, 3,
+        let b = CsMatOwned::new((3, 3),
                                 vec![0, 1, 2, 2],
                                 vec![0, 1],
                                 vec![1., 1.]);
-        let c = CsMatOwned::new(3, 3,
+        let c = CsMatOwned::new((3, 3),
                                 vec![0, 1, 2, 3],
                                 vec![0, 1, 2],
                                 vec![2., 1., 1.]);

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -354,21 +354,20 @@ mod test {
 
     #[test]
     fn csvec_binops() {
-        let vec1 = CsVec::new_owned(8, vec![0, 2, 4, 6], vec![1.; 4]).unwrap();
-        let vec2 = CsVec::new_owned(8, vec![1, 3, 5, 7], vec![2.; 4]).unwrap();
-        let vec3 = CsVec::new_owned(8, vec![1, 2, 5, 6], vec![3.; 4]).unwrap();
+        let vec1 = CsVec::new(8, vec![0, 2, 4, 6], vec![1.; 4]);
+        let vec2 = CsVec::new(8, vec![1, 3, 5, 7], vec![2.; 4]);
+        let vec3 = CsVec::new(8, vec![1, 2, 5, 6], vec![3.; 4]);
 
         let res = &vec1 + &vec2;
-        let expected_output = CsVec::new_owned(
-            8, vec![0, 1, 2, 3, 4, 5, 6, 7],
-            vec![1., 2., 1., 2., 1., 2., 1., 2.]).unwrap();
+        let expected_output = CsVec::new(8,
+                                         vec![0, 1, 2, 3, 4, 5, 6, 7],
+                                         vec![1., 2., 1., 2., 1., 2., 1., 2.]);
         assert_eq!(expected_output, res);
 
         let res = &vec1 + &vec3;
-        let expected_output = CsVec::new_owned(8,
-                                               vec![0, 1, 2, 4, 5, 6],
-                                               vec![1., 3., 4., 1., 3., 4.]
-                                              ).unwrap();
+        let expected_output = CsVec::new(8,
+                                         vec![0, 1, 2, 4, 5, 6],
+                                         vec![1., 3., 4., 1., 3., 4.]);
         assert_eq!(expected_output, res);
     }
 

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -1,7 +1,7 @@
 ///! Traits to generalize over compressed sparse matrices storages
 
 
-use sparse::csmat::{CsMat, CsMatView};
+use sparse::prelude::*;
 use sparse::vec::{CsVec, CsVecView};
 use std::ops::{Deref};
 

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -75,8 +75,8 @@ where N: 'a + Clone + Default,
 /// ```
 /// use sprs::sparse::CompressedStorage::CSR;
 /// use sprs::CsMatOwned;
-/// let a = CsMatOwned::<f64>::eye(CSR, 3);
-/// let b = CsMatOwned::<f64>::eye(CSR, 4);
+/// let a = CsMatOwned::<f64>::eye(3);
+/// let b = CsMatOwned::<f64>::eye(4);
 /// let c = sprs::bmat(&[[Some(a.view()), None],
 ///                      [None, Some(b.view())]]).unwrap();
 /// assert_eq!(c.rows(), 7);
@@ -273,8 +273,8 @@ mod test {
 
     #[test]
     fn bmat_simple() {
-        let a = CsMatOwned::<f64>::eye(CSR, 5);
-        let b = CsMatOwned::<f64>::eye(CSR, 4);
+        let a = CsMatOwned::<f64>::eye(5);
+        let b = CsMatOwned::<f64>::eye(4);
         let c = super::bmat(&[[Some(a.view()), None],
                               [None, Some(b.view())]]).unwrap();
         let expected = CsMatOwned::new_owned(
@@ -320,7 +320,7 @@ mod test {
         let m = OwnedArray::eye(3);
         let m_sparse = super::csr_from_dense(m.view(), 0.);
 
-        assert_eq!(m_sparse, CsMatOwned::eye(CSR, 3));
+        assert_eq!(m_sparse, CsMatOwned::eye(3));
 
         let m = arr2(&[[1., 0., 2., 1e-7, 1.],
                        [0., 0., 0., 1.,   0.],
@@ -343,7 +343,7 @@ mod test {
         let m = OwnedArray::eye(3);
         let m_sparse = super::csc_from_dense(m.view(), 0.);
 
-        assert_eq!(m_sparse, CsMatOwned::eye(CSC, 3));
+        assert_eq!(m_sparse, CsMatOwned::eye_csc(3));
 
         let m = arr2(&[[1., 0., 2., 1e-7, 1.],
                        [0., 0., 0., 1.,   0.],

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -125,8 +125,8 @@ where N: 'a + Clone + Default,
     to_vstack.reserve(super_rows);
     for (i, row) in mats.iter().enumerate() {
         let with_zeros: Vec<_> = row.as_ref().iter().enumerate().map(|(j, m)| {
-            m.as_ref().map_or(CsMatOwned::zero(rows_per_row[i], cols_per_col[j]),
-                              |x| x.to_owned())
+            let shape = (rows_per_row[i], cols_per_col[j]);
+            m.as_ref().map_or(CsMatOwned::zero(shape), |x| x.to_owned())
         }).collect();
         let borrows: Vec<_> = with_zeros.iter().map(|x| x.view()).collect();
         let stacked = try!(hstack(&borrows));
@@ -198,7 +198,7 @@ mod test {
         let indices = vec![2, 3, 3, 4, 2, 1, 3, 0, 1, 2, 4, 0, 3, 2, 3, 1, 2];
         let data = vec![3., 4., 2., 5., 5., 8., 7., 6., 7., 3., 3.,
                         8., 9., 2., 4., 4., 4.];
-        CsMatOwned::new(10, 5, indptr, indices, data)
+        CsMatOwned::new((10, 5), indptr, indices, data)
     }
 
     #[test]
@@ -279,7 +279,7 @@ mod test {
         let c = super::bmat(&[[Some(a.view()), None],
                               [None, Some(b.view())]]).unwrap();
         let expected = CsMatOwned::new(
-            9, 9,
+            (9, 9),
             vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
             vec![0, 1, 2, 3, 4, 5, 6, 7, 8],
             vec![1.; 9]);
@@ -293,7 +293,7 @@ mod test {
         let c = super::bmat(&[[Some(a.view()), Some(b.view())],
                               [Some(b.view()), None]]).unwrap();
         let expected = CsMatOwned::new(
-            10, 10,
+            (10, 10),
             vec![0,  6, 10, 11, 14, 17, 21, 23, 23, 25, 27],
             vec![2, 3, 5, 6, 7, 9, 3, 4, 5, 8, 2, 1, 7, 8, 3,
                  6, 7, 0, 1, 2, 4, 0, 3, 2, 3, 1, 2],
@@ -307,7 +307,7 @@ mod test {
                               [None, Some(e.view())]]
                            ).unwrap();
         let expected = CsMatOwned::new(
-            10, 9,
+            (10, 9),
             vec![0, 4, 8, 10, 12, 14, 16, 18, 21, 23, 24],
             vec![2, 3, 6, 7, 2, 3, 7, 8, 2, 6, 1, 5, 3, 7, 4,
                  5, 4, 8, 4, 7, 8, 5, 7, 4],
@@ -328,8 +328,7 @@ mod test {
                        [3., 0., 1., 0.,   0.]]);
         let m_sparse = super::csr_from_dense(m.view(), 1e-5);
 
-        let expected_output = CsMatOwned::new(3,
-                                              5,
+        let expected_output = CsMatOwned::new((3, 5),
                                               vec![0, 3, 4, 6],
                                               vec![0, 2, 4, 3, 0, 2],
                                               vec![1., 2., 1., 1., 3., 1.]);
@@ -349,8 +348,7 @@ mod test {
                        [3., 0., 1., 0.,   0.]]);
         let m_sparse = super::csc_from_dense(m.view(), 1e-5);
 
-        let expected_output = CsMatOwned::new_csc(3,
-                                                  5,
+        let expected_output = CsMatOwned::new_csc((3, 5),
                                                   vec![0, 2, 2, 4, 5, 6],
                                                   vec![0, 2, 0, 2, 1, 0],
                                                   vec![1., 3., 2., 1., 1., 1.]);

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -245,7 +245,7 @@ impl<'a, N:'a> CsMat<N, Vec<usize>, &'a [usize], &'a [N]> {
 impl<'a, N:'a> CsMat<N, &'a [usize], &'a [usize], &'a [N]> {
     /// Create a borrowed CsMat matrix from sliced data,
     /// checking their validity
-    pub fn new_borrowed(
+    pub fn new_view(
         storage: CompressedStorage, nrows : usize, ncols: usize,
         indptr : &'a[usize], indices : &'a[usize], data : &'a[N]
         )
@@ -1363,7 +1363,7 @@ mod test {
         let indptr_ok : &[usize] = &[0, 1, 2, 3];
         let indices_ok : &[usize] = &[0, 1, 2];
         let data_ok : &[f64] = &[1., 1., 1.];
-        let m = CsMat::new_borrowed(CSR, 3, 3, indptr_ok, indices_ok, data_ok);
+        let m = CsMat::new_view(CSR, 3, 3, indptr_ok, indices_ok, data_ok);
         assert!(m.is_ok());
     }
 
@@ -1379,26 +1379,26 @@ mod test {
         let indices_fail2 : &[usize] = &[0, 1, 4];
         let data_fail1 : &[f64] = &[1., 1., 1., 1.];
         let data_fail2 : &[f64] = &[1., 1.,];
-        assert_eq!(CsMat::new_borrowed(CSR, 3, 3, indptr_fail1,
+        assert_eq!(CsMat::new_view(CSR, 3, 3, indptr_fail1,
                                       indices_ok, data_ok),
                    Err(SprsError::BadIndptrLength));
-        assert_eq!(CsMat::new_borrowed(CSR, 3, 3,
-                                      indptr_fail2, indices_ok, data_ok),
+        assert_eq!(CsMat::new_view(CSR, 3, 3,
+                                   indptr_fail2, indices_ok, data_ok),
                    Err(SprsError::OutOfBoundsIndptr));
-        assert_eq!(CsMat::new_borrowed(CSR, 3, 3,
-                                      indptr_fail3, indices_ok, data_ok),
+        assert_eq!(CsMat::new_view(CSR, 3, 3,
+                                   indptr_fail3, indices_ok, data_ok),
                    Err(SprsError::UnsortedIndptr));
-        assert_eq!(CsMat::new_borrowed(CSR, 3, 3,
-                                      indptr_ok, indices_fail1, data_ok),
+        assert_eq!(CsMat::new_view(CSR, 3, 3,
+                                   indptr_ok, indices_fail1, data_ok),
                    Err(SprsError::DataIndicesMismatch));
-        assert_eq!(CsMat::new_borrowed(CSR, 3, 3,
-                                      indptr_ok, indices_fail2, data_ok),
+        assert_eq!(CsMat::new_view(CSR, 3, 3,
+                                   indptr_ok, indices_fail2, data_ok),
                    Err(SprsError::OutOfBoundsIndex));
-        assert_eq!(CsMat::new_borrowed(CSR, 3, 3,
-                                      indptr_ok, indices_ok, data_fail1),
+        assert_eq!(CsMat::new_view(CSR, 3, 3,
+                                   indptr_ok, indices_ok, data_fail1),
                    Err(SprsError::DataIndicesMismatch));
-        assert_eq!(CsMat::new_borrowed(CSR, 3, 3,
-                                      indptr_ok, indices_ok, data_fail2),
+        assert_eq!(CsMat::new_view(CSR, 3, 3,
+                                   indptr_ok, indices_ok, data_fail2),
                    Err(SprsError::DataIndicesMismatch));
     }
 
@@ -1410,8 +1410,8 @@ mod test {
         let data: &[f64] = &[
             0.35310881, 0.42380633, 0.28035896, 0.58082095,
             0.53350123, 0.88132896, 0.72527863];
-        assert_eq!(CsMat::new_borrowed(CSR, 5, 5,
-                                      indptr, indices, data),
+        assert_eq!(CsMat::new_view(CSR, 5, 5,
+                                   indptr, indices, data),
                    Err(SprsError::NonSortedIndices));
     }
 
@@ -1422,10 +1422,10 @@ mod test {
         let data_ok : &[f64] = &[
             0.05734571, 0.15543348, 0.75628258,
             0.83054515, 0.71851547, 0.46202352];
-        assert!(CsMat::new_borrowed(CSR, 3, 4,
-                                   indptr_ok, indices_ok, data_ok).is_ok());
-        assert!(CsMat::new_borrowed(CSC, 4, 3,
-                                   indptr_ok, indices_ok, data_ok).is_ok());
+        assert!(CsMat::new_view(CSR, 3, 4,
+                                indptr_ok, indices_ok, data_ok).is_ok());
+        assert!(CsMat::new_view(CSC, 4, 3,
+                                indptr_ok, indices_ok, data_ok).is_ok());
     }
 
     #[test]
@@ -1435,11 +1435,11 @@ mod test {
         let data_ok : &[f64] = &[
             0.05734571, 0.15543348, 0.75628258,
             0.83054515, 0.71851547, 0.46202352];
-        assert_eq!(CsMat::new_borrowed(CSR, 4, 3,
-                                      indptr_ok, indices_ok, data_ok),
+        assert_eq!(CsMat::new_view(CSR, 4, 3,
+                                   indptr_ok, indices_ok, data_ok),
                    Err(SprsError::BadIndptrLength));
-        assert_eq!(CsMat::new_borrowed(CSC, 3, 4,
-                                      indptr_ok, indices_ok, data_ok),
+        assert_eq!(CsMat::new_view(CSC, 3, 4,
+                                   indptr_ok, indices_ok, data_ok),
                    Err(SprsError::BadIndptrLength));
     }
 
@@ -1449,8 +1449,8 @@ mod test {
         let indptr_ok = vec![0, 1, 2, 3];
         let indices_ok = vec![0, 1, 2];
         let data_ok : Vec<f64> = vec![1., 1., 1.];
-        assert!(CsMat::new_borrowed(CSR, 3, 3,
-                                   &indptr_ok, &indices_ok, &data_ok).is_ok());
+        assert!(CsMat::new_view(CSR, 3, 3,
+                                &indptr_ok, &indices_ok, &data_ok).is_ok());
     }
 
     #[test]
@@ -1469,7 +1469,7 @@ mod test {
         let data: &[f64] = &[
             0.75672424, 0.1649078, 0.30140296, 0.10358244,
             0.6283315, 0.39244208, 0.57202407];
-        assert!(CsMat::new_borrowed(CSR, 5, 5, indptr, indices, data).is_ok());
+        assert!(CsMat::new_view(CSR, 5, 5, indptr, indices, data).is_ok());
     }
 
     #[test]

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -23,6 +23,7 @@ use sparse::vec::{CsVec, CsVecView, CsVecViewMut, self};
 use sparse::compressed::SpMatView;
 use sparse::binop;
 use sparse::prod;
+use sparse::utils;
 use errors::SprsError;
 use sparse::to_dense::assign_to_dense;
 
@@ -446,18 +447,7 @@ impl<N> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
             let len = stop - start;
             let indices = &mut indices[..len];
             let data = &mut data[..len];
-            buf.clear();
-            buf.reserve_exact(len);
-            for i in 0..len {
-                buf.push((indices[i], data[i]));
-            }
-
-            buf.sort_by_key(|x| x.0);
-
-            for (i, &(ind, x)) in buf.iter().enumerate() {
-                indices[i] = ind;
-                data[i] = x;
-            }
+            utils::sort_indices_data_slices(indices, data, &mut buf);
         }
     }
 
@@ -506,7 +496,7 @@ impl<N: Num> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
     /// use sprs::{CsMat, CsVec};
     /// let eye = CsMat::eye(5);
     /// assert!(eye.is_csr());
-    /// let x = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
+    /// let x = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
     /// let y = &eye * &x;
     /// assert_eq!(x, y);
     /// ```
@@ -533,7 +523,7 @@ impl<N: Num> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
     /// use sprs::{CsMat, CsVec};
     /// let eye = CsMat::eye_csc(5);
     /// assert!(eye.is_csc());
-    /// let x = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
+    /// let x = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
     /// let y = &eye * &x;
     /// assert_eq!(x, y);
     /// ```

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -120,8 +120,10 @@ for OuterIterator<'iter, N> {
                 let data = &self.data[inner_start..inner_end];
                 // safety derives from the structure checks in the constructors
                 unsafe {
-                    let vec = CsVec::new_raw(self.inner_len, indices.len(),
-                                             indices.as_ptr(), data.as_ptr());
+                    let vec = CsVec::new_view_raw(self.inner_len,
+                                                  indices.len(),
+                                                  indices.as_ptr(),
+                                                  data.as_ptr());
                     Some(vec)
                 }
             }
@@ -152,8 +154,10 @@ for OuterIteratorPerm<'iter, 'perm, N> {
                 let data = &self.data[inner_start..inner_end];
                 // safety derives from the structure checks in the constructors
                 unsafe {
-                    let vec = CsVec::new_raw(self.inner_len, indices.len(),
-                                             indices.as_ptr(), data.as_ptr());
+                    let vec = CsVec::new_view_raw(self.inner_len,
+                                                  indices.len(),
+                                                  indices.as_ptr(),
+                                                  data.as_ptr());
                     Some((outer_ind_perm, vec))
                 }
             }
@@ -186,8 +190,10 @@ for OuterIterator<'iter, N> {
                 let data = &self.data[inner_start..inner_end];
                 // safety derives from the structure checks in the constructors
                 unsafe {
-                    let vec = CsVec::new_raw(self.inner_len, indices.len(),
-                                             indices.as_ptr(), data.as_ptr());
+                    let vec = CsVec::new_view_raw(self.inner_len,
+                                                  indices.len(),
+                                                  indices.as_ptr(),
+                                                  data.as_ptr());
                     Some(vec)
                 }
             }
@@ -269,7 +275,7 @@ impl<'a, N:'a> CsMat<N, &'a [usize], &'a [usize], &'a [N]> {
     /// that properties guaranteed by check_compressed_structure are enforced.
     /// For instance, non out-of-bounds indices can be relied upon to
     /// perform unchecked slice access.
-    pub unsafe fn new_raw(
+    pub unsafe fn new_view_raw(
         storage: CompressedStorage, nrows : usize, ncols: usize,
         indptr : *const usize, indices : *const usize, data : *const N
         )
@@ -602,10 +608,10 @@ where IptrStorage: Deref<Target=[usize]>,
         let stop = self.indptr[i+1];
         // safety derives from the structure checks in the constructors
         unsafe {
-            Some(CsVec::new_raw(self.inner_dims(),
-                                self.indices[start..stop].len(),
-                                self.indices[start..stop].as_ptr(),
-                                self.data[start..stop].as_ptr()))
+            Some(CsVec::new_view_raw(self.inner_dims(),
+                                     self.indices[start..stop].len(),
+                                     self.indices[start..stop].as_ptr(),
+                                     self.data[start..stop].as_ptr()))
         }
     }
 
@@ -914,10 +920,10 @@ DataStorage: DerefMut<Target=[N]> {
         let stop = self.indptr[i+1];
         // safety derives from the structure checks in the constructors
         unsafe {
-            Some(CsVec::new_raw_mut(self.inner_dims(),
-                                    self.indices[start..stop].len(),
-                                    self.indices[start..stop].as_ptr(),
-                                    self.data[start..stop].as_mut_ptr()))
+            Some(CsVec::new_view_mut_raw(self.inner_dims(),
+                                         self.indices[start..stop].len(),
+                                         self.indices[start..stop].as_ptr(),
+                                         self.data[start..stop].as_mut_ptr()))
         }
     }
 

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -430,17 +430,17 @@ impl<N> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
 }
 
 impl<N: Num> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
-    /// Identity matrix
+    /// Identity matrix, stored as a CSR matrix.
     ///
     /// ```rust
     /// use sprs::{CsMat, CsVec};
-    /// let eye = CsMat::eye(sprs::CSR, 5);
+    /// let eye = CsMat::eye(5);
+    /// assert!(eye.is_csr());
     /// let x = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
     /// let y = &eye * &x;
     /// assert_eq!(x, y);
     /// ```
-    pub fn eye(storage: CompressedStorage, dim: usize
-              ) -> CsMatOwned<N>
+    pub fn eye(dim: usize) -> CsMatOwned<N>
     where N: Clone
     {
         let n = dim;
@@ -448,7 +448,35 @@ impl<N: Num> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
         let indices = (0..n).collect();
         let data = vec![N::one(); n];
         CsMat {
-            storage: storage,
+            storage: CSR,
+            nrows: n,
+            ncols: n,
+            nnz: n,
+            indptr: indptr,
+            indices: indices,
+            data: data,
+        }
+    }
+
+    /// Identity matrix, stored as a CSC matrix.
+    ///
+    /// ```rust
+    /// use sprs::{CsMat, CsVec};
+    /// let eye = CsMat::eye_csc(5);
+    /// assert!(eye.is_csc());
+    /// let x = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
+    /// let y = &eye * &x;
+    /// assert_eq!(x, y);
+    /// ```
+    pub fn eye_csc(dim: usize) -> CsMatOwned<N>
+    where N: Clone
+    {
+        let n = dim;
+        let indptr = (0..n+1).collect();
+        let indices = (0..n).collect();
+        let data = vec![N::one(); n];
+        CsMat {
+            storage: CSC,
             nrows: n,
             ncols: n,
             nnz: n,
@@ -473,7 +501,7 @@ where IptrStorage: Deref<Target=[usize]>,
     ///
     /// ```rust
     /// use sprs::{CsMat};
-    /// let eye = CsMat::eye(sprs::CSR, 5);
+    /// let eye = CsMat::eye(5);
     /// for (row_ind, row_vec) in eye.outer_iterator().enumerate() {
     ///     let (col_ind, &val): (_, &f64) = row_vec.iter().next().unwrap();
     ///     assert_eq!(row_ind, col_ind);
@@ -609,7 +637,7 @@ where IptrStorage: Deref<Target=[usize]>,
     ///
     /// ```rust
     /// use sprs::{CsMat, CsMatOwned};
-    /// let eye : CsMatOwned<f64> = CsMat::eye(sprs::CSR, 5);
+    /// let eye : CsMatOwned<f64> = CsMat::eye(5);
     /// // get the element of row 3
     /// // there is only one element in this row, with a column index of 3
     /// // and a value of 1.
@@ -1464,7 +1492,7 @@ mod test {
 
     #[test]
     fn outer_block_iter() {
-        let mat : CsMatOwned<f64> = CsMat::eye(CSR, 11);
+        let mat : CsMatOwned<f64> = CsMat::eye(11);
         let mut block_iter = mat.outer_block_iter(3);
         assert_eq!(block_iter.next().unwrap().rows(), 3);
         assert_eq!(block_iter.next().unwrap().rows(), 3);
@@ -1481,7 +1509,7 @@ mod test {
 
     #[test]
     fn nnz_index() {
-        let mat : CsMatOwned<f64> = CsMat::eye(CSR, 11);
+        let mat : CsMatOwned<f64> = CsMat::eye(11);
 
         assert_eq!(mat.nnz_index(2, 3), None);
         assert_eq!(mat.nnz_index(5, 7), None);

--- a/src/sparse/linalg/cholesky.rs
+++ b/src/sparse/linalg/cholesky.rs
@@ -257,8 +257,7 @@ impl<N> LdlNumeric<N> {
         let mut x = &self.symbolic.perm * &rhs[..];
         let n = self.symbolic.problem_size();
         let l = csmat_borrowed_uchk(csmat::CSC,
-                                    n,
-                                    n,
+                                    (n, n),
                                     &self.symbolic.colptr,
                                     &self.l_indices,
                                     &self.l_data);
@@ -440,7 +439,6 @@ where N: Clone + Copy + Num,
 #[cfg(test)]
 mod test {
     use sparse::{csmat, CsMat, CsMatOwned};
-    use sparse::csmat::CompressedStorage::CSC;
     use sparse::permutation::Permutation;
     use sparse::linalg;
     use super::SymmetryCheck;
@@ -454,7 +452,7 @@ mod test {
         let data = vec![1.7, 0.13, 1., 0.02, 0.01, 1.5, 1.1, 0.02, 2.6, 0.16,
                         0.09, 0.52, 0.53, 1.2, 0.16, 1.3, 0.56, 0.09, 1.6,
                         0.11, 0.13, 0.52, 0.11, 1.4, 0.01, 0.53, 0.56, 3.1];
-        CsMat::new_csc(10, 10, indptr, indices, data)
+        CsMat::new_csc((10, 10), indptr, indices, data)
     }
 
     fn test_vec1() -> Vec<f64> {
@@ -580,8 +578,7 @@ mod test {
         let mut x = b.clone();
         let n = b.len();
         let l = csmat_borrowed_uchk(csmat::CSC,
-                                    n,
-                                    n,
+                                    (n, n),
                                     &expected_lp,
                                     &expected_li,
                                     &expected_lx);
@@ -618,8 +615,7 @@ mod test {
         // |   6 2  | |3| = |18|
         // |2      8| |4|   |34|
 
-        let mat = CsMatOwned::new_csc(4,
-                                      4,
+        let mat = CsMatOwned::new_csc((4, 4),
                                       vec![0, 2, 4, 6, 8],
                                       vec![0, 3, 1, 2, 1, 2, 0, 3],
                                       vec![1, 2, 21, 6, 6, 2, 2, 8]);

--- a/src/sparse/linalg/cholesky.rs
+++ b/src/sparse/linalg/cholesky.rs
@@ -454,7 +454,7 @@ mod test {
         let data = vec![1.7, 0.13, 1., 0.02, 0.01, 1.5, 1.1, 0.02, 2.6, 0.16,
                         0.09, 0.52, 0.53, 1.2, 0.16, 1.3, 0.56, 0.09, 1.6,
                         0.11, 0.13, 0.52, 0.11, 1.4, 0.01, 0.53, 0.56, 3.1];
-        CsMat::new_owned(CSC, 10, 10, indptr, indices, data).unwrap()
+        CsMat::new_csc(10, 10, indptr, indices, data)
     }
 
     fn test_vec1() -> Vec<f64> {
@@ -618,13 +618,11 @@ mod test {
         // |   6 2  | |3| = |18|
         // |2      8| |4|   |34|
 
-        let mat = CsMatOwned::new_owned(CSC,
-                                        4,
-                                        4,
-                                        vec![0, 2, 4, 6, 8],
-                                        vec![0, 3, 1, 2, 1, 2, 0, 3],
-                                        vec![1, 2, 21, 6, 6, 2, 2, 8])
-                      .unwrap();
+        let mat = CsMatOwned::new_csc(4,
+                                      4,
+                                      vec![0, 2, 4, 6, 8],
+                                      vec![0, 3, 1, 2, 1, 2, 0, 3],
+                                      vec![1, 2, 21, 6, 6, 2, 2, 8]);
 
         let perm = Permutation::new(vec![0, 2, 1, 3]);
 

--- a/src/sparse/linalg/cholesky.rs
+++ b/src/sparse/linalg/cholesky.rs
@@ -59,7 +59,7 @@ use std::ops::IndexMut;
 
 use num::traits::Num;
 
-use sparse::csmat::{self, CsMat, CsMatView};
+use sparse::{csmat, CsMat, CsMatView};
 use sparse::symmetric::is_symmetric;
 use sparse::permutation::{Permutation, PermOwned};
 use utils::csmat_borrowed_uchk;
@@ -439,7 +439,7 @@ where N: Clone + Copy + Num,
 
 #[cfg(test)]
 mod test {
-    use sparse::csmat::{self, CsMat, CsMatOwned};
+    use sparse::{csmat, CsMat, CsMatOwned};
     use sparse::csmat::CompressedStorage::CSC;
     use sparse::permutation::Permutation;
     use sparse::linalg;

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -401,8 +401,7 @@ mod test {
                                     vec![0, 2, 5, 6, 8, 9],
                                     vec![0, 1, 1, 2, 4, 2, 3, 4, 4],
                                     vec![1, 1, 2, 3, 2, 3, 7, 3, 5]);
-        let b = vec::CsVecOwned::new_owned(5, vec![1, 2, 4], vec![4, 9, 9])
-                    .unwrap();
+        let b = vec::CsVecOwned::new(5, vec![1, 2, 4], vec![4, 9, 9]);
         let mut xw = vec![1; 5]; // inital values should not matter
         let mut visited = vec![false; 5]; // inital values matter here
         let mut dstack = DStack::with_capacity(2 * 5);
@@ -418,10 +417,9 @@ mod test {
                                   .map(|&i| (i, xw[i]))
                                   .collect();
 
-        let expected_output = vec::CsVecOwned::new_owned(5,
-                                                         vec![1, 2, 4],
-                                                         vec![2, 1, 1])
-                                  .unwrap();
+        let expected_output = vec::CsVecOwned::new(5,
+                                                   vec![1, 2, 4],
+                                                   vec![2, 1, 1]);
         let expected_output = expected_output.to_set();
 
         assert_eq!(x, expected_output);
@@ -439,10 +437,9 @@ mod test {
                                          5, 6],
                                     vec![1, 1, 2, 3, 3, 1, 7, 5, 2,
                                          1, 2]);
-        let b = vec::CsVecOwned::new_owned(7,
-                                           vec![0, 2, 3, 5],
-                                           vec![1, 7, 7, 3])
-                    .unwrap();
+        let b = vec::CsVecOwned::new(7,
+                                     vec![0, 2, 3, 5],
+                                     vec![1, 7, 7, 3]);
         let mut dstack = DStack::with_capacity(2 * 7);
         let mut xw = vec![1; 7]; // inital values should not matter
         let mut visited = vec![false; 7]; // inital values matter here
@@ -458,11 +455,10 @@ mod test {
                                   .map(|&i| (i, xw[i]))
                                   .collect();
 
-        let expected_output = vec::CsVecOwned::new_owned(7,
-                                                         vec![0, 2, 3, 5],
-                                                         vec![1, 2, 1, 1])
-                                  .unwrap()
-                                  .to_set();
+        let expected_output = vec::CsVecOwned::new(7,
+                                                   vec![0, 2, 3, 5],
+                                                   vec![1, 2, 1, 1]
+                                                  ).to_set();
 
         assert_eq!(x, expected_output);
     }

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -331,8 +331,7 @@ mod test {
         // |1    | |3|   |3|
         // |0 2  | |1| = |2|
         // |1 0 1| |1|   |4|
-        let l = CsMatOwned::new(3,
-                                3,
+        let l = CsMatOwned::new((3, 3),
                                 vec![0, 1, 2, 4],
                                 vec![0, 1, 0, 2],
                                 vec![1, 2, 1, 1]);
@@ -348,8 +347,7 @@ mod test {
         // |1    | |3|   |3|
         // |1 2  | |1| = |5|
         // |0 0 3| |1|   |3|
-        let l = CsMatOwned::new_csc(3,
-                                    3,
+        let l = CsMatOwned::new_csc((3, 3),
                                     vec![0, 2, 3, 4],
                                     vec![0, 1, 1, 2],
                                     vec![1, 1, 2, 3]);
@@ -365,8 +363,7 @@ mod test {
         // |1 0 1| |3|   |4|
         // |  2 0| |1| = |2|
         // |    3| |1|   |3|
-        let u = CsMatOwned::new_csc(3,
-                                    3,
+        let u = CsMatOwned::new_csc((3, 3),
                                     vec![0, 1, 2, 4],
                                     vec![0, 1, 0, 2],
                                     vec![1, 2, 1, 3]);
@@ -382,8 +379,7 @@ mod test {
         // |1 1 0| |3|   |4|
         // |  5 3| |1| = |8|
         // |    1| |1|   |1|
-        let u = CsMatOwned::new(3,
-                                3,
+        let u = CsMatOwned::new((3, 3),
                                 vec![0, 2, 4, 5],
                                 vec![0, 1, 1, 2, 2],
                                 vec![1, 1, 5, 3, 1]);
@@ -401,8 +397,7 @@ mod test {
         // |  3 3    | |1|   |9|
         // |      7  | | |   | |
         // |  2   3 5| |1|   |9|
-        let l = CsMatOwned::new_csc(5,
-                                    5,
+        let l = CsMatOwned::new_csc((5, 5),
                                     vec![0, 2, 5, 6, 8, 9],
                                     vec![0, 1, 1, 2, 4, 2, 3, 4, 4],
                                     vec![1, 1, 2, 3, 2, 3, 7, 3, 5]);
@@ -438,8 +433,7 @@ mod test {
         // |        5    | | |   | |
         // |    1     1  | |1|   |3|
         // |  3     2   2| | |   | |
-        let l = CsMatOwned::new_csc(7,
-                                    7,
+        let l = CsMatOwned::new_csc((7, 7),
                                     vec![0, 2, 4, 6, 7, 9, 10, 11],
                                     vec![0, 2, 1, 6, 2, 5, 3, 4, 6,
                                          5, 6],

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -2,12 +2,12 @@
 
 use std::ops::IndexMut;
 use num::traits::Num;
-use sparse::csmat;
+use sparse::CsMatView;
 use sparse::vec::{self, VecDim};
 use errors::SprsError;
 use stack::{self, StackVal, DStack};
 
-fn check_solver_dimensions<N, V: ?Sized>(lower_tri_mat: &csmat::CsMatView<N>,
+fn check_solver_dimensions<N, V: ?Sized>(lower_tri_mat: &CsMatView<N>,
                                          rhs: &V)
                                          -> Result<(), SprsError>
 where N: Copy + Num,
@@ -30,7 +30,7 @@ where N: Copy + Num,
 ///
 /// This solve does not assume the input matrix to actually be
 /// triangular, instead it ignores the upper triangular part.
-pub fn lsolve_csr_dense_rhs<N, V: ?Sized>(lower_tri_mat: csmat::CsMatView<N>,
+pub fn lsolve_csr_dense_rhs<N, V: ?Sized>(lower_tri_mat: CsMatView<N>,
                                           rhs: &mut V)
                                           -> Result<(), SprsError>
 where N: Copy + Num,
@@ -80,7 +80,7 @@ where N: Copy + Num,
 /// is the diagonal element (thus actual sorted lower triangular matrices work
 /// best). Otherwise, logarithmic search for the diagonal element
 /// has to be performed for each column.
-pub fn lsolve_csc_dense_rhs<N, V: ?Sized>(lower_tri_mat: csmat::CsMatView<N>,
+pub fn lsolve_csc_dense_rhs<N, V: ?Sized>(lower_tri_mat: CsMatView<N>,
                                           rhs: &mut V)
                                           -> Result<(), SprsError>
 where N: Copy + Num,
@@ -142,7 +142,7 @@ where V: vec::VecDim<N> + IndexMut<usize, Output = N>
 /// is the diagonal element (thus actual sorted lower triangular matrices work
 /// best). Otherwise, logarithmic search for the diagonal element
 /// has to be performed for each column.
-pub fn usolve_csc_dense_rhs<N, V: ?Sized>(upper_tri_mat: csmat::CsMatView<N>,
+pub fn usolve_csc_dense_rhs<N, V: ?Sized>(upper_tri_mat: CsMatView<N>,
                                           rhs: &mut V)
                                           -> Result<(), SprsError>
 where N: Copy + Num,
@@ -191,7 +191,7 @@ where N: Copy + Num,
 ///
 /// This solve does not assume the input matrix to actually be
 /// triangular, instead it ignores the upper triangular part.
-pub fn usolve_csr_dense_rhs<N, V: ?Sized>(upper_tri_mat: csmat::CsMatView<N>,
+pub fn usolve_csr_dense_rhs<N, V: ?Sized>(upper_tri_mat: CsMatView<N>,
                                           rhs: &mut V)
                                           -> Result<(), SprsError>
 where N: Copy + Num,
@@ -251,7 +251,7 @@ where N: Copy + Num,
 /// * if dstack is not empty
 /// * if w_workspace is not of length n
 ///
-pub fn lsolve_csc_sparse_rhs<N>(lower_tri_mat: csmat::CsMatView<N>,
+pub fn lsolve_csc_sparse_rhs<N>(lower_tri_mat: CsMatView<N>,
                                 rhs: vec::CsVecView<N>,
                                 dstack: &mut DStack<StackVal<usize>>,
                                 x_workspace: &mut [N],
@@ -322,7 +322,7 @@ where N: Copy + Num
 #[cfg(test)]
 mod test {
 
-    use sparse::{csmat, vec};
+    use sparse::{CsMatOwned, vec};
     use stack::{self, DStack};
     use std::collections::HashSet;
 
@@ -331,13 +331,11 @@ mod test {
         // |1    | |3|   |3|
         // |0 2  | |1| = |2|
         // |1 0 1| |1|   |4|
-        let l = csmat::CsMatOwned::new_owned(csmat::CompressedStorage::CSR,
-                                             3,
-                                             3,
-                                             vec![0, 1, 2, 4],
-                                             vec![0, 1, 0, 2],
-                                             vec![1, 2, 1, 1])
-                    .unwrap();
+        let l = CsMatOwned::new(3,
+                                3,
+                                vec![0, 1, 2, 4],
+                                vec![0, 1, 0, 2],
+                                vec![1, 2, 1, 1]);
         let b = vec![3, 2, 4];
         let mut x = b.clone();
 
@@ -350,13 +348,11 @@ mod test {
         // |1    | |3|   |3|
         // |1 2  | |1| = |5|
         // |0 0 3| |1|   |3|
-        let l = csmat::CsMatOwned::new_owned(csmat::CompressedStorage::CSC,
-                                             3,
-                                             3,
-                                             vec![0, 2, 3, 4],
-                                             vec![0, 1, 1, 2],
-                                             vec![1, 1, 2, 3])
-                    .unwrap();
+        let l = CsMatOwned::new_csc(3,
+                                    3,
+                                    vec![0, 2, 3, 4],
+                                    vec![0, 1, 1, 2],
+                                    vec![1, 1, 2, 3]);
         let b = vec![3, 5, 3];
         let mut x = b.clone();
 
@@ -369,13 +365,11 @@ mod test {
         // |1 0 1| |3|   |4|
         // |  2 0| |1| = |2|
         // |    3| |1|   |3|
-        let u = csmat::CsMatOwned::new_owned(csmat::CompressedStorage::CSC,
-                                             3,
-                                             3,
-                                             vec![0, 1, 2, 4],
-                                             vec![0, 1, 0, 2],
-                                             vec![1, 2, 1, 3])
-                    .unwrap();
+        let u = CsMatOwned::new_csc(3,
+                                    3,
+                                    vec![0, 1, 2, 4],
+                                    vec![0, 1, 0, 2],
+                                    vec![1, 2, 1, 3]);
         let b = vec![4, 2, 3];
         let mut x = b.clone();
 
@@ -388,13 +382,11 @@ mod test {
         // |1 1 0| |3|   |4|
         // |  5 3| |1| = |8|
         // |    1| |1|   |1|
-        let u = csmat::CsMatOwned::new_owned(csmat::CompressedStorage::CSR,
-                                             3,
-                                             3,
-                                             vec![0, 2, 4, 5],
-                                             vec![0, 1, 1, 2, 2],
-                                             vec![1, 1, 5, 3, 1])
-                    .unwrap();
+        let u = CsMatOwned::new(3,
+                                3,
+                                vec![0, 2, 4, 5],
+                                vec![0, 1, 1, 2, 2],
+                                vec![1, 1, 5, 3, 1]);
         let b = vec![4, 8, 1];
         let mut x = b.clone();
 
@@ -409,13 +401,11 @@ mod test {
         // |  3 3    | |1|   |9|
         // |      7  | | |   | |
         // |  2   3 5| |1|   |9|
-        let l = csmat::CsMatOwned::new_owned(csmat::CompressedStorage::CSC,
-                                             5,
-                                             5,
-                                             vec![0, 2, 5, 6, 8, 9],
-                                             vec![0, 1, 1, 2, 4, 2, 3, 4, 4],
-                                             vec![1, 1, 2, 3, 2, 3, 7, 3, 5])
-                    .unwrap();
+        let l = CsMatOwned::new_csc(5,
+                                    5,
+                                    vec![0, 2, 5, 6, 8, 9],
+                                    vec![0, 1, 1, 2, 4, 2, 3, 4, 4],
+                                    vec![1, 1, 2, 3, 2, 3, 7, 3, 5]);
         let b = vec::CsVecOwned::new_owned(5, vec![1, 2, 4], vec![4, 9, 9])
                     .unwrap();
         let mut xw = vec![1; 5]; // inital values should not matter
@@ -448,15 +438,13 @@ mod test {
         // |        5    | | |   | |
         // |    1     1  | |1|   |3|
         // |  3     2   2| | |   | |
-        let l = csmat::CsMatOwned::new_owned(csmat::CompressedStorage::CSC,
-                                             7,
-                                             7,
-                                             vec![0, 2, 4, 6, 7, 9, 10, 11],
-                                             vec![0, 2, 1, 6, 2, 5, 3, 4, 6,
-                                                  5, 6],
-                                             vec![1, 1, 2, 3, 3, 1, 7, 5, 2,
-                                                  1, 2])
-                    .unwrap();
+        let l = CsMatOwned::new_csc(7,
+                                    7,
+                                    vec![0, 2, 4, 6, 7, 9, 10, 11],
+                                    vec![0, 2, 1, 6, 2, 5, 3, 4, 6,
+                                         5, 6],
+                                    vec![1, 1, 2, 3, 3, 1, 7, 5, 2,
+                                         1, 2]);
         let b = vec::CsVecOwned::new_owned(7,
                                            vec![0, 2, 3, 5],
                                            vec![1, 7, 7, 3])

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -1,15 +1,41 @@
+use std::ops::Deref;
 
-pub use self::csmat::{CompressedStorage,
-                      CsMat,
-                      CsMatOwned,
-                      CsMatView,
-};
+pub use self::csmat::{CompressedStorage};
 
 pub use self::vec::{CsVec,
                     CsVecOwned,
                     CsVecView,
 };
 
+/// Compressed matrix in the CSR or CSC format.
+#[derive(PartialEq, Debug)]
+pub struct CsMat<N, IptrStorage, IndStorage, DataStorage>
+where IptrStorage: Deref<Target=[usize]>,
+      IndStorage: Deref<Target=[usize]>,
+      DataStorage: Deref<Target=[N]> {
+    storage: CompressedStorage,
+    nrows : usize,
+    ncols : usize,
+    indptr : IptrStorage,
+    indices : IndStorage,
+    data : DataStorage
+}
+
+pub type CsMatOwned<N> = CsMat<N, Vec<usize>, Vec<usize>, Vec<N>>;
+pub type CsMatView<'a, N> = CsMat<N, &'a [usize], &'a [usize], &'a [N]>;
+pub type CsMatViewMut<'a, N> = CsMat<N, &'a [usize], &'a [usize], &'a mut [N]>;
+// FIXME: a fixed size array would be better, but no Deref impl
+pub type CsMatVecView<'a, N> = CsMat<N, Vec<usize>, &'a [usize], &'a [N]>;
+
+mod prelude {
+    pub use super::{
+        CsMat,
+        CsMatView,
+        CsMatViewMut,
+        CsMatOwned,
+        CsMatVecView,
+    };
+}
 
 pub mod csmat;
 pub mod triplet;

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -37,6 +37,29 @@ mod prelude {
     };
 }
 
+mod utils {
+    pub fn sort_indices_data_slices<N: Copy>(indices: &mut [usize],
+                                             data: &mut [N],
+                                             buf: &mut Vec<(usize, N)>) {
+        let len = indices.len();
+        assert_eq!(len, data.len());
+        let indices = &mut indices[..len];
+        let data = &mut data[..len];
+        buf.clear();
+        buf.reserve_exact(len);
+        for i in 0..len {
+            buf.push((indices[i], data[i]));
+        }
+
+        buf.sort_by_key(|x| x.0);
+
+        for (i, &(ind, x)) in buf.iter().enumerate() {
+            indices[i] = ind;
+            data[i] = x;
+        }
+    }
+}
+
 pub mod csmat;
 pub mod triplet;
 pub mod vec;

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -462,44 +462,36 @@ mod test {
     #[test]
     fn mul_csr_csvec() {
         let a = mat1();
-        let v = CsVec::new_owned(5, vec![0, 2, 4], vec![1.; 3]).unwrap();
+        let v = CsVec::new(5, vec![0, 2, 4], vec![1.; 3]);
         let res = &a * &v;
-        let expected_output = CsVec::new_owned(5,
-                                               vec![0, 1, 2],
-                                               vec![3., 5., 5.]).unwrap();
+        let expected_output = CsVec::new(5, vec![0, 1, 2], vec![3., 5., 5.]);
         assert_eq!(expected_output, res);
     }
 
     #[test]
     fn mul_csvec_csr() {
         let a = mat1();
-        let v = CsVec::new_owned(5, vec![0, 2, 4], vec![1.; 3]).unwrap();
+        let v = CsVec::new(5, vec![0, 2, 4], vec![1.; 3]);
         let res = &v * &a;
-        let expected_output = CsVec::new_owned(5,
-                                               vec![2, 3],
-                                               vec![8., 11.]).unwrap();
+        let expected_output = CsVec::new(5, vec![2, 3], vec![8., 11.]);
         assert_eq!(expected_output, res);
     }
 
     #[test]
     fn mul_csc_csvec() {
         let a = mat1_csc();
-        let v = CsVec::new_owned(5, vec![0, 2, 4], vec![1.; 3]).unwrap();
+        let v = CsVec::new(5, vec![0, 2, 4], vec![1.; 3]);
         let res = &a * &v;
-        let expected_output = CsVec::new_owned(5,
-                                               vec![0, 1, 2],
-                                               vec![3., 5., 5.]).unwrap();
+        let expected_output = CsVec::new(5, vec![0, 1, 2], vec![3., 5., 5.]);
         assert_eq!(expected_output, res);
     }
 
     #[test]
     fn mul_csvec_csc() {
         let a = mat1_csc();
-        let v = CsVec::new_owned(5, vec![0, 2, 4], vec![1.; 3]).unwrap();
+        let v = CsVec::new(5, vec![0, 2, 4], vec![1.; 3]);
         let res = &v * &a;
-        let expected_output = CsVec::new_owned(5,
-                                               vec![2, 3],
-                                               vec![8., 11.]).unwrap();
+        let expected_output = CsVec::new(5, vec![2, 3], vec![8., 11.]);
         assert_eq!(expected_output, res);
     }
 

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -414,7 +414,7 @@ mod test {
 
     #[test]
     fn mul_csr_csr_identity() {
-        let eye: CsMatOwned<i32> = CsMat::eye(CSR, 10);
+        let eye: CsMatOwned<i32> = CsMat::eye(10);
         let mut workspace = [0; 10];
         let res = csr_mul_csr(&eye, &eye, &mut workspace).unwrap();
         assert_eq!(eye, res);
@@ -506,7 +506,7 @@ mod test {
     #[test]
     fn mul_csr_dense_rowmaj() {
         let a = OwnedArray::eye(3);
-        let e: CsMatOwned<f64> = CsMat::eye(CSR, 3);
+        let e: CsMatOwned<f64> = CsMat::eye(3);
         let mut res = OwnedArray::zeros((3, 3));
         super::csr_mulacc_dense_rowmaj(e.view(),
                                        a.view(),

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -376,7 +376,7 @@ mod test {
             0.35310881, 0.42380633, 0.28035896, 0.58082095,
             0.53350123, 0.88132896, 0.72527863];
 
-        let mat = CsMat::new_borrowed(CSC, 5, 5, indptr, indices, data).unwrap();
+        let mat = CsMat::new_view(CSC, 5, 5, indptr, indices, data).unwrap();
         let vector = vec![0.1, 0.2, -0.1, 0.3, 0.9];
         let mut res_vec = vec![0., 0., 0., 0., 0.];
         mul_acc_mat_vec_csc(mat, &vector, &mut res_vec).unwrap();
@@ -398,7 +398,7 @@ mod test {
             0.75672424, 0.1649078, 0.30140296, 0.10358244,
             0.6283315, 0.39244208, 0.57202407];
 
-        let mat = CsMat::new_borrowed(CSR, 5, 5, indptr, indices, data).unwrap();
+        let mat = CsMat::new_view(CSR, 5, 5, indptr, indices, data).unwrap();
         let vector = vec![0.1, 0.2, -0.1, 0.3, 0.9];
         let mut res_vec = vec![0., 0., 0., 0., 0.];
         mul_acc_mat_vec_csr(mat, &vector, &mut res_vec).unwrap();

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -1,6 +1,6 @@
 ///! Sparse matrix product
 
-use sparse::csmat::{CsMatOwned, CsMatView};
+use sparse::prelude::*;
 use sparse::vec::{CsVecView, CsVecOwned};
 use num::traits::Num;
 use sparse::compressed::SpMatView;
@@ -142,7 +142,7 @@ where N: Num + Copy {
     }
 
     let mut res = CsMatOwned::empty(lhs.storage(), res_cols);
-    res.reserve_nnz_exact(lhs.nb_nonzero() + rhs.nb_nonzero());
+    res.reserve_nnz_exact(lhs.nnz() + rhs.nnz());
     for lvec in lhs.outer_iterator() {
         // reset the accumulators
         for wval in workspace.iter_mut() {
@@ -359,7 +359,7 @@ where N: 'a + Num + Copy
 
 #[cfg(test)]
 mod test {
-    use sparse::csmat::{CsMat, CsMatOwned};
+    use sparse::{CsMat, CsMatOwned};
     use sparse::vec::{CsVec};
     use sparse::csmat::CompressedStorage::{CSC, CSR};
     use super::{mul_acc_mat_vec_csc, mul_acc_mat_vec_csr, csr_mul_csr};

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -376,7 +376,7 @@ mod test {
             0.35310881, 0.42380633, 0.28035896, 0.58082095,
             0.53350123, 0.88132896, 0.72527863];
 
-        let mat = CsMat::new_view(CSC, 5, 5, indptr, indices, data).unwrap();
+        let mat = CsMat::new_view(CSC, (5, 5), indptr, indices, data).unwrap();
         let vector = vec![0.1, 0.2, -0.1, 0.3, 0.9];
         let mut res_vec = vec![0., 0., 0., 0., 0.];
         mul_acc_mat_vec_csc(mat, &vector, &mut res_vec).unwrap();
@@ -398,7 +398,7 @@ mod test {
             0.75672424, 0.1649078, 0.30140296, 0.10358244,
             0.6283315, 0.39244208, 0.57202407];
 
-        let mat = CsMat::new_view(CSR, 5, 5, indptr, indices, data).unwrap();
+        let mat = CsMat::new_view(CSR, (5, 5), indptr, indices, data).unwrap();
         let vector = vec![0.1, 0.2, -0.1, 0.3, 0.9];
         let mut res_vec = vec![0., 0., 0., 0., 0.];
         mul_acc_mat_vec_csr(mat, &vector, &mut res_vec).unwrap();

--- a/src/sparse/symmetric.rs
+++ b/src/sparse/symmetric.rs
@@ -59,7 +59,7 @@ mod test {
             0.13, 0.52, 0.11, 1.4,
             0.01, 0.53, 0.56, 3.1];
 
-        let a = CsMat::new_borrowed(CSR, 10, 10, indptr, indices, data).unwrap();
+        let a = CsMat::new_view(CSR, 10, 10, indptr, indices, data).unwrap();
 
         assert!(is_symmetric(&a));
     }

--- a/src/sparse/symmetric.rs
+++ b/src/sparse/symmetric.rs
@@ -59,7 +59,7 @@ mod test {
             0.13, 0.52, 0.11, 1.4,
             0.01, 0.53, 0.56, 3.1];
 
-        let a = CsMat::new_view(CSR, 10, 10, indptr, indices, data).unwrap();
+        let a = CsMat::new_view(CSR, (10, 10), indptr, indices, data).unwrap();
 
         assert!(is_symmetric(&a));
     }

--- a/src/sparse/symmetric.rs
+++ b/src/sparse/symmetric.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Deref};
 
-use sparse::csmat::CsMat;
+use sparse::prelude::*;
 
 pub fn is_symmetric<N, IpStorage, IStorage, DStorage>(
     mat: &CsMat<N, IpStorage, IStorage, DStorage>) -> bool
@@ -29,7 +29,7 @@ DStorage: Deref<Target=[N]> {
 
 #[cfg(test)]
 mod test {
-    use sparse::csmat::CsMat;
+    use sparse::CsMat;
     use sparse::csmat::CompressedStorage::{CSR};
     use super::is_symmetric;
 

--- a/src/sparse/to_dense.rs
+++ b/src/sparse/to_dense.rs
@@ -36,12 +36,11 @@ where N: Clone
 mod test {
     use ndarray::{OwnedArray, arr2};
     use ::CsMatOwned;
-    use ::{CSR, CSC};
     use test_data::{mat1};
 
     #[test]
     fn to_dense() {
-        let speye: CsMatOwned<f64> = CsMatOwned::eye(CSR, 3);
+        let speye: CsMatOwned<f64> = CsMatOwned::eye(3);
         let mut deye = OwnedArray::zeros((3, 3));
 
         super::assign_to_dense(deye.view_mut(), speye.view()).unwrap();
@@ -49,7 +48,7 @@ mod test {
         let res = OwnedArray::eye(3);
         assert_eq!(deye, res);
 
-        let speye: CsMatOwned<f64> = CsMatOwned::eye(CSC, 3);
+        let speye: CsMatOwned<f64> = CsMatOwned::eye_csc(3);
         let mut deye = OwnedArray::zeros((3, 3));
 
         super::assign_to_dense(deye.view_mut(), speye.view()).unwrap();

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -336,8 +336,7 @@ impl<'a, N> TripletView<'a, N> {
         let mut out_indices = vec![0; nnz];
         let mut out_data = vec![N::zero(); nnz];
         csmat::raw::convert_storage(csmat::CompressedStorage::CSR,
-                                    self.rows(),
-                                    self.cols(),
+                                    self.shape(),
                                     &indptr,
                                     &indices,
                                     &data,
@@ -473,8 +472,7 @@ mod test {
         triplet_mat.add_triplet(3, 3, 6.);
 
         let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc(4,
-                                           4,
+        let expected = CsMatOwned::new_csc((4, 4),
                                            vec![0, 2, 3, 4, 6],
                                            vec![0, 1, 0, 3, 2, 3],
                                            vec![1., 3., 2., 5., 4., 6.]);
@@ -500,8 +498,7 @@ mod test {
         triplet_mat.add_triplet(3, 2, 5.);
 
         let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc(4,
-                                           4,
+        let expected = CsMatOwned::new_csc((4, 4),
                                            vec![0, 2, 3, 4, 6],
                                            vec![0, 1, 0, 3, 2, 3],
                                            vec![1., 3., 2., 5., 4., 6.]);
@@ -527,8 +524,7 @@ mod test {
         triplet_mat.add_triplet(3, 2, 2.);
 
         let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc(4,
-                                           4,
+        let expected = CsMatOwned::new_csc((4, 4),
                                            vec![0, 2, 3, 4, 6],
                                            vec![0, 1, 0, 3, 2, 3],
                                            vec![1., 3., 2., 5., 4., 6.]);
@@ -552,8 +548,7 @@ mod test {
                                                            data);
 
         let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc(5,
-                                           4,
+        let expected = CsMatOwned::new_csc((5, 4),
                                            vec![0, 2, 4, 5, 8],
                                            vec![0, 1, 0, 4, 3, 2, 3, 4],
                                            vec![1, 3, 2, 7, 5, 4, 6, 8]);
@@ -577,8 +572,7 @@ mod test {
 
 
         let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc(4,
-                                           4,
+        let expected = CsMatOwned::new_csc((4, 4),
                                            vec![0, 2, 3, 4, 6],
                                            vec![0, 1, 0, 3, 2, 3],
                                            vec![1., 3., 2., 5., 0., 6.]);
@@ -604,8 +598,7 @@ mod test {
         triplet_mat.add_triplet(3, 2, 2.);
 
         let csr = triplet_mat.to_csr();
-        let expected = CsMatOwned::new_csc(4,
-                                           4,
+        let expected = CsMatOwned::new_csc((4, 4),
                                            vec![0, 2, 3, 4, 6],
                                            vec![0, 1, 0, 3, 2, 3],
                                            vec![1., 3., 2., 5., 4., 6.])
@@ -652,8 +645,7 @@ mod test {
 
         let csc = triplet_mat.to_csc();
 
-        let expected = CsMatOwned::new_csc(6,
-                                           9,
+        let expected = CsMatOwned::new_csc((6, 9),
                                            vec![0, 6, 7, 8, 10, 11,
                                                 14, 15, 16, 22],
                                            vec![0, 1, 2, 3, 4, 5, 2,

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -346,7 +346,7 @@ where Ite1: Iterator<Item=(usize, &'a N1)>,
 impl<'a, N: 'a> CsVecView<'a, N> {
 
     /// Create a borrowed CsVec over slice data.
-    pub fn new_borrowed(
+    pub fn new_view(
         n: usize,
         indices: &'a [usize],
         data: &'a [N])

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -380,11 +380,11 @@ impl<'a, N: 'a> CsVecView<'a, N> {
     /// that properties guaranteed by check_structure are enforced.
     /// For instance, non out-of-bounds indices can be relied upon to
     /// perform unchecked slice access.
-    pub unsafe fn new_raw(n: usize,
-                          nnz: usize,
-                          indices: *const usize,
-                          data: *const N,
-                          ) -> CsVec<N, &'a[usize], &'a[N]> {
+    pub unsafe fn new_view_raw(n: usize,
+                               nnz: usize,
+                               indices: *const usize,
+                               data: *const N,
+                              ) -> CsVec<N, &'a[usize], &'a[N]> {
         CsVec {
             dim: n,
             indices: slice::from_raw_parts(indices, nnz),
@@ -693,11 +693,11 @@ where N: 'a {
     /// that properties guaranteed by check_structure are enforced.
     /// For instance, non out-of-bounds indices can be relied upon to
     /// perform unchecked slice access.
-    pub unsafe fn new_raw_mut(n: usize,
-                              nnz: usize,
-                              indices: *const usize,
-                              data: *mut N,
-                             ) -> CsVecViewMut<'a, N> {
+    pub unsafe fn new_view_mut_raw(n: usize,
+                                   nnz: usize,
+                                   indices: *const usize,
+                                   data: *mut N,
+                                  ) -> CsVecViewMut<'a, N> {
         CsVec {
             dim: n,
             indices: slice::from_raw_parts(indices, nnz),

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -30,7 +30,7 @@ use num::traits::Num;
 
 use sparse::permutation::PermView;
 use sparse::{prod, binop};
-use sparse::csmat::{CsMat, CsMatVecView};
+use sparse::prelude::*;
 use sparse::csmat::CompressedStorage::{CSR, CSC};
 use errors::SprsError;
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -3,8 +3,8 @@
 /// # Example
 /// ```rust
 /// use sprs::CsVec;
-/// let vec1 = CsVec::new_owned(8, vec![0, 2, 5, 6], vec![1.; 4]).unwrap();
-/// let vec2 = CsVec::new_owned(8, vec![1, 3, 5], vec![2.; 3]).unwrap();
+/// let vec1 = CsVec::new(8, vec![0, 2, 5, 6], vec![1.; 4]);
+/// let vec2 = CsVec::new(8, vec![1, 3, 5], vec![2.; 3]);
 /// let res = &vec1 + &vec2;
 /// let mut iter = res.iter();
 /// assert_eq!(iter.next(), Some((0, &1.)));
@@ -30,6 +30,7 @@ use num::traits::Num;
 
 use sparse::permutation::PermView;
 use sparse::{prod, binop};
+use sparse::utils;
 use sparse::prelude::*;
 use sparse::csmat::CompressedStorage::{CSR, CSC};
 use errors::SprsError;
@@ -131,9 +132,8 @@ pub trait SparseIterTools: Iterator {
     /// use sprs::CsVec;
     /// use sprs::sparse::vec::NnzEither;
     /// use sprs::sparse::vec::SparseIterTools;
-    /// let v0 = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
-    /// let v1 = CsVec::new_owned(5, vec![1, 2, 3], vec![-1., -2., -3.]
-    ///                          ).unwrap();
+    /// let v0 = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
+    /// let v1 = CsVec::new(5, vec![1, 2, 3], vec![-1., -2., -3.]);
     /// let mut nnz_or_iter = v0.iter().nnz_or_zip(v1.iter());
     /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Left((0, &1.))));
     /// assert_eq!(nnz_or_iter.next(), Some(NnzEither::Right((1, &-1.))));
@@ -161,9 +161,8 @@ pub trait SparseIterTools: Iterator {
     /// ```rust
     /// use sprs::CsVec;
     /// use sprs::sparse::vec::SparseIterTools;
-    /// let v0 = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
-    /// let v1 = CsVec::new_owned(5, vec![1, 2, 3], vec![-1., -2., -3.]
-    ///                          ).unwrap();
+    /// let v0 = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
+    /// let v1 = CsVec::new(5, vec![1, 2, 3], vec![-1., -2., -3.]);
     /// let mut nnz_zip = v0.iter().nnz_zip(v1.iter());
     /// assert_eq!(nnz_zip.next(), Some((2, &2., &-2.)));
     /// assert_eq!(nnz_zip.next(), None);
@@ -395,16 +394,27 @@ impl<'a, N: 'a> CsVecView<'a, N> {
 
 impl<N> CsVec<N, Vec<usize>, Vec<N>> {
     /// Create an owning CsVec from vector data.
-    pub fn new_owned(n: usize,
-                     indices: Vec<usize>,
-                     data: Vec<N>
-                    ) -> Result<CsVec<N, Vec<usize>, Vec<N>>, SprsError> {
+    ///
+    /// # Panics
+    ///
+    /// - if `indices` and `data` lengths differ
+    /// - if the vector contains out of bounds indices
+    pub fn new(n: usize,
+               mut indices: Vec<usize>,
+               mut data: Vec<N>
+              ) -> CsVec<N, Vec<usize>, Vec<N>>
+    where N: Copy
+    {
+        let mut buf = Vec::with_capacity(indices.len());
+        utils::sort_indices_data_slices(&mut indices[..],
+                                        &mut data[..],
+                                        &mut buf);
         let v = CsVec {
             dim: n,
             indices: indices,
             data: data
         };
-        v.check_structure().and(Ok(v))
+        v.check_structure().and(Ok(v)).unwrap()
     }
 
     /// Create an empty CsVec, which can be used for incremental construction
@@ -479,7 +489,7 @@ where IStorage: Deref<Target=[usize]>,
     ///
     /// ```rust
     /// use sprs::CsVec;
-    /// let v = CsVec::new_owned(5, vec![0, 2, 4], vec![1., 2., 3.]).unwrap();
+    /// let v = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
     /// let mut iter = v.iter();
     /// assert_eq!(iter.next(), Some((0, &1.)));
     /// assert_eq!(iter.next(), Some((2, &2.)));
@@ -604,8 +614,8 @@ where IStorage: Deref<Target=[usize]>,
     ///
     /// ```rust
     /// use sprs::CsVec;
-    /// let v1 = CsVec::new_owned(8, vec![1, 2, 4, 6], vec![1.; 4]).unwrap();
-    /// let v2 = CsVec::new_owned(8, vec![1, 3, 5, 7], vec![2.; 4]).unwrap();
+    /// let v1 = CsVec::new(8, vec![1, 2, 4, 6], vec![1.; 4]);
+    /// let v2 = CsVec::new(8, vec![1, 3, 5, 7], vec![2.; 4]);
     /// assert_eq!(2., v1.dot(&v2));
     /// assert_eq!(4., v1.dot(&v1));
     /// assert_eq!(16., v2.dot(&v2));
@@ -832,7 +842,7 @@ mod test {
         let indices = vec![0, 1, 4, 5, 7];
         let data = vec![0., 1., 4., 5., 7.];
 
-        return CsVec::new_owned(n, indices, data).unwrap();
+        return CsVec::new(n, indices, data);
     }
 
     fn test_vec2() -> CsVec<f64, Vec<usize>, Vec<f64>> {
@@ -840,7 +850,7 @@ mod test {
         let indices = vec![0, 2, 4, 6, 7];
         let data = vec![0.5, 2.5, 4.5, 6.5, 7.5];
 
-        return CsVec::new_owned(n, indices, data).unwrap();
+        return CsVec::new(n, indices, data);
     }
 
     #[test]
@@ -871,9 +881,9 @@ mod test {
 
     #[test]
     fn dot_product() {
-        let vec1 = CsVec::new_owned(8, vec![0, 2, 4, 6], vec![1.; 4]).unwrap();
-        let vec2 = CsVec::new_owned(8, vec![1, 3, 5, 7], vec![2.; 4]).unwrap();
-        let vec3 = CsVec::new_owned(8, vec![1, 2, 5, 6], vec![3.; 4]).unwrap();
+        let vec1 = CsVec::new(8, vec![0, 2, 4, 6], vec![1.; 4]);
+        let vec2 = CsVec::new(8, vec![1, 3, 5, 7], vec![2.; 4]);
+        let vec3 = CsVec::new(8, vec![1, 2, 5, 6], vec![3.; 4]);
 
         assert_eq!(0., vec1.dot(&vec2));
         assert_eq!(4., vec1.dot(&vec1));
@@ -893,22 +903,22 @@ mod test {
     #[test]
     #[should_panic]
     fn dot_product_panics() {
-        let vec1 = CsVec::new_owned(8, vec![0, 2, 4, 6], vec![1.; 4]).unwrap();
-        let vec2 = CsVec::new_owned(9, vec![1, 3, 5, 7], vec![2.; 4]).unwrap();
+        let vec1 = CsVec::new(8, vec![0, 2, 4, 6], vec![1.; 4]);
+        let vec2 = CsVec::new(9, vec![1, 3, 5, 7], vec![2.; 4]);
         vec1.dot(&vec2);
     }
 
     #[test]
     #[should_panic]
     fn dot_product_panics2() {
-        let vec1 = CsVec::new_owned(8, vec![0, 2, 4, 6], vec![1.; 4]).unwrap();
+        let vec1 = CsVec::new(8, vec![0, 2, 4, 6], vec![1.; 4]);
         let dense_vec = vec![0., 1., 2., 3., 4., 5., 6., 7., 8.];
         vec1.dot(&dense_vec);
     }
 
     #[test]
     fn nnz_index() {
-        let vec = CsVec::new_owned(8, vec![0, 2, 4, 6], vec![1.; 4]).unwrap();
+        let vec = CsVec::new(8, vec![0, 2, 4, 6], vec![1.; 4]);
         assert_eq!(vec.nnz_index(1), None);
         assert_eq!(vec.nnz_index(9), None);
         assert_eq!(vec.nnz_index(0), Some(super::NnzIndex(0)));
@@ -924,36 +934,24 @@ mod test {
 
     #[test]
     fn get_mut() {
-        let mut vec = CsVec::new_owned(8,
-                                       vec![0, 2, 4, 6],
-                                       vec![1.; 4]
-                                      ).unwrap();
+        let mut vec = CsVec::new(8, vec![0, 2, 4, 6], vec![1.; 4]);
 
         *vec.get_mut(4).unwrap() = 2.;
 
-        let expected = CsVec::new_owned(8,
-                                        vec![0, 2, 4, 6],
-                                        vec![1., 1., 2., 1.],
-                                       ).unwrap();
+        let expected = CsVec::new(8, vec![0, 2, 4, 6], vec![1., 1., 2., 1.],);
 
         assert_eq!(vec, expected);
 
         vec[6] = 3.;
 
-        let expected = CsVec::new_owned(8,
-                                        vec![0, 2, 4, 6],
-                                        vec![1., 1., 2., 3.],
-                                       ).unwrap();
+        let expected = CsVec::new(8, vec![0, 2, 4, 6], vec![1., 1., 2., 3.],);
 
         assert_eq!(vec, expected);
     }
 
     #[test]
     fn indexing() {
-        let vec = CsVec::new_owned(8,
-                                   vec![0, 2, 4, 6],
-                                   vec![1., 2., 3., 4.]
-                                  ).unwrap();
+        let vec = CsVec::new(8, vec![0, 2, 4, 6], vec![1., 2., 3., 4.]);
         assert_eq!(vec[0], 1.);
         assert_eq!(vec[2], 2.);
         assert_eq!(vec[4], 3.);
@@ -962,29 +960,17 @@ mod test {
 
     #[test]
     fn map_inplace() {
-        let mut vec = CsVec::new_owned(8,
-                                       vec![0, 2, 4, 6],
-                                       vec![1., 2., 3., 4.]
-                                      ).unwrap();
+        let mut vec = CsVec::new(8, vec![0, 2, 4, 6], vec![1., 2., 3., 4.]);
         vec.map_inplace(|&x| x + 1.);
-        let expected = CsVec::new_owned(8,
-                                        vec![0, 2, 4, 6],
-                                        vec![2., 3., 4., 5.]
-                                       ).unwrap();
+        let expected = CsVec::new(8, vec![0, 2, 4, 6], vec![2., 3., 4., 5.]);
         assert_eq!(vec, expected);
     }
 
     #[test]
     fn map() {
-        let vec = CsVec::new_owned(8,
-                                   vec![0, 2, 4, 6],
-                                   vec![1., 2., 3., 4.]
-                                  ).unwrap();
+        let vec = CsVec::new(8, vec![0, 2, 4, 6], vec![1., 2., 3., 4.]);
         let res = vec.map(|&x| x * 2.);
-        let expected = CsVec::new_owned(8,
-                                        vec![0, 2, 4, 6],
-                                        vec![2., 4., 6., 8.]
-                                       ).unwrap();
+        let expected = CsVec::new(8, vec![0, 2, 4, 6], vec![2., 4., 6., 8.]);
         assert_eq!(res, expected);
     }
 }

--- a/src/test_data.rs
+++ b/src/test_data.rs
@@ -1,42 +1,41 @@
 //! Some matrices used in tests
 
 use sparse::{CsMat, CsMatOwned};
-use sparse::CompressedStorage::{CSR, CSC};
 use ndarray::{arr2, OwnedArray, Ix};
 
 pub fn mat1() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 4, 5, 6, 7];
     let indices = vec![2, 3, 3, 4, 2, 1, 3];
     let data = vec![3., 4., 2., 5., 5., 8., 7.];
-    CsMat::new_owned(CSR, 5, 5, indptr, indices, data).unwrap()
+    CsMat::new(5, 5, indptr, indices, data)
 }
 
 pub fn mat1_csc() -> CsMatOwned<f64> {
     let indptr = vec![0, 0, 1, 3, 6, 7];
     let indices = vec![3, 0, 2, 0, 1, 4, 1];
     let data = vec![8.,  3.,  5.,  4.,  2.,  7.,  5.];
-    CsMat::new_owned(CSC, 5, 5, indptr, indices, data).unwrap()
+    CsMat::new_csc(5, 5, indptr, indices, data)
 }
 
 pub fn mat2() -> CsMatOwned<f64> {
     let indptr = vec![0,  4,  6,  6,  8, 10];
     let indices = vec![0, 1, 2, 4, 0, 3, 2, 3, 1, 2];
     let data = vec![6.,  7.,  3.,  3.,  8., 9.,  2.,  4.,  4.,  4.];
-    CsMat::new_owned(CSR, 5, 5, indptr, indices, data).unwrap()
+    CsMat::new(5, 5, indptr, indices, data)
 }
 
 pub fn mat3() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 4, 5, 6, 7];
     let indices = vec![2, 3, 2, 3, 2, 1, 3];
     let data = vec![3., 4., 2., 5., 5., 8., 7.];
-    CsMat::new_owned(CSR, 5, 4, indptr, indices, data).unwrap()
+    CsMat::new(5, 4, indptr, indices, data)
 }
 
 pub fn mat4() -> CsMatOwned<f64> {
     let indptr = vec![0,  4,  6,  6,  8, 10];
     let indices = vec![0, 1, 2, 4, 0, 3, 2, 3, 1, 2];
     let data = vec![6.,  7.,  3.,  3.,  8., 9.,  2.,  4.,  4.,  4.];
-    CsMat::new_owned(CSC, 5, 5, indptr, indices, data).unwrap()
+    CsMat::new_csc(5, 5, indptr, indices, data)
 }
 
 pub fn mat5() -> CsMatOwned<f64> {
@@ -45,7 +44,7 @@ pub fn mat5() -> CsMatOwned<f64> {
                        10, 11, 14, 4, 12];
     let data = vec![4.8, 2. , 3.7, 5.9, 6. , 1.6, 0.3, 9.2, 9.9, 4.8, 6.1,
                     4.4, 6. , 0.1, 7.2, 1. , 1.4, 6.4, 2.8, 3.4, 5.5, 3.5];
-    CsMat::new_owned(CSR, 5, 15, indptr, indices, data).unwrap()
+    CsMat::new(5, 15, indptr, indices, data)
 }
 
 /// Returns the scalar product of mat1 and mat2
@@ -53,7 +52,7 @@ pub fn mat1_times_2() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 4, 5, 6, 7];
     let indices = vec![2, 3, 3, 4, 2, 1, 3];
     let data = vec![6., 8., 4., 10., 10., 16., 14.];
-    CsMat::new_owned(CSR, 5, 5, indptr, indices, data).unwrap()
+    CsMat::new(5, 5, indptr, indices, data)
 }
 
 // Matrix product of mat1 with itself
@@ -61,14 +60,14 @@ pub fn mat1_self_matprod() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 4, 5, 7, 8];
     let indices = vec![1, 2, 1, 3, 2, 3, 4, 1];
     let data = vec![32., 15., 16., 35., 25., 16., 40., 56.];
-    CsMat::new_owned(CSR, 5, 5, indptr, indices, data).unwrap()
+    CsMat::new(5, 5, indptr, indices, data)
 }
 
 pub fn mat1_matprod_mat2() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 5, 5, 7, 9];
     let indices = vec![2, 3, 1, 2, 3, 0, 3, 2, 3];
     let data = vec![8., 16., 20., 24.,  8., 64., 72., 14., 28.];
-    CsMat::new_owned(CSR, 5, 5, indptr, indices, data).unwrap()
+    CsMat::new(5, 5, indptr, indices, data)
 }
 
 pub fn mat1_csc_matprod_mat4() -> CsMatOwned<f64> {
@@ -76,7 +75,7 @@ pub fn mat1_csc_matprod_mat4() -> CsMatOwned<f64> {
     let indices = vec![0, 1, 2, 3, 0, 1, 4, 0, 1, 2, 4, 0, 2, 3];
     let data = vec![9., 15., 15., 56., 36., 18., 63., 22.,
                     8., 10., 28., 12., 20., 32.];
-    CsMat::new_owned(CSC, 5, 5, indptr, indices, data).unwrap()
+    CsMat::new_csc(5, 5, indptr, indices, data)
 }
 
 pub fn mat_dense1() -> OwnedArray<f64, (Ix, Ix)> {

--- a/src/test_data.rs
+++ b/src/test_data.rs
@@ -7,35 +7,35 @@ pub fn mat1() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 4, 5, 6, 7];
     let indices = vec![2, 3, 3, 4, 2, 1, 3];
     let data = vec![3., 4., 2., 5., 5., 8., 7.];
-    CsMat::new(5, 5, indptr, indices, data)
+    CsMat::new((5, 5), indptr, indices, data)
 }
 
 pub fn mat1_csc() -> CsMatOwned<f64> {
     let indptr = vec![0, 0, 1, 3, 6, 7];
     let indices = vec![3, 0, 2, 0, 1, 4, 1];
     let data = vec![8.,  3.,  5.,  4.,  2.,  7.,  5.];
-    CsMat::new_csc(5, 5, indptr, indices, data)
+    CsMat::new_csc((5, 5), indptr, indices, data)
 }
 
 pub fn mat2() -> CsMatOwned<f64> {
     let indptr = vec![0,  4,  6,  6,  8, 10];
     let indices = vec![0, 1, 2, 4, 0, 3, 2, 3, 1, 2];
     let data = vec![6.,  7.,  3.,  3.,  8., 9.,  2.,  4.,  4.,  4.];
-    CsMat::new(5, 5, indptr, indices, data)
+    CsMat::new((5, 5), indptr, indices, data)
 }
 
 pub fn mat3() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 4, 5, 6, 7];
     let indices = vec![2, 3, 2, 3, 2, 1, 3];
     let data = vec![3., 4., 2., 5., 5., 8., 7.];
-    CsMat::new(5, 4, indptr, indices, data)
+    CsMat::new((5, 4), indptr, indices, data)
 }
 
 pub fn mat4() -> CsMatOwned<f64> {
     let indptr = vec![0,  4,  6,  6,  8, 10];
     let indices = vec![0, 1, 2, 4, 0, 3, 2, 3, 1, 2];
     let data = vec![6.,  7.,  3.,  3.,  8., 9.,  2.,  4.,  4.,  4.];
-    CsMat::new_csc(5, 5, indptr, indices, data)
+    CsMat::new_csc((5, 5), indptr, indices, data)
 }
 
 pub fn mat5() -> CsMatOwned<f64> {
@@ -44,7 +44,7 @@ pub fn mat5() -> CsMatOwned<f64> {
                        10, 11, 14, 4, 12];
     let data = vec![4.8, 2. , 3.7, 5.9, 6. , 1.6, 0.3, 9.2, 9.9, 4.8, 6.1,
                     4.4, 6. , 0.1, 7.2, 1. , 1.4, 6.4, 2.8, 3.4, 5.5, 3.5];
-    CsMat::new(5, 15, indptr, indices, data)
+    CsMat::new((5, 15), indptr, indices, data)
 }
 
 /// Returns the scalar product of mat1 and mat2
@@ -52,7 +52,7 @@ pub fn mat1_times_2() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 4, 5, 6, 7];
     let indices = vec![2, 3, 3, 4, 2, 1, 3];
     let data = vec![6., 8., 4., 10., 10., 16., 14.];
-    CsMat::new(5, 5, indptr, indices, data)
+    CsMat::new((5, 5), indptr, indices, data)
 }
 
 // Matrix product of mat1 with itself
@@ -60,14 +60,14 @@ pub fn mat1_self_matprod() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 4, 5, 7, 8];
     let indices = vec![1, 2, 1, 3, 2, 3, 4, 1];
     let data = vec![32., 15., 16., 35., 25., 16., 40., 56.];
-    CsMat::new(5, 5, indptr, indices, data)
+    CsMat::new((5, 5), indptr, indices, data)
 }
 
 pub fn mat1_matprod_mat2() -> CsMatOwned<f64> {
     let indptr = vec![0, 2, 5, 5, 7, 9];
     let indices = vec![2, 3, 1, 2, 3, 0, 3, 2, 3];
     let data = vec![8., 16., 20., 24.,  8., 64., 72., 14., 28.];
-    CsMat::new(5, 5, indptr, indices, data)
+    CsMat::new((5, 5), indptr, indices, data)
 }
 
 pub fn mat1_csc_matprod_mat4() -> CsMatOwned<f64> {
@@ -75,7 +75,7 @@ pub fn mat1_csc_matprod_mat4() -> CsMatOwned<f64> {
     let indices = vec![0, 1, 2, 3, 0, 1, 4, 0, 1, 2, 4, 0, 2, 3];
     let data = vec![9., 15., 15., 56., 36., 18., 63., 22.,
                     8., 10., 28., 12., 20., 32.];
-    CsMat::new_csc(5, 5, indptr, indices, data)
+    CsMat::new_csc((5, 5), indptr, indices, data)
 }
 
 pub fn mat_dense1() -> OwnedArray<f64, (Ix, Ix)> {


### PR DESCRIPTION
Refactor `CsMat` and `CsVec` constructors to allow more ergonomic interaction.

Constructors yielding owned matrices no longer require a storage argument, instead different functions are provided for the csr/csc cases, with csr being the default. Owning constructors are now more tolerant to structure errors (they will sort indices if necessary) but will panick on unrecoverable structure errors (eg out of bounds indices).

Shape arguments are now passed using a tuple.

Fixes #81.