### PR TITLE
Csmat insertion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,8 @@ Documentation is available at docs.rs_.
 Changelog
 ---------
 
+- next version:
+    - add ``insert()`` method to insert an element inside an owned csmat
 - 0.4.0:
     - panic for contract violations, use errors only for recoverable problems
       **breaking change**

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -528,6 +528,7 @@ impl<N> CsMat<N, Vec<usize>, Vec<usize>, Vec<N>> {
             let location = self.indices[start..stop].binary_search(&inner_ind);
             match location {
                 Ok(ind) => {
+                    let ind = start + ind;
                     self.data[ind] = val;
                     return;
                 }


### PR DESCRIPTION
Add the `fn insert(&mut self, row, col, val)` method to enable inserting a non-zero in a `CsMatOwned`.

While this is an inefficent operation in the general case, it is efficient to build a matrix if the elements are supplied in the appropriate order (ie row order for a CSR matrix, col order for a CSC matrix).

Fixes #96 #57