### PR TITLE
Error policy

### DIFF
--- a/Guidelines.rst
+++ b/Guidelines.rst
@@ -1,0 +1,25 @@
+==========
+Guidelines
+==========
+
+This document describes development guidelines for this library.
+
+Error policy
+============
+
+As encouraged by rust, contract violations should be handled by panicking,
+whereas softer errors such as I/O errors should be dealt with using the
+``Result`` type. Here we describe, in the particular context of sparse linear
+algebra, what we consider to be contract violations. Any error not mentionned
+here should be dealt with using the ``Result`` type.
+
+Contract violation
+------------------
+
+- *Dimension mismatch* in linear algebra operations
+- *Storage assumption violation* in functions that require a specific storage
+  type.
+- *Out of bounds indices* when constructing a sparse matrix. Generally speaking
+  all indices should be in bounds for the prescriber shape.
+- *Length mismatch in constructors*, such as an ``indptr`` length not
+  corresponding to the matrix' dimension.

--- a/Guidelines.rst
+++ b/Guidelines.rst
@@ -22,5 +22,6 @@ Contract violation
 - *Out of bounds indices* when constructing a sparse matrix. Generally speaking
   all indices should be in bounds for the prescriber shape.
 - *Length mismatch in constructors*, such as an ``indptr`` length not
-  corresponding to the matrix' dimension.
+  corresponding to the matrix' dimension, different lengths for ``indices`` and
+  ``data``, etc.
 - *Wrong workspace length*

--- a/Guidelines.rst
+++ b/Guidelines.rst
@@ -23,3 +23,4 @@ Contract violation
   all indices should be in bounds for the prescriber shape.
 - *Length mismatch in constructors*, such as an ``indptr`` length not
   corresponding to the matrix' dimension.
+- *Wrong workspace length*

--- a/README.rst
+++ b/README.rst
@@ -87,10 +87,13 @@ Documentation
 Changelog
 ---------
 
-- O.4.0-alpha.4 version:
+- next version:
+    - panic for contract violations, use errors only for recoverable problems
+      **breaking change**
+- O.4.0-alpha.4 version, most changes are **breaking changes**:
     - move cholesky factorization into its own crate
     - add ``to_dense()`` method for sparse matrices
