### PR TITLE
Get rid of unsafe usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,30 +135,5 @@ pub type Shape = (usize, usize); // FIXME: maybe we could use Ix2 here?
 
 pub type SpRes<T> = Result<T, errors::SprsError>;
 
-
-
-mod utils {
-
-    use sparse::{csmat, CsMatView};
-    use ::Shape;
-
-    /// Create a borrowed CsMat matrix from sliced data without
-    /// checking validity. Intended for internal use only.
-    pub fn csmat_borrowed_uchk<'a, N>(storage: csmat::CompressedStorage,
-                                      shape: Shape,
-                                      indptr : &'a [usize],
-                                      indices : &'a [usize],
-                                      data : &'a [N]
-                                     ) -> CsMatView<'a, N> {
-        // not actually memory unsafe here since data comes from slices
-        unsafe {
-            CsMatView::new_view_raw(storage, shape,
-                                    indptr.as_ptr(),
-                                    indices.as_ptr(),
-                                    data.as_ptr())
-        }
-    }
-}
-
 #[cfg(test)]
 mod test_data;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,23 @@ pub use sparse::CompressedStorage::{
 pub use sparse::linalg;
 pub use sparse::prod;
 pub use sparse::binop;
-pub use sparse::vec;
+
+pub mod vec {
+    pub use sparse::vec::{
+        CsVec,
+        CsVecOwned,
+        CsVecView,
+        CsVecViewMut,
+        NnzIndex,
+        VecDim,
+        VectorIterator,
+        VectorIteratorMut,
+        SparseIterTools,
+        IntoSparseVecIter,
+        NnzOrZip,
+        NnzEither,
+    };
+}
 
 pub use sparse::triplet::{
     TripletMat,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,14 @@ pub use sparse::prod;
 pub use sparse::binop;
 
 pub mod vec {
-    pub use sparse::vec::{
+    pub use sparse::{
         CsVec,
         CsVecOwned,
         CsVecView,
         CsVecViewMut,
+    };
+
+    pub use sparse::vec::{
         NnzIndex,
         VecDim,
         VectorIterator,

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -4,7 +4,7 @@ use sparse::csmat::CompressedStorage;
 use sparse::prelude::*;
 use num_traits::Num;
 use sparse::vec::NnzEither::{Left, Right, Both};
-use sparse::vec::{CsVec, CsVecView, CsVecOwned, SparseIterTools};
+use sparse::vec::SparseIterTools;
 use sparse::compressed::SpMatView;
 use ndarray::{
     self,
@@ -263,7 +263,7 @@ where N: Num,
 #[cfg(test)]
 mod test {
     use sparse::{CsMat, CsMatOwned};
-    use sparse::vec::CsVec;
+    use sparse::CsVec;
     use test_data::{mat1, mat2, mat1_times_2, mat_dense1};
     use ndarray::{arr2, Array};
 

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -2,7 +2,6 @@
 
 
 use sparse::prelude::*;
-use sparse::vec::{CsVec, CsVecView};
 use std::ops::{Deref};
 
 /// The SpMatView trait describes data that can be seen as a view

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -19,18 +19,13 @@ use ::{Ix2, Shape};
 
 use sparse::prelude::*;
 use sparse::permutation::PermView;
-use sparse::vec::{CsVec, CsVecView, CsVecViewMut, self};
+use sparse::vec;
 use sparse::compressed::SpMatView;
 use sparse::binop;
 use sparse::prod;
 use sparse::utils;
 use errors::SprsError;
 use sparse::to_dense::assign_to_dense;
-
-use sparse::vec::noexport::{
-    new_vecview_unchecked,
-    new_vecview_mut_unchecked,
-};
 
 /// Describe the storage of a CsMat
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -126,8 +121,12 @@ for OuterIterator<'iter, N> {
                 let inner_end = window[1];
                 let indices = &self.indices[inner_start..inner_end];
                 let data = &self.data[inner_start..inner_end];
-                // safety derives from the structure checks in the constructors
-                Some(new_vecview_unchecked(self.inner_len, indices, data))
+                // CsMat invariants imply CsVec invariants
+                Some(CsVec {
+                    dim: self.inner_len,
+                    indices: indices,
+                    data: data,
+                })
             }
         }
     }
@@ -154,8 +153,12 @@ for OuterIteratorPerm<'iter, 'perm, N> {
                 let inner_end = self.indptr[outer_ind_perm + 1];
                 let indices = &self.indices[inner_start..inner_end];
                 let data = &self.data[inner_start..inner_end];
-                // safety derives from the structure checks in the constructors
-                let vec = new_vecview_unchecked(self.inner_len, indices, data);
+                // CsMat invariants imply CsVec invariants
+                let vec = CsVec {
+                    dim: self.inner_len,
+                    indices: indices,
+                    data: data,
+                };
                 Some((outer_ind_perm, vec))
             }
         }
@@ -186,8 +189,12 @@ for OuterIteratorMut<'iter, N> {
                 let (data, next) = tmp.split_at_mut(inner_end - inner_start);
                 self.data = next;
 
-                // safety derives from the structure checks in the constructors
-                Some(new_vecview_mut_unchecked(self.inner_len, indices, data))
+                // CsMat invariants imply CsVec invariants
+                Some(CsVec {
+                    dim: self.inner_len,
+                    indices: indices,
+                    data: data,
+                })
             }
         }
     }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1180,7 +1180,6 @@ DataStorage: DerefMut<Target=[N]> {
 
 pub mod raw {
     use sparse::prelude::*;
-    use utils;
     use ::Shape;
     use std::mem::swap;
 
@@ -1209,8 +1208,15 @@ pub mod raw {
         // we're building a csmat even though the indices are not sorted,
         // but it's not a problem since we don't rely on this property.
         // FIXME: this would be better with an explicit unsorted matrix type
-        let mat = utils::csmat_borrowed_uchk(
-            in_storage, shape, in_indtpr, in_indices, in_data);
+        let mat = CsMat {
+            storage: in_storage,
+            nrows: shape.0,
+            ncols: shape.1,
+            indptr: in_indtpr,
+            indices: in_indices,
+            data: in_data,
+        };
+
         convert_mat_storage(mat, indptr, indices, data);
     }
 

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -224,14 +224,12 @@ for OuterIterator<'iter, N> {
                 let inner_end = window[1];
                 let indices = &self.indices[inner_start..inner_end];
                 let data = &self.data[inner_start..inner_end];
-                // safety derives from the structure checks in the constructors
-                unsafe {
-                    let vec = CsVec::new_view_raw(self.inner_len,
-                                                  indices.len(),
-                                                  indices.as_ptr(),
-                                                  data.as_ptr());
-                    Some(vec)
-                }
+                // CsMat invariants imply CsVec invariants
+                Some(CsVec {
+                    dim: self.inner_len,
+                    indices: indices,
+                    data: data,
+                })
             }
         }
     }
