### PR TITLE
Refactor API to expose shorter paths

### DIFF
--- a/sprs-ldl/src/lib.rs
+++ b/sprs-ldl/src/lib.rs
@@ -61,10 +61,14 @@ use std::ops::IndexMut;
 
 use num::traits::Num;
 
-use sprs::sparse::{csmat, CsMat, CsMatView};
-use sprs::sparse::symmetric::is_symmetric;
-use sprs::sparse::permutation::{Permutation, PermOwned};
-use sprs::sparse::linalg::{self, etree};
+use sprs::{
+    CsMat,
+    CsMatView,
+    is_symmetric,
+    Permutation,
+    PermOwned,
+};
+use sprs::linalg;
 use sprs::stack::DStack;
 
 pub enum SymmetryCheck {
@@ -269,7 +273,7 @@ impl<N> LdlNumeric<N> {
         let n = self.symbolic.problem_size();
         // CsMat invariants are guaranteed by the LDL algorithm
         unsafe {
-            CsMatView::new_view_raw(csmat::CSC,
+            CsMatView::new_view_raw(sprs::CSC,
                                     (n, n),
                                     self.symbolic.colptr.as_ptr(),
                                     self.l_indices.as_ptr(),
@@ -295,7 +299,7 @@ impl<N> LdlNumeric<N> {
 pub fn ldl_symbolic<N, PStorage>(mat: CsMatView<N>,
                                  perm: &Permutation<PStorage>,
                                  l_colptr: &mut [usize],
-                                 mut parents: etree::ParentsViewMut,
+                                 mut parents: linalg::etree::ParentsViewMut,
                                  l_nz: &mut [usize],
                                  flag_workspace: &mut [usize],
                                  check_symmetry: SymmetryCheck)
@@ -350,7 +354,7 @@ where N: Clone + Copy + PartialEq,
 /// pattern_workspace is a DStack of capacity n
 pub fn ldl_numeric<N, PStorage>(mat: CsMatView<N>,
                                 l_colptr: &[usize],
-                                parents: etree::ParentsView,
+                                parents: linalg::etree::ParentsView,
                                 perm: &Permutation<PStorage>,
                                 l_nz: &mut [usize],
                                 l_indices: &mut [usize],
@@ -447,9 +451,14 @@ where N: Clone + Copy + Num,
 
 #[cfg(test)]
 mod test {
-    use sprs::sparse::{csmat, CsMat, CsMatView, CsMatOwned};
-    use sprs::sparse::permutation::Permutation;
-    use sprs::sparse::linalg;
+    use sprs::{
+        self,
+        CsMat,
+        CsMatView,
+        CsMatOwned,
+        Permutation,
+        linalg,
+    };
     use super::SymmetryCheck;
     use sprs::stack::DStack;
 
@@ -585,7 +594,7 @@ mod test {
         let b = test_vec1();
         let mut x = b.clone();
         let n = b.len();
-        let l = CsMatView::new_view(csmat::CSC,
+        let l = CsMatView::new_view(sprs::CSC,
                                     (n, n),
                                     &expected_lp,
                                     &expected_li,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,10 @@ pub use sparse::construct::{
     csc_from_dense,
 };
 
+pub use sparse::to_dense::{
+    assign_to_dense,
+};
+
 
 pub type Ix2 = (Ix_, Ix_);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,16 +52,53 @@ assert_eq!(a, b.to_csc());
 extern crate num_traits;
 extern crate ndarray;
 
-pub mod sparse;
+mod sparse;
 pub mod errors;
 pub mod stack;
 
 pub use ndarray::Ix as Ix_;
 
-pub use sparse::{CsMat, CsMatOwned, CsMatView,
-                 CsVec, CsVecView, CsVecOwned};
-pub use sparse::CompressedStorage::{CSR, CSC};
-pub use sparse::construct::{vstack, hstack, bmat};
+pub use sparse::{
+    CsMat,
+    CsMatOwned,
+    CsMatView,
+    CsVec,
+    CsVecView,
+    CsVecOwned,
+};
+
+
+pub use sparse::symmetric::{
+    is_symmetric,
+};
+
+pub use sparse::permutation::{
+    Permutation,
+    PermView,
+    PermOwned,
+};
+
+pub use sparse::CompressedStorage::{
+    self,
+    CSR,
+    CSC,
+};
+
+pub use sparse::linalg;
+pub use sparse::prod;
+pub use sparse::binop;
+pub use sparse::vec;
+
+pub use sparse::triplet::TripletMat;
+
+pub use sparse::construct::{
+    vstack,
+    hstack,
+    bmat,
+    csr_from_dense,
+    csc_from_dense,
+};
+
 
 pub type Ix2 = (Ix_, Ix_);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,11 @@ pub use sparse::prod;
 pub use sparse::binop;
 pub use sparse::vec;
 
-pub use sparse::triplet::TripletMat;
+pub use sparse::triplet::{
+    TripletMat,
+    TripletMatView,
+    TripletMatViewMut,
+};
 
 pub use sparse::construct::{
     vstack,

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -73,7 +73,6 @@ where N: 'a + Clone + Default,
 ///
 /// # Examples
 /// ```
-/// use sprs::sparse::CompressedStorage::CSR;
 /// use sprs::CsMatOwned;
 /// let a = CsMatOwned::<f64>::eye(3);
 /// let b = CsMatOwned::<f64>::eye(4);

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -121,8 +121,8 @@ impl<N> TripletMat<N> {
     }
 
     /// Return a view of this matrix
-    pub fn borrowed(&self) -> TripletView<N> {
-        TripletView {
+    pub fn borrowed(&self) -> TripletMatView<N> {
+        TripletMatView {
             rows: self.rows,
             cols: self.cols,
             row_inds: &self.row_inds[..],
@@ -143,8 +143,8 @@ impl<N> TripletMat<N> {
     }
 
     /// Get a mutable view into this matrix.
-    pub fn borrowed_mut(&mut self) -> TripletViewMut<N> {
-        TripletViewMut {
+    pub fn borrowed_mut(&mut self) -> TripletMatViewMut<N> {
+        TripletMatViewMut {
             rows: self.rows,
             cols: self.cols,
             row_inds: &mut self.row_inds[..],
@@ -154,7 +154,7 @@ impl<N> TripletMat<N> {
     }
 
     /// Get a transposed view of this matrix
-    pub fn transpose_view(&self) -> TripletView<N> {
+    pub fn transpose_view(&self) -> TripletMatView<N> {
         self.borrowed().transpose_view()
     }
 
@@ -197,7 +197,7 @@ impl<N> TripletMat<N> {
 }
 
 /// Triplet matrix view
-pub struct TripletView<'a, N: 'a> {
+pub struct TripletMatView<'a, N: 'a> {
     rows: usize,
     cols: usize,
     row_inds: &'a [usize],
@@ -205,7 +205,7 @@ pub struct TripletView<'a, N: 'a> {
     data: &'a [N],
 }
 
-impl<'a, N> TripletView<'a, N> {
+impl<'a, N> TripletMatView<'a, N> {
     /// The number of rows of the matrix
     pub fn rows(&self) -> usize {
         self.rows
@@ -253,8 +253,8 @@ impl<'a, N> TripletView<'a, N> {
     }
 
     /// Get a transposed view of this matrix
-    pub fn transpose_view(&self) -> TripletView<'a, N> {
-        TripletView {
+    pub fn transpose_view(&self) -> TripletMatView<'a, N> {
+        TripletMatView {
             rows: self.cols,
             cols: self.rows,
             row_inds: self.col_inds,
@@ -364,7 +364,7 @@ impl<'a, N> TripletView<'a, N> {
 
 
 /// Triplet matrix mutable view
-pub struct TripletViewMut<'a, N: 'a> {
+pub struct TripletMatViewMut<'a, N: 'a> {
     rows: usize,
     cols: usize,
     row_inds: &'a mut [usize],
@@ -372,7 +372,7 @@ pub struct TripletViewMut<'a, N: 'a> {
     data: &'a mut [N],
 }
 
-impl<'a, N> TripletViewMut<'a, N> {
+impl<'a, N> TripletMatViewMut<'a, N> {
     /// The number of rows of the matrix
     pub fn rows(&self) -> usize {
         self.borrowed().rows()
@@ -409,8 +409,8 @@ impl<'a, N> TripletViewMut<'a, N> {
     }
 
     /// Return a view of this matrix
-    pub fn borrowed(&self) -> TripletView<N> {
-        TripletView {
+    pub fn borrowed(&self) -> TripletMatView<N> {
+        TripletMatView {
             rows: self.rows,
             cols: self.cols,
             row_inds: &self.row_inds[..],
@@ -420,7 +420,7 @@ impl<'a, N> TripletViewMut<'a, N> {
     }
 
     /// Get a transposed view of this matrix
-    pub fn transpose_view(&self) -> TripletView<N> {
+    pub fn transpose_view(&self) -> TripletMatView<N> {
         self.borrowed().transpose_view()
     }
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -130,8 +130,8 @@ pub trait SparseIterTools: Iterator {
     ///
     /// ```rust
     /// use sprs::CsVec;
-    /// use sprs::sparse::vec::NnzEither;
-    /// use sprs::sparse::vec::SparseIterTools;
+    /// use sprs::vec::NnzEither;
+    /// use sprs::vec::SparseIterTools;
     /// let v0 = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
     /// let v1 = CsVec::new(5, vec![1, 2, 3], vec![-1., -2., -3.]);
     /// let mut nnz_or_iter = v0.iter().nnz_or_zip(v1.iter());
@@ -160,7 +160,7 @@ pub trait SparseIterTools: Iterator {
     ///
     /// ```rust
     /// use sprs::CsVec;
-    /// use sprs::sparse::vec::SparseIterTools;
+    /// use sprs::vec::SparseIterTools;
     /// let v0 = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
     /// let v1 = CsVec::new(5, vec![1, 2, 3], vec![-1., -2., -3.]);
     /// let mut nnz_zip = v0.iter().nnz_zip(v1.iter());


### PR DESCRIPTION
Most functionality is now available either directly (eg `sprs::CsMat`) or with one module indirection (eg `sprs::stack::DStack`).

Fixes #71