-    - rename ``borrowed()`` into ``view()`` **breaking change**
+    - rename ``borrowed()`` into ``view()``
     - ``outer_iterator()`` no longer returns the index of the dimension we're
       iterating. The old behavior can be obtained by chaining a call
       to ``enumerate()``.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,9 +5,7 @@ use std::fmt;
 
 #[derive(PartialEq, Debug)]
 pub enum SprsError {
-    IncompatibleDimensions,
     BadWorkspaceDimensions,
-    IncompatibleStorages,
     BadStorageType,
     EmptyStackingList,
     NotImplemented,
@@ -31,10 +29,8 @@ use self::SprsError::*;
 impl SprsError {
     fn descr(&self) -> &str {
         match *self {
-            IncompatibleDimensions => "matrices dimensions do not agree",
             BadWorkspaceDimensions =>
                 "workspace dimension does not match requirements",
-            IncompatibleStorages => "incompatible storages",
             BadStorageType => "wrong storage type",
             EmptyStackingList => "stacking list is empty",
             NotImplemented => "this method is not yet implemented",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,16 +6,8 @@ use std::fmt;
 #[derive(PartialEq, Debug)]
 pub enum SprsError {
     NonSortedIndices,
-    OutOfBoundsIndex,
-    BadIndptrLength,
-    DataIndicesMismatch,
-    BadNnzCount,
-    OutOfBoundsIndptr,
-    TooLargeIndptr,
     UnsortedIndptr,
-    EmptyBlock,
     SingularMatrix,
-    NonSquareMatrix,
 }
 
 use self::SprsError::*;
@@ -24,16 +16,8 @@ impl SprsError {
     fn descr(&self) -> &str {
         match *self {
             NonSortedIndices => "a vector's indices are not sorted",
-            OutOfBoundsIndex => "an element in indices is out of bounds",
-            BadIndptrLength => "inpdtr's length doesn't agree with dimensions",
-            DataIndicesMismatch => "data and indices lengths differ",
-            BadNnzCount => "the nnz count and indptr do not agree",
-            OutOfBoundsIndptr => "some indptr values are out of bounds",
-            TooLargeIndptr => "indptr value > usize::MAX / 2",
             UnsortedIndptr => "indptr is not sorted",
-            EmptyBlock => "tried to create an empty block",
             SingularMatrix => "matrix is singular",
-            NonSquareMatrix => "matrix should be square",
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,12 +5,6 @@ use std::fmt;
 
 #[derive(PartialEq, Debug)]
 pub enum SprsError {
-    BadWorkspaceDimensions,
-    BadStorageType,
-    EmptyStackingList,
-    NotImplemented,
-    EmptyBmatRow,
-    EmptyBmatCol,
     NonSortedIndices,
     OutOfBoundsIndex,
     BadIndptrLength,
@@ -29,13 +23,6 @@ use self::SprsError::*;
 impl SprsError {
     fn descr(&self) -> &str {
         match *self {
-            BadWorkspaceDimensions =>
-                "workspace dimension does not match requirements",
-            BadStorageType => "wrong storage type",
-            EmptyStackingList => "stacking list is empty",
-            NotImplemented => "this method is not yet implemented",
-            EmptyBmatRow => "empty row in bmat argument",
-            EmptyBmatCol => "empty column in bmat argument",
             NonSortedIndices => "a vector's indices are not sorted",
             OutOfBoundsIndex => "an element in indices is out of bounds",
             BadIndptrLength => "inpdtr's length doesn't agree with dimensions",

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -6,7 +6,6 @@ use num::traits::Num;
 use sparse::vec::NnzEither::{Left, Right, Both};
 use sparse::vec::{CsVec, CsVecView, CsVecOwned, SparseIterTools};
 use sparse::compressed::SpMatView;
-use errors::SprsError;
 use ndarray::{self, OwnedArray, ArrayBase, ArrayView, ArrayViewMut, Axis};
 
 use ::Ix2;
@@ -14,21 +13,21 @@ use ::SpRes;
 
 /// Sparse matrix addition, with matrices sharing the same storage type
 pub fn add_mat_same_storage<N, Mat1, Mat2>(
-    lhs: &Mat1, rhs: &Mat2) -> SpRes<CsMatOwned<N>>
+    lhs: &Mat1, rhs: &Mat2) -> CsMatOwned<N>
 where N: Num + Copy, Mat1: SpMatView<N>, Mat2: SpMatView<N> {
     csmat_binop(lhs.view(), rhs.view(), |&x, &y| x + y)
 }
 
 /// Sparse matrix subtraction, with same storage type
 pub fn sub_mat_same_storage<N, Mat1, Mat2>(
-    lhs: &Mat1, rhs: &Mat2) -> SpRes<CsMatOwned<N>>
+    lhs: &Mat1, rhs: &Mat2) -> CsMatOwned<N>
 where N: Num + Copy, Mat1: SpMatView<N>, Mat2: SpMatView<N> {
     csmat_binop(lhs.view(), rhs.view(), |&x, &y| x - y)
 }
 
 /// Sparse matrix scalar multiplication, with same storage type
 pub fn mul_mat_same_storage<N, Mat1, Mat2>(
-    lhs: &Mat1, rhs: &Mat2) -> SpRes<CsMatOwned<N>>
+    lhs: &Mat1, rhs: &Mat2) -> CsMatOwned<N>
 where N: Num + Copy, Mat1: SpMatView<N>, Mat2: SpMatView<N> {
     csmat_binop(lhs.view(), rhs.view(), |&x, &y| x * y)
 }
@@ -55,7 +54,7 @@ where N: Num + Copy, Mat: SpMatView<N> {
 pub fn csmat_binop<N, F>(lhs: CsMatView<N>,
                          rhs: CsMatView<N>,
                          binop: F
-                        ) -> SpRes<CsMatOwned<N>>
+                        ) -> CsMatOwned<N>
 where N: Num,
       F: Fn(&N, &N) -> N
 {
@@ -63,10 +62,10 @@ where N: Num,
     let ncols = lhs.cols();
     let storage_type = lhs.storage();
     if nrows != rhs.rows() || ncols != rhs.cols() {
-        return Err(SprsError::IncompatibleDimensions);
+        panic!("Dimension mismatch");
     }
     if storage_type != rhs.storage() {
-        return Err(SprsError::IncompatibleStorages);
+        panic!("Storage mismatch");
     }
 
     let max_nnz = lhs.nnz() + rhs.nnz();
@@ -87,14 +86,14 @@ where N: Num,
                                            &mut out_data[..]);
     out_indices.truncate(nnz);
     out_data.truncate(nnz);
-    Ok(CsMat {
+    CsMat {
         storage: storage_type,
         nrows: nrows,
         ncols: ncols,
         indptr: out_indptr,
         indices: out_indices,
         data: out_data
-    })
+    }
 }
 
 
@@ -237,7 +236,7 @@ where N: Num,
       F: Fn(&N, &N) -> N
 {
     if lhs.dim() != rhs.dim() {
-        return Err(SprsError::IncompatibleDimensions);
+        panic!("Dimension mismatch");
     }
     let mut res = CsVec::empty(lhs.dim());
     let max_nnz = lhs.nnz() + rhs.nnz();

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -290,7 +290,7 @@ mod test {
         let a = mat1();
         let b = mat2();
 
-        let c = super::add_mat_same_storage(&a, &b).unwrap();
+        let c = super::add_mat_same_storage(&a, &b);
         let c_true = mat1_plus_mat2();
         assert_eq!(c, c_true);
 
@@ -319,7 +319,7 @@ mod test {
         let a = mat1();
         let b = mat2();
 
-        let c = super::sub_mat_same_storage(&a, &b).unwrap();
+        let c = super::sub_mat_same_storage(&a, &b);
         let c_true = mat1_minus_mat2();
         assert_eq!(c, c_true);
 
@@ -332,7 +332,7 @@ mod test {
         let a = mat1();
         let b = mat2();
 
-        let c = super::mul_mat_same_storage(&a, &b).unwrap();
+        let c = super::mul_mat_same_storage(&a, &b);
         let c_true = mat1_times_mat2();
         assert_eq!(c.indptr(), c_true.indptr());
         assert_eq!(c.indices(), c_true.indices());

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -202,18 +202,29 @@ mod test {
     }
 
     #[test]
-    fn same_storage_fast_stack_failures() {
+    #[should_panic]
+    fn same_storage_fast_stack_fail_shape() {
         let res: Result<CsMatOwned<f64>, _> =
             super::same_storage_fast_stack(&[]);
         assert_eq!(res, Err(EmptyStackingList));
         let a = mat1();
         let c = mat3();
-        let d = mat4();
         let _: Result<CsMatOwned<f64>, _> = super::same_storage_fast_stack(&[]);
         let res = super::same_storage_fast_stack(&[a.view(), c.view()]);
-        assert_eq!(res, Err(IncompatibleDimensions));
+        res.unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn same_storage_fast_stack_fail_storage() {
+        let res: Result<CsMatOwned<f64>, _> =
+            super::same_storage_fast_stack(&[]);
+        assert_eq!(res, Err(EmptyStackingList));
+        let a = mat1();
+        let d = mat4();
+        let _: Result<CsMatOwned<f64>, _> = super::same_storage_fast_stack(&[]);
         let res = super::same_storage_fast_stack(&[a.view(), d.view()]);
-        assert_eq!(res, Err(IncompatibleStorages));
+        res.unwrap();
     }
 
     #[test]
@@ -253,15 +264,20 @@ mod test {
     }
 
     #[test]
+    #[should_panic]
+    fn bmat_fail_shapes() {
+        let res: Result<CsMatOwned<f64>,_> = super::bmat(
+            &vec![vec![None, None], vec![None]]);
+        res.unwrap();
+    }
+
+    #[test]
     fn bmat_failures() {
         let res: Result<CsMatOwned<f64>, _> =
             super::bmat(&[[]]);
         assert_eq!(res, Err(EmptyStackingList));
         let a = mat1();
         let c = mat3();
-        let res: Result<CsMatOwned<f64>,_> = super::bmat(
-            &vec![vec![None, None], vec![None]]);
-        assert_eq!(res, Err(IncompatibleDimensions));
         let res: Result<CsMatOwned<f64>, _> =
             super::bmat(&[[None, None],
                           [Some(a.view()), Some(c.view())]]);

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -20,11 +20,11 @@ where N: 'a + Clone,
     }
     let inner_dim = mats[0].inner_dims();
     if ! mats.iter().all(|x| x.inner_dims() == inner_dim) {
-        return Err(SprsError::IncompatibleDimensions);
+        panic!("Dimension mismatch");
     }
     let storage_type = mats[0].storage();
     if ! mats.iter().all(|x| x.storage() == storage_type) {
-        return Err(SprsError::IncompatibleStorages);
+        panic!("Storage mismatch");
     }
 
     let outer_dim = mats.iter().map(|x| x.outer_dims()).fold(0, |x, y| x + y);
@@ -99,7 +99,7 @@ where N: 'a + Clone + Default,
 
     // check input has matrix shape
     if ! mats.iter().all(|x| x.as_ref().len() == super_cols) {
-        return Err(SprsError::IncompatibleDimensions);
+        panic!("Dimension mismatch");
     }
 
     if mats.iter().any(|x| x.as_ref().iter().all(|y| y.is_none())) {

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1254,7 +1254,7 @@ where N: 'a + Copy + Num + Default,
                                                        rhs,
                                                        N::one(),
                                                        N::one()
-                                                      ).unwrap()
+                                                      )
                 }
                 (CSR, false) => {
                     let lhs = self.to_other_storage();
@@ -1262,7 +1262,7 @@ where N: 'a + Copy + Num + Default,
                                                        rhs,
                                                        N::one(),
                                                        N::one()
-                                                      ).unwrap()
+                                                      )
                 }
                 (CSC, true) => {
                     let lhs = self.to_other_storage();
@@ -1270,14 +1270,14 @@ where N: 'a + Copy + Num + Default,
                                                        rhs,
                                                        N::one(),
                                                        N::one()
-                                                      ).unwrap()
+                                                      )
                 }
                 (CSC, false) => {
                     binop::add_dense_mat_same_ordering(self,
                                                        rhs,
                                                        N::one(),
                                                        N::one()
-                                                      ).unwrap()
+                                                      )
                 }
         }
     }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -894,7 +894,7 @@ where IptrStorage: Deref<Target=[usize]>,
     where N: Clone + Zero
     {
         let mut res = OwnedArray::zeros((self.rows(), self.cols()));
-        assign_to_dense(res.view_mut(), self.view()).unwrap();
+        assign_to_dense(res.view_mut(), self.view());
         res
     }
 }
@@ -1151,9 +1151,9 @@ where N: 'a + Copy + Num + Default,
     fn add(self, rhs: &'b CsMat<N, IpS2, IS2, DS2>) -> CsMatOwned<N> {
         if self.storage() != rhs.view().storage() {
             return binop::add_mat_same_storage(
-                self, &rhs.view().to_other_storage()).unwrap()
+                self, &rhs.view().to_other_storage())
         }
-        binop::add_mat_same_storage(self, rhs).unwrap()
+        binop::add_mat_same_storage(self, rhs)
     }
 }
 
@@ -1169,9 +1169,9 @@ where N: 'a + Copy + Num + Default,
     fn sub(self, rhs: &'b Mat) -> CsMatOwned<N> {
         if self.storage() != rhs.view().storage() {
             return binop::sub_mat_same_storage(
-                self, &rhs.view().to_other_storage()).unwrap()
+                self, &rhs.view().to_other_storage())
         }
-        binop::sub_mat_same_storage(self, rhs).unwrap()
+        binop::sub_mat_same_storage(self, rhs)
     }
 }
 