@@ -779,13 +777,12 @@ where IptrStorage: Deref<Target=[usize]>,
         }
         let start = self.indptr[i];
         let stop = self.indptr[i+1];
-        // safety derives from the structure checks in the constructors
-        unsafe {
-            Some(CsVec::new_view_raw(self.inner_dims(),
-                                     self.indices[start..stop].len(),
-                                     self.indices[start..stop].as_ptr(),
-                                     self.data[start..stop].as_ptr()))
-        }
+        // CsMat invariants imply CsVec invariants
+        Some(CsVec {
+            dim: self.inner_dims(),
+            indices: &self.indices[start..stop],
+            data: &self.data[start..stop],
+        })
     }
 
     /// Iteration on outer blocks of size block_size
@@ -1097,13 +1094,12 @@ DataStorage: DerefMut<Target=[N]> {
         }
         let start = self.indptr[i];
         let stop = self.indptr[i+1];
-        // safety derives from the structure checks in the constructors
-        unsafe {
-            Some(CsVec::new_view_mut_raw(self.inner_dims(),
-                                         self.indices[start..stop].len(),
-                                         self.indices[start..stop].as_ptr(),
-                                         self.data[start..stop].as_mut_ptr()))
-        }
+        // CsMat invariants imply CsVec invariants
+        Some(CsVec {
+            dim: self.inner_dims(),
+            indices: &self.indices[start..stop],
+            data: &mut self.data[start..stop],
+        })
     }
 
     /// Get a mutable reference to the element located at row i and column j.

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -27,7 +27,9 @@ use sparse::utils;
 use errors::SprsError;
 use sparse::to_dense::assign_to_dense;
 
-
+use sparse::vec::noexport::{
+    new_vecview_unchecked,
+};
 
 /// Describe the storage of a CsMat
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -124,13 +126,7 @@ for OuterIterator<'iter, N> {
                 let indices = &self.indices[inner_start..inner_end];
                 let data = &self.data[inner_start..inner_end];
                 // safety derives from the structure checks in the constructors