@@ -1216,22 +1216,22 @@ where N: 'a + Copy + Num + Default,
         match (self.storage(), rhs.storage()) {
             (CSR, CSR) => {
                 let mut workspace = prod::workspace_csr(self, rhs);
-                prod::csr_mul_csr(self, rhs, &mut workspace).unwrap()
+                prod::csr_mul_csr(self, rhs, &mut workspace)
             }
             (CSR, CSC) => {
                 let mut workspace = prod::workspace_csr(self, rhs);
                 prod::csr_mul_csr(self,
                                   &rhs.to_other_storage(),
-                                  &mut workspace).unwrap()
+                                  &mut workspace)
             }
             (CSC, CSR) => {
                 let mut workspace = prod::workspace_csc(self, rhs);
                 prod::csc_mul_csc(self, &rhs.to_other_storage(),
-                                  &mut workspace).unwrap()
+                                  &mut workspace)
             }
             (CSC, CSC) => {
                 let mut workspace = prod::workspace_csc(self, rhs);
-                prod::csc_mul_csc(self, rhs, &mut workspace).unwrap()
+                prod::csc_mul_csc(self, rhs, &mut workspace)
             }
         }
     }
@@ -1302,7 +1302,7 @@ where N: 'a + Copy + Num + Default,
                 prod::csr_mulacc_dense_rowmaj(self.view(),
                                               rhs.view(),
                                               res.view_mut()
-                                             ).unwrap();
+                                             );
                 res
             }
             (CSR, false) => {
@@ -1310,7 +1310,7 @@ where N: 'a + Copy + Num + Default,
                 prod::csr_mulacc_dense_colmaj(self.view(),
                                               rhs.view(),
                                               res.view_mut()
-                                             ).unwrap();
+                                             );
                 res
             }
             (CSC, true) => {
@@ -1318,7 +1318,7 @@ where N: 'a + Copy + Num + Default,
                 prod::csc_mulacc_dense_rowmaj(self.view(),
                                               rhs.view(),
                                               res.view_mut()
-                                             ).unwrap();
+                                             );
                 res
             }
             (CSC, false) => {
@@ -1326,7 +1326,7 @@ where N: 'a + Copy + Num + Default,
                 prod::csc_mulacc_dense_colmaj(self.view(),
                                               rhs.view(),
                                               res.view_mut()
-                                             ).unwrap();
+                                             );
                 res
             }
         }

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -252,12 +252,12 @@ pub fn lsolve_csc_sparse_rhs<N>(lower_tri_mat: CsMatView<N>,
                                 rhs: vec::CsVecView<N>,
                                 dstack: &mut DStack<StackVal<usize>>,
                                 x_workspace: &mut [N],
-                                visited: &mut [bool])
-                                -> Result<(), SprsError>
+                                visited: &mut [bool]
+                               ) -> Result<(), SprsError>
 where N: Copy + Num
 {
     if !lower_tri_mat.is_csc() {
-        return Err(SprsError::BadStorageType);
+        panic!("Storage mismatch");
     }
     let n = lower_tri_mat.rows();
     assert!(dstack.capacity() >= 2 * n, "dstack cap should be 2*n");
@@ -312,7 +312,6 @@ where N: Copy + Num
         let col = lower_tri_mat.outer_view(ind).expect("ind not in bounds");
         try!(lspsolve_csc_process_col(col, ind, x_workspace));
     }