-                unsafe {
-                    let vec = CsVec::new_view_raw(self.inner_len,
-                                                  indices.len(),
-                                                  indices.as_ptr(),
-                                                  data.as_ptr());
-                    Some(vec)
-                }
+                Some(new_vecview_unchecked(self.inner_len, indices, data))
             }
         }
     }
@@ -158,13 +154,8 @@ for OuterIteratorPerm<'iter, 'perm, N> {
                 let indices = &self.indices[inner_start..inner_end];
                 let data = &self.data[inner_start..inner_end];
                 // safety derives from the structure checks in the constructors
-                unsafe {
-                    let vec = CsVec::new_view_raw(self.inner_len,
-                                                  indices.len(),
-                                                  indices.as_ptr(),
-                                                  data.as_ptr());
-                    Some((outer_ind_perm, vec))
-                }
+                let vec = new_vecview_unchecked(self.inner_len, indices, data);
+                Some((outer_ind_perm, vec))
             }
         }
     }

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -4,6 +4,7 @@ use std::ops::IndexMut;
 use num_traits::Num;
 use sparse::CsMatView;
 use sparse::vec;
+use sparse::CsVecView;
 use errors::SprsError;
 use stack::{self, StackVal, DStack};
 
@@ -103,7 +104,7 @@ where N: Copy + Num,
 }
 
 fn lspsolve_csc_process_col<N: Copy + Num, V: ?Sized>