-
     Ok(())
 }
 

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -7,20 +7,17 @@ use sparse::vec::{self, VecDim};
 use errors::SprsError;
 use stack::{self, StackVal, DStack};
 
-fn check_solver_dimensions<N, V: ?Sized>(lower_tri_mat: &CsMatView<N>,
-                                         rhs: &V)
-                                         -> Result<(), SprsError>
+fn check_solver_dimensions<N, V: ?Sized>(lower_tri_mat: &CsMatView<N>, rhs: &V)
 where N: Copy + Num,
       V: vec::VecDim<N>
 {
     let (cols, rows) = (lower_tri_mat.cols(), lower_tri_mat.rows());
     if cols != rows {
-        return Err(SprsError::NonSquareMatrix);
+        panic!("Non square matrix passed to solver");
     }
     if cols != rhs.dim() {
-        return Err(SprsError::IncompatibleDimensions);
+        panic!("Dimension mismatch");
     }
-    Ok(())
 }
 
 /// Solve a sparse lower triangular matrix system, with a csr matrix
@@ -36,9 +33,9 @@ pub fn lsolve_csr_dense_rhs<N, V: ?Sized>(lower_tri_mat: CsMatView<N>,
 where N: Copy + Num,
       V: IndexMut<usize, Output = N> + vec::VecDim<N>
 {
-    try!(check_solver_dimensions(&lower_tri_mat, rhs));
+    check_solver_dimensions(&lower_tri_mat, rhs);
     if !lower_tri_mat.is_csr() {
-        return Err(SprsError::BadStorageType);
+        panic!("Storage mismatch");
     }
 
     // we base our algorithm on the following decomposition:
@@ -86,9 +83,9 @@ pub fn lsolve_csc_dense_rhs<N, V: ?Sized>(lower_tri_mat: CsMatView<N>,
 where N: Copy + Num,
       V: IndexMut<usize, Output = N> + vec::VecDim<N>
 {
-    try!(check_solver_dimensions(&lower_tri_mat, rhs));
+    check_solver_dimensions(&lower_tri_mat, rhs);
     if !lower_tri_mat.is_csc() {
-        return Err(SprsError::BadStorageType);
+        panic!("Storage mismatch");
     }
 
     // we base our algorithm on the following decomposition:
@@ -148,9 +145,9 @@ pub fn usolve_csc_dense_rhs<N, V: ?Sized>(upper_tri_mat: CsMatView<N>,
 where N: Copy + Num,
       V: IndexMut<usize, Output = N> + vec::VecDim<N>
 {
-    try!(check_solver_dimensions(&upper_tri_mat, rhs));
+    check_solver_dimensions(&upper_tri_mat, rhs);
     if !upper_tri_mat.is_csc() {
-        return Err(SprsError::BadStorageType);
+        panic!("Storage mismatch");
     }
 
     // we base our algorithm on the following decomposition:
@@ -197,9 +194,9 @@ pub fn usolve_csr_dense_rhs<N, V: ?Sized>(upper_tri_mat: CsMatView<N>,
 where N: Copy + Num,
       V: IndexMut<usize, Output = N> + vec::VecDim<N>
 {
-    try!(check_solver_dimensions(&upper_tri_mat, rhs));
+    check_solver_dimensions(&upper_tri_mat, rhs);
     if !upper_tri_mat.is_csr() {
-        return Err(SprsError::BadStorageType);
+        panic!("Storage mismatch");
     }
     // we base our algorithm on the following decomposition:
     // | u_0_0    u_0_1^T | | x_0 |    | b_0 |

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -368,7 +368,7 @@ mod test {
         let mat = CsMat::new_view(CSC, (5, 5), indptr, indices, data).unwrap();
         let vector = vec![0.1, 0.2, -0.1, 0.3, 0.9];
         let mut res_vec = vec![0., 0., 0., 0., 0.];
-        mul_acc_mat_vec_csc(mat, &vector, &mut res_vec).unwrap();
+        mul_acc_mat_vec_csc(mat, &vector, &mut res_vec);
 
         let expected_output =
             vec![ 0., 0.26439869, -0.01803924, 0.75120319, 0.11616419];
@@ -390,7 +390,7 @@ mod test {
         let mat = CsMat::new_view(CSR, (5, 5), indptr, indices, data).unwrap();
         let vector = vec![0.1, 0.2, -0.1, 0.3, 0.9];
         let mut res_vec = vec![0., 0., 0., 0., 0.];
-        mul_acc_mat_vec_csr(mat, &vector, &mut res_vec).unwrap();
+        mul_acc_mat_vec_csr(mat, &vector, &mut res_vec);
 
         let expected_output =
             vec![0.22527496, 0., 0.17814121, 0.35319787, 0.51482166];
@@ -405,7 +405,7 @@ mod test {
     fn mul_csr_csr_identity() {
         let eye: CsMatOwned<i32> = CsMat::eye(10);
         let mut workspace = [0; 10];
-        let res = csr_mul_csr(&eye, &eye, &mut workspace).unwrap();
+        let res = csr_mul_csr(&eye, &eye, &mut workspace);
         assert_eq!(eye, res);
 
         let res = &eye * &eye;
@@ -492,7 +492,7 @@ mod test {
         super::csr_mulacc_dense_rowmaj(e.view(),
                                        a.view(),
                                        res.view_mut()
-                                      ).unwrap();
+                                      );
         assert_eq!(res, a);
 
         let a = mat1();
@@ -501,7 +501,7 @@ mod test {
         super::csr_mulacc_dense_rowmaj(a.view(),
                                        b.view(),
                                        res.view_mut()
-                                      ).unwrap();
+                                      );
         let expected_output = arr2(&[[24., 31., 24., 17., 10.],
                                      [11., 18., 11.,  9.,  2.],
                                      [20., 25., 20., 15., 10.],
@@ -518,7 +518,7 @@ mod test {
         super::csr_mulacc_dense_rowmaj(a.view(),
                                        b.view(),
                                        res.view_mut()
-                                      ).unwrap();
+                                      );
         let expected_output = arr2(
             &[[130.04,  150.1,  87.19, 90.89,  99.48,  80.43,   99.3],
               [217.72, 161.61,  79.47, 121.5, 124.23, 146.91, 157.79],
@@ -537,7 +537,7 @@ mod test {
         let mut res = OwnedArray::zeros((5, 5));
         super::csc_mulacc_dense_rowmaj(a.view(),
                                        b.view(),
-                                       res.view_mut()).unwrap();
+                                       res.view_mut());
         let expected_output = arr2(&[[24., 31., 24., 17., 10.],
                                      [11., 18., 11.,  9.,  2.],
                                      [20., 25., 20., 15., 10.],
@@ -556,7 +556,7 @@ mod test {
         let mut res = OwnedArray::zeros_f((5, 5));
         super::csc_mulacc_dense_colmaj(a.view(),
                                        b.view(),
-                                       res.view_mut()).unwrap();
+                                       res.view_mut());
         let v = vec![24., 11., 20., 40., 21.,
                      31., 18., 25., 48., 28.,
                      24., 11., 20., 40., 21.,
@@ -580,7 +580,7 @@ mod test {
         super::csr_mulacc_dense_colmaj(a.view(),
                                        b.view(),
                                        res.view_mut()
-                                      ).unwrap();
+                                      );
         let v = vec![24., 11., 20., 40., 21.,
                     31., 18., 25., 48., 28.,
                     24., 11., 20., 40., 21.,

--- a/src/sparse/to_dense.rs
+++ b/src/sparse/to_dense.rs
@@ -1,24 +1,21 @@
 ///! Utilities for sparse-to-dense conversion
 
 use ndarray::{ArrayViewMut, Axis};
-use errors::SprsError;
-use ::{CsMatView, SpRes};
+use ::CsMatView;
 use ::Ix2;
 
 /// Assign a sparse matrix into a dense matrix
 ///
 /// The dense matrix will not be zeroed prior to assignment,
 /// so existing values not corresponding to non-zeroes will be preserved.
-pub fn assign_to_dense<N>(mut array: ArrayViewMut<N, Ix2>,
-                          spmat: CsMatView<N>
-                         ) -> SpRes<()>
+pub fn assign_to_dense<N>(mut array: ArrayViewMut<N, Ix2>, spmat: CsMatView<N>)
 where N: Clone
 {
     if spmat.cols() != array.shape()[0] {
-        return Err(SprsError::IncompatibleDimensions);
+        panic!("Dimension mismatch");
     }
     if spmat.rows() != array.shape()[0] {
-        return Err(SprsError::IncompatibleDimensions);
+        panic!("Dimension mismatch");
     }
     let outer_axis = if spmat.is_csr() { Axis(0) } else { Axis(1) };
 
@@ -28,8 +25,6 @@ where N: Clone
             drow[[ind]] = val.clone();
         }
     }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/sparse/to_dense.rs
+++ b/src/sparse/to_dense.rs
@@ -38,7 +38,7 @@ mod test {
         let speye: CsMatOwned<f64> = CsMatOwned::eye(3);
         let mut deye = OwnedArray::zeros((3, 3));
 
-        super::assign_to_dense(deye.view_mut(), speye.view()).unwrap();
+        super::assign_to_dense(deye.view_mut(), speye.view());
 
         let res = OwnedArray::eye(3);
         assert_eq!(deye, res);
@@ -46,7 +46,7 @@ mod test {
         let speye: CsMatOwned<f64> = CsMatOwned::eye_csc(3);
         let mut deye = OwnedArray::zeros((3, 3));
 
-        super::assign_to_dense(deye.view_mut(), speye.view()).unwrap();
+        super::assign_to_dense(deye.view_mut(), speye.view());
 
         assert_eq!(deye, res);
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -544,7 +544,7 @@ where IStorage: Deref<Target=[usize]>,
         }
 
         if self.indices.iter().max().unwrap_or(&0) >= &self.dim {
-            return Err(SprsError::OutOfBoundsIndex);
+            panic!("Out of bounds index");
         }
 
         Ok(())

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -745,7 +745,7 @@ where N: Copy + Num + Default,
 
     fn mul(self, rhs: &CsVec<N, IS2, DS2>) -> CsVecOwned<N> {
         if self.is_csr() {
-            prod::csr_mul_csvec(self.view(), rhs.view()).unwrap()
+            prod::csr_mul_csvec(self.view(), rhs.view())
         }
         else {
             (self * &rhs.col_view()).outer_view(0).unwrap().to_owned()


### PR DESCRIPTION
Remove error codes that corresponded to programming errors. Only error cases left are:

- unsorted indices, since it will be possible to use this error in the future to create a sparse matrix with unsorted indices, which is functional though less performant.
- singular matrices in linear algebra, since this leaves the caller the opportunity to add some regularization.

The errors removed should be plain bugs when they happen (eg dimension mismatch, out of bounds, ...).