-                                                      (col: vec::CsVecView<N>,
+                                                      (col: CsVecView<N>,
                                                        col_ind: usize,
                                                        rhs: &mut V)
                                                        -> Result<(), SprsError>
@@ -249,7 +250,7 @@ where N: Copy + Num,
 /// * if w_workspace is not of length n
 ///
 pub fn lsolve_csc_sparse_rhs<N>(lower_tri_mat: CsMatView<N>,
-                                rhs: vec::CsVecView<N>,
+                                rhs: CsVecView<N>,
                                 dstack: &mut DStack<StackVal<usize>>,
                                 x_workspace: &mut [N],
                                 visited: &mut [bool]
@@ -318,7 +319,7 @@ where N: Copy + Num
 #[cfg(test)]
 mod test {
 
-    use sparse::{CsMatOwned, vec};
+    use sparse::{CsMatOwned, CsVecOwned};
     use stack::{self, DStack};
     use std::collections::HashSet;
 
@@ -397,7 +398,7 @@ mod test {
                                     vec![0, 2, 5, 6, 8, 9],
                                     vec![0, 1, 1, 2, 4, 2, 3, 4, 4],
                                     vec![1, 1, 2, 3, 2, 3, 7, 3, 5]);
-        let b = vec::CsVecOwned::new(5, vec![1, 2, 4], vec![4, 9, 9]);
+        let b = CsVecOwned::new(5, vec![1, 2, 4], vec![4, 9, 9]);
         let mut xw = vec![1; 5]; // inital values should not matter
         let mut visited = vec![false; 5]; // inital values matter here
         let mut dstack = DStack::with_capacity(2 * 5);
@@ -413,9 +414,9 @@ mod test {
                                   .map(|&i| (i, xw[i]))
                                   .collect();
 
-        let expected_output = vec::CsVecOwned::new(5,
-                                                   vec![1, 2, 4],
-                                                   vec![2, 1, 1]);
+        let expected_output = CsVecOwned::new(5,
+                                              vec![1, 2, 4],
+                                              vec![2, 1, 1]);
         let expected_output = expected_output.to_set();
 
         assert_eq!(x, expected_output);
@@ -433,9 +434,9 @@ mod test {
                                          5, 6],
                                     vec![1, 1, 2, 3, 3, 1, 7, 5, 2,
                                          1, 2]);
-        let b = vec::CsVecOwned::new(7,
-                                     vec![0, 2, 3, 5],
-                                     vec![1, 7, 7, 3]);
+        let b = CsVecOwned::new(7,
+                                vec![0, 2, 3, 5],
+                                vec![1, 7, 7, 3]);
         let mut dstack = DStack::with_capacity(2 * 7);
         let mut xw = vec![1; 7]; // inital values should not matter
         let mut visited = vec![false; 7]; // inital values matter here
@@ -451,10 +452,10 @@ mod test {
                                   .map(|&i| (i, xw[i]))
                                   .collect();
 
-        let expected_output = vec::CsVecOwned::new(7,
-                                                   vec![0, 2, 3, 5],
-                                                   vec![1, 2, 1, 1]
-                                                  ).to_set();
+        let expected_output = CsVecOwned::new(7,
+                                              vec![0, 2, 3, 5],
+                                              vec![1, 2, 1, 1]
+                                             ).to_set();
 
         assert_eq!(x, expected_output);
     }

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -2,11 +2,6 @@ use std::ops::Deref;
 
 pub use self::csmat::{CompressedStorage};
 
-pub use self::vec::{CsVec,
-                    CsVecOwned,
-                    CsVecView,
-};
-
 /// Compressed matrix in the CSR or CSC format.
 #[derive(PartialEq, Debug)]
 pub struct CsMat<N, IptrStorage, IndStorage, DataStorage>
@@ -27,6 +22,20 @@ pub type CsMatViewMut<'a, N> = CsMat<N, &'a [usize], &'a [usize], &'a mut [N]>;
 // FIXME: a fixed size array would be better, but no Deref impl
 pub type CsMatVecView<'a, N> = CsMat<N, Vec<usize>, &'a [usize], &'a [N]>;
 
+/// A sparse vector, storing the indices of its non-zero data.
+/// The indices should be sorted.
+#[derive(PartialEq, Debug)]
+pub struct CsVec<N, IStorage, DStorage>
+where DStorage: Deref<Target=[N]> {
+    dim: usize,
+    indices : IStorage,
+    data : DStorage
+}
+
+pub type CsVecView<'a, N> = CsVec<N, &'a [usize], &'a [N]>;
+pub type CsVecViewMut<'a, N> = CsVec<N, &'a [usize], &'a mut [N]>;
+pub type CsVecOwned<N> = CsVec<N, Vec<usize>, Vec<N>>;
+
 mod prelude {
     pub use super::{
         CsMat,
@@ -34,6 +43,10 @@ mod prelude {
         CsMatViewMut,
         CsMatOwned,
         CsMatVecView,
+        CsVec,
+        CsVecView,
+        CsVecViewMut,
+        CsVecOwned,
     };
 }
 

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -1,7 +1,6 @@
 ///! Sparse matrix product
 
 use sparse::prelude::*;
-use sparse::vec::{CsVecView, CsVecOwned};
 use num_traits::Num;
 use sparse::compressed::SpMatView;
 use ndarray::{ArrayView, ArrayViewMut, Axis};
@@ -348,8 +347,7 @@ where N: 'a + Num + Copy
 
 #[cfg(test)]
 mod test {
-    use sparse::{CsMat, CsMatOwned};
-    use sparse::vec::{CsVec};
+    use sparse::{CsMat, CsMatOwned, CsVec};
     use sparse::csmat::CompressedStorage::{CSC, CSR};
     use super::{mul_acc_mat_vec_csc, mul_acc_mat_vec_csr, csr_mul_csr};
     use test_data::{mat1, mat2, mat1_self_matprod, mat1_matprod_mat2,

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -338,8 +338,8 @@ impl<'a, N> TripletMatView<'a, N> {
         csmat::raw::convert_storage(csmat::CompressedStorage::CSR,
                                     self.shape(),
                                     &indptr,
-                                    &indices,
-                                    &data,
+                                    &indices[..nnz],
+                                    &data[..nnz],
                                     &mut out_indptr,
                                     &mut out_indices,
                                     &mut out_data);

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -862,6 +862,32 @@ where IS: Deref<Target=[usize]>,
     }
 }
 
+/// This module contains functions that should not be
+/// exported by the library, but are intended to be usable
+/// throughout the library. They are not unsafe by themselves,
+/// but failing to respect their contracts could lead
+/// to unsafety in other parts of the library.
+pub mod noexport {
+    /// Create a sparse vector view over borrowed data, without performing
+    /// structure checks.
+    ///
+    /// This function can be used to break guarantees enforced by the library
+    /// and should be used with care. As such, it shouldn't be exported to
+    /// outside crates.
+    pub fn new_vecview_unchecked<'a, N>(n: usize,
+                                        indices: &'a [usize],
+                                        data: &'a [N]
+                                       ) -> super::CsVecView<'a, N> {
+        debug_assert!(indices.len() <= n);
+        debug_assert!(indices.len() == data.len());
+        super::CsVec {
+            dim: n,
+            indices: indices,
+            data: data,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::CsVec;

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -35,26 +35,12 @@ use sparse::prelude::*;
 use sparse::csmat::CompressedStorage::{CSR, CSC};
 use errors::SprsError;
 
-/// A sparse vector, storing the indices of its non-zero data.
-/// The indices should be sorted.
-#[derive(PartialEq, Debug)]
-pub struct CsVec<N, IStorage, DStorage>
-where DStorage: Deref<Target=[N]> {
-    dim: usize,
-    indices : IStorage,
-    data : DStorage
-}
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 /// Hold the index of a non-zero element in the compressed storage
 ///
 /// An NnzIndex can be used to later access the non-zero element in constant
 /// time.
 pub struct NnzIndex(pub usize);
-
-pub type CsVecView<'a, N> = CsVec<N, &'a [usize], &'a [N]>;
-pub type CsVecViewMut<'a, N> = CsVec<N, &'a [usize], &'a mut [N]>;
-pub type CsVecOwned<N> = CsVec<N, Vec<usize>, Vec<N>>;
 
 /// A trait to represent types which can be interpreted as vectors
 /// of a given dimension.
@@ -862,54 +848,9 @@ where IS: Deref<Target=[usize]>,
     }
 }
 
-/// This module contains functions that should not be
-/// exported by the library, but are intended to be usable
-/// throughout the library. They are not unsafe by themselves,
-/// but failing to respect their contracts could lead
-/// to unsafety in other parts of the library.
-pub mod noexport {
-    /// Create a sparse vector view over borrowed data, without performing
-    /// structure checks.
-    ///
-    /// This function can be used to break guarantees enforced by the library
-    /// and should be used with care. As such, it shouldn't be exported to
-    /// outside crates.
-    pub fn new_vecview_unchecked<'a, N>(n: usize,
-                                        indices: &'a [usize],
-                                        data: &'a [N]
-                                       ) -> super::CsVecView<'a, N> {
-        debug_assert!(indices.len() <= n);
-        debug_assert!(indices.len() == data.len());
-        super::CsVec {
-            dim: n,
-            indices: indices,
-            data: data,
-        }
-    }
-
-    /// Create a mutable sparse vector view over borrowed data,
-    /// without performing structure checks.
-    ///
-    /// This function can be used to break guarantees enforced by the library
-    /// and should be used with care. As such, it shouldn't be exported to
-    /// outside crates.
-    pub fn new_vecview_mut_unchecked<'a, N>(n: usize,
-                                            indices: &'a [usize],
-                                            data: &'a mut [N]
-                                           ) -> super::CsVecViewMut<'a, N> {
-        debug_assert!(indices.len() <= n);
-        debug_assert!(indices.len() == data.len());
-        super::CsVec {
-            dim: n,
-            indices: indices,
-            data: data,
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use super::CsVec;
+    use sparse::CsVec;
     use super::SparseIterTools;
     use ndarray::Array;
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -574,11 +574,13 @@ where IStorage: Deref<Target=[usize]>,
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = vec![0, self.indices.len()];
-        unsafe {
-            CsMatVecView::new_vecview_raw(CSR, 1, self.dim,
-                                          indptr,
-                                          self.indices.as_ptr(),
-                                          self.data.as_ptr())
+        CsMat {
+            storage: CSR,
+            nrows: 1,
+            ncols: self.dim,
+            indptr: indptr,
+            indices: &self.indices[..],
+            data: &self.data[..],
         }
     }
 
@@ -587,11 +589,13 @@ where IStorage: Deref<Target=[usize]>,
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = vec![0, self.indices.len()];
-        unsafe {
-            CsMatVecView::new_vecview_raw(CSC, self.dim, 1,
-                                          indptr,
-                                          self.indices.as_ptr(),
-                                          self.data.as_ptr())
+        CsMat {
+            storage: CSC,
+            nrows: self.dim,
+            ncols: 1,
+            indptr: indptr,
+            indices: &self.indices[..],
+            data: &self.data[..],
         }
     }
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -886,6 +886,25 @@ pub mod noexport {
             data: data,
         }
     }
+
+    /// Create a mutable sparse vector view over borrowed data,
+    /// without performing structure checks.
+    ///
+    /// This function can be used to break guarantees enforced by the library
+    /// and should be used with care. As such, it shouldn't be exported to
+    /// outside crates.
+    pub fn new_vecview_mut_unchecked<'a, N>(n: usize,
+                                            indices: &'a [usize],
+                                            data: &'a mut [N]
+                                           ) -> super::CsVecViewMut<'a, N> {
+        debug_assert!(indices.len() <= n);
+        debug_assert!(indices.len() == data.len());
+        super::CsVec {
+            dim: n,
+            indices: indices,
+            data: data,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Rework the module hierarchy to avoid relying on unsafe calls inside the library.

Fixes #98.