### PR TITLE
Documentation improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ num-traits = "0.1.32"
 
 
 [dependencies.ndarray]
-version = "0.9.1"
+version = "0.10.0"
 

--- a/examples/heat.rs
+++ b/examples/heat.rs
@@ -45,7 +45,7 @@ fn is_border(row: usize, col: usize, shape: (usize, usize)) -> bool {
 /// This example shows how a relatively straightforward sparse matrix
 /// can be constructed with a minimal number of allocations by directly
 /// building up its sparse structure.
-fn grid_laplacian(shape: (usize, usize)) -> sprs::CsMatOwned<f64> {
+fn grid_laplacian(shape: (usize, usize)) -> sprs::CsMat<f64> {
     let (rows, cols) = shape;
     let nb_vert = rows * cols;
     let mut indptr = Vec::with_capacity(nb_vert + 1);
@@ -80,7 +80,7 @@ fn grid_laplacian(shape: (usize, usize)) -> sprs::CsMatOwned<f64> {
 
     indptr.push(cumsum);
 
-    sprs::CsMatOwned::new((nb_vert, nb_vert), indptr, indices, data)
+    sprs::CsMat::new((nb_vert, nb_vert), indptr, indices, data)
 }
 
 /// Set a dirichlet boundary condition

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,9 @@ pub use sparse::triplet::{
     TripletMat,
     TripletMatView,
     TripletMatViewMut,
+    TripletMatI,
+    TripletMatViewI,
+    TripletMatViewMutI,
 };
 
 pub use sparse::construct::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,43 +1,54 @@
 /*!
-# sprs
 
 sprs is a sparse linear algebra library for Rust.
 
-It features a sparse matrix type, CsMat, and a sparse vector type, CsVec,
-both based on the compressed storage scheme.
+It features a sparse matrix type, [**`CsMat`**](struct.CsMatBase.html), and a sparse vector type,
+[**`CsVec`**](struct.CsVecBase.html), both based on the
+[compressed storage scheme](https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_.28CSR.2C_CRS_or_Yale_format.29).
 
-All matrix algebra operations are supported, and support for direct sparse
-solvers is planned.
+## Features
 
-## Examples
+- sparse matrix/sparse matrix addition, multiplication.
+- sparse vector/sparse vector addition, dot product.
+- sparse matrix/dense matrix addition, multiplication.
+- sparse triangular solves.
+- powerful iteration over the sparse structure, enabling easy extension of the library.
+- matrix construction using the [triplet format](struct.TriMatBase.html),
+  vertical and horizontal stacking, block construction.
+- sparse cholesky solver in the separate crate `sprs-ldl`.
+- fully generic integer type for the storage of indices, enabling compact
+  representations.
+- planned interoperability with existing sparse solvers such as SuiteSparse.
 
-Matrix construction
+## Quick Examples
+
+Matrix construction:
 
 ```rust
-use sprs::{CsMatBase, CsMat, CsVec};
-let eye : CsMat<f64> = CsMatBase::eye(3);
-let a = CsMatBase::new_csc((3, 3),
+use sprs::{CsMat, CsVec};
+let eye : CsMat<f64> = CsMat::eye(3);
+let a = CsMat::new_csc((3, 3),
                        vec![0, 2, 4, 5],
                        vec![0, 1, 0, 2, 2],
                        vec![1., 2., 3., 4., 5.]);
 ```
 
-Matrix vector multiplication
+Matrix vector multiplication:
 
 ```rust
-use sprs::{CsMatBase, CsVec};
-let eye = CsMatBase::eye(5);
+use sprs::{CsMat, CsVec};
+let eye = CsMat::eye(5);
 let x = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
 let y = &eye * &x;
 assert_eq!(x, y);
 ```
 
-Matrix matrix multiplication, addition
+Matrix matrix multiplication, addition:
 
 ```rust
-use sprs::{CsMatBase, CsVec};
-let eye = CsMatBase::eye(3);
-let a = CsMatBase::new_csc((3, 3),
+use sprs::{CsMat, CsVec};
+let eye = CsMat::eye(3);
+let a = CsMat::new_csc((3, 3),
                        vec![0, 2, 4, 5],
                        vec![0, 1, 0, 2, 2],
                        vec![1., 2., 3., 4., 5.]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,12 +122,12 @@ pub mod vec {
 }
 
 pub use sparse::triplet::{
-    TripletMat,
-    TripletMatView,
-    TripletMatViewMut,
-    TripletMatI,
-    TripletMatViewI,
-    TripletMatViewMutI,
+    TriMat,
+    TriMatView,
+    TriMatViewMut,
+    TriMatI,
+    TriMatViewI,
+    TriMatViewMutI,
 };
 
 pub use sparse::construct::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,13 @@ pub use sparse::{
     CsVecViewI,
     CsVec,
     CsVecI,
+    TriMatBase,
+    TriMat,
+    TriMatView,
+    TriMatViewMut,
+    TriMatI,
+    TriMatViewI,
+    TriMatViewMutI,
 };
 
 
@@ -131,15 +138,6 @@ pub mod vec {
         NnzEither,
     };
 }
-
-pub use sparse::triplet::{
-    TriMat,
-    TriMatView,
-    TriMatViewMut,
-    TriMatI,
-    TriMatViewI,
-    TriMatViewMutI,
-};
 
 pub use sparse::construct::{
     vstack,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,11 +71,11 @@ pub use sparse::{
     CsMatViewMut,
     CsMatViewMutI,
     CsMatVecView,
-    CsVec,
+    CsVecBase,
     CsVecView,
     CsVecViewI,
-    CsVecOwned,
-    CsVecOwnedI,
+    CsVec,
+    CsVecI,
 };
 
 
@@ -103,8 +103,8 @@ pub use sparse::binop;
 
 pub mod vec {
     pub use sparse::{
+        CsVecBase,
         CsVec,
-        CsVecOwned,
         CsVecView,
         CsVecViewMut,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,8 @@ pub use sparse::{
     CsVecViewI,
     CsVec,
     CsVecI,
+    CsVecViewMut,
+    CsVecViewMutI,
     TriMatBase,
     TriMat,
     TriMatView,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@ solvers is planned.
 Matrix construction
 
 ```rust
-use sprs::{CsMat, CsMatOwned, CsVec};
-let eye : CsMatOwned<f64> = CsMat::eye(3);
-let a = CsMat::new_csc((3, 3),
+use sprs::{CsMatBase, CsMat, CsVec};
+let eye : CsMat<f64> = CsMatBase::eye(3);
+let a = CsMatBase::new_csc((3, 3),
                        vec![0, 2, 4, 5],
                        vec![0, 1, 0, 2, 2],
                        vec![1., 2., 3., 4., 5.]);
@@ -25,8 +25,8 @@ let a = CsMat::new_csc((3, 3),
 Matrix vector multiplication
 
 ```rust
-use sprs::{CsMat, CsVec};
-let eye = CsMat::eye(5);
+use sprs::{CsMatBase, CsVec};
+let eye = CsMatBase::eye(5);
 let x = CsVec::new(5, vec![0, 2, 4], vec![1., 2., 3.]);
 let y = &eye * &x;
 assert_eq!(x, y);
@@ -35,9 +35,9 @@ assert_eq!(x, y);
 Matrix matrix multiplication, addition
 
 ```rust
-use sprs::{CsMat, CsVec};
-let eye = CsMat::eye(3);
-let a = CsMat::new_csc((3, 3),
+use sprs::{CsMatBase, CsVec};
+let eye = CsMatBase::eye(3);
+let a = CsMatBase::new_csc((3, 3),
                        vec![0, 2, 4, 5],
                        vec![0, 1, 0, 2, 2],
                        vec![1., 2., 3., 4., 5.]);
@@ -63,9 +63,9 @@ pub type Ix1 = ndarray::Ix1;
 pub type Ix2 = ndarray::Ix2;
 
 pub use sparse::{
+    CsMatBase,
     CsMat,
-    CsMatOwned,
-    CsMatOwnedI,
+    CsMatI,
     CsMatView,
     CsMatViewI,
     CsMatViewMut,

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -261,17 +261,18 @@ where N: 'a + Num,
 /// to zero when e.g. only `lhs` has a non-zero at a given location).
 ///
 /// The function thus has a correct behavior iff `binop(0, 0) == 0`.
-pub fn csvec_binop<N, F>(lhs: CsVecView<N>,
-                         rhs: CsVecView<N>,
-                         binop: F
-                        ) -> SpRes<CsVec<N>>
+pub fn csvec_binop<N, I, F>(lhs: CsVecViewI<N, I>,
+                            rhs: CsVecViewI<N, I>,
+                            binop: F
+                           ) -> SpRes<CsVecI<N, I>>
 where N: Num,
-      F: Fn(&N, &N) -> N
+      F: Fn(&N, &N) -> N,
+      I: SpIndex,
 {
     if lhs.dim() != rhs.dim() {
         panic!("Dimension mismatch");
     }
-    let mut res = CsVec::empty(lhs.dim());
+    let mut res = CsVecI::empty(lhs.dim());
     let max_nnz = lhs.nnz() + rhs.nnz();
     res.reserve_exact(max_nnz);
     for elem in lhs.iter().nnz_or_zip(rhs.iter()) {

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -264,7 +264,7 @@ where N: 'a + Num,
 pub fn csvec_binop<N, F>(lhs: CsVecView<N>,
                          rhs: CsVecView<N>,
                          binop: F
-                        ) -> SpRes<CsVecOwned<N>>
+                        ) -> SpRes<CsVec<N>>
 where N: Num,
       F: Fn(&N, &N) -> N
 {

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -23,7 +23,7 @@ use ::SpRes;
 /// Sparse matrix addition, with matrices sharing the same storage type
 pub fn add_mat_same_storage<N, I, Mat1, Mat2>(lhs: &Mat1,
                                               rhs: &Mat2
-                                             ) -> CsMatOwnedI<N, I>
+                                             ) -> CsMatI<N, I>
 where N: Num + Copy,
       I: SpIndex,
       Mat1: SpMatView<N, I>,
@@ -35,7 +35,7 @@ where N: Num + Copy,
 /// Sparse matrix subtraction, with same storage type
 pub fn sub_mat_same_storage<N, I, Mat1, Mat2>(lhs: &Mat1,
                                               rhs: &Mat2
-                                             ) -> CsMatOwnedI<N, I>
+                                             ) -> CsMatI<N, I>
 where N: Num + Copy,
       I: SpIndex,
       Mat1: SpMatView<N, I>,
@@ -47,7 +47,7 @@ where N: Num + Copy,
 /// Sparse matrix scalar multiplication, with same storage type
 pub fn mul_mat_same_storage<N, I, Mat1, Mat2>(lhs: &Mat1,
                                               rhs: &Mat2
-                                             ) -> CsMatOwnedI<N, I>
+                                             ) -> CsMatI<N, I>
 where N: Num + Copy,
       I: SpIndex,
       Mat1: SpMatView<N, I>,
@@ -59,7 +59,7 @@ where N: Num + Copy,
 /// Sparse matrix multiplication by a scalar
 pub fn scalar_mul_mat<N, I, Mat>(mat: &Mat,
                                  val: N
-                                ) -> CsMatOwnedI<N, I>
+                                ) -> CsMatI<N, I>
 where N: Num + Copy,
       I: SpIndex,
       Mat: SpMatView<N, I>
@@ -82,7 +82,7 @@ where N: Num + Copy,
 pub fn csmat_binop<N, I, F>(lhs: CsMatViewI<N, I>,
                             rhs: CsMatViewI<N, I>,
                             binop: F
-                           ) -> CsMatOwnedI<N, I>
+                           ) -> CsMatI<N, I>
 where N: Num,
       I: SpIndex,
       F: Fn(&N, &N) -> N
@@ -115,7 +115,7 @@ where N: Num,
                                            &mut out_data[..]);
     out_indices.truncate(nnz);
     out_data.truncate(nnz);
-    CsMat {
+    CsMatI {
         storage: storage_type,
         nrows: nrows,
         ncols: ncols,
@@ -287,12 +287,12 @@ where N: Num,
 
 #[cfg(test)]
 mod test {
-    use sparse::{CsMat, CsMatOwned};
+    use sparse::CsMat;
     use sparse::CsVec;
     use test_data::{mat1, mat2, mat1_times_2, mat_dense1};
     use ndarray::{arr2, Array};
 
-    fn mat1_plus_mat2() -> CsMatOwned<f64> {
+    fn mat1_plus_mat2() -> CsMat<f64> {
         let indptr = vec![0,  5,  8,  9, 12, 15];
         let indices = vec![0, 1, 2, 3, 4, 0, 3, 4, 2, 1, 2, 3, 1, 2, 3];
         let data = vec![6.,  7.,  6.,  4.,  3.,
@@ -301,7 +301,7 @@ mod test {
         CsMat::new((5, 5), indptr, indices, data)
     }
 
-    fn mat1_minus_mat2() -> CsMatOwned<f64> {
+    fn mat1_minus_mat2() -> CsMat<f64> {
         let indptr = vec![0,  4,  7,  8, 11, 14];
         let indices = vec![0, 1, 3, 4, 0, 3, 4, 2, 1, 2, 3, 1, 2, 3];
         let data = vec![-6., -7.,  4., -3., -8.,
@@ -310,7 +310,7 @@ mod test {
         CsMat::new((5, 5), indptr, indices, data)
     }
 
-    fn mat1_times_mat2() -> CsMatOwned<f64> {
+    fn mat1_times_mat2() -> CsMat<f64> {
         let indptr = vec![0,  1,  2,  2, 2, 2];
         let indices = vec![2, 3];
         let data = vec![9., 18.];
@@ -331,15 +331,15 @@ mod test {
         assert_eq!(c, c_true);
 
         // test with CSR matrices having differ row patterns
-        let a = CsMatOwned::new((3, 3),
+        let a = CsMat::new((3, 3),
                                 vec![0, 1, 1, 2],
                                 vec![0, 2],
                                 vec![1., 1.]);
-        let b = CsMatOwned::new((3, 3),
+        let b = CsMat::new((3, 3),
                                 vec![0, 1, 2, 2],
                                 vec![0, 1],
                                 vec![1., 1.]);
-        let c = CsMatOwned::new((3, 3),
+        let c = CsMat::new((3, 3),
                                 vec![0, 1, 2, 3],
                                 vec![0, 1, 2],
                                 vec![2., 1., 1.]);
@@ -404,7 +404,7 @@ mod test {
     #[test]
     fn csr_add_dense_rowmaj() {
         let a = Array::zeros((3,3));
-        let b = CsMatOwned::eye(3);
+        let b = CsMat::eye(3);
 
         let c = super::add_dense_mat_same_ordering(&b, &a, 1., 1.);
 
@@ -432,7 +432,7 @@ mod test {
     #[test]
     fn csr_mul_dense_rowmaj() {
         let a = Array::from_elem((3,3), 1.);
-        let b = CsMatOwned::eye(3);
+        let b = CsMat::eye(3);
 
         let c = super::mul_dense_mat_same_ordering(&b, &a, 1.);
 

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -17,7 +17,7 @@ pub trait SpMatView<N, I: SpIndex> {
 
 
 impl<N, I, IpStorage, IndStorage, DataStorage> SpMatView<N, I>
-for CsMat<N, I, IpStorage, IndStorage, DataStorage>
+for CsMatBase<N, I, IpStorage, IndStorage, DataStorage>
 where I: SpIndex,
       IpStorage: Deref<Target=[I]>,
       IndStorage: Deref<Target=[I]>,

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -34,17 +34,19 @@ where I: SpIndex,
 
 /// The SpVecView trait describes types that can be seen as a view into
 /// a CsVec
-pub trait SpVecView<N> {
+pub trait SpVecView<N, I: SpIndex> {
     /// Return a view into the current vector
-    fn view(&self) ->  CsVecView<N>;
+    fn view(&self) ->  CsVecViewI<N, I>;
 }
 
-impl<N, IndStorage, DataStorage> SpVecView<N>
+impl<N, I, IndStorage, DataStorage> SpVecView<N, I>
 for CsVecBase<N, IndStorage, DataStorage>
-where IndStorage: Deref<Target=[usize]>,
-      DataStorage: Deref<Target=[N]> {
+where IndStorage: Deref<Target=[I]>,
+      DataStorage: Deref<Target=[N]>,
+      I: SpIndex,
+{
 
-    fn view(&self) -> CsVecView<N> {
+    fn view(&self) -> CsVecViewI<N, I> {
         self.view()
     }
 }

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -40,7 +40,7 @@ pub trait SpVecView<N> {
 }
 
 impl<N, IndStorage, DataStorage> SpVecView<N>
-for CsVec<N, IndStorage, DataStorage>
+for CsVecBase<N, IndStorage, DataStorage>
 where IndStorage: Deref<Target=[usize]>,
       DataStorage: Deref<Target=[N]> {
 

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -40,7 +40,7 @@ pub trait SpVecView<N, I: SpIndex> {
 }
 
 impl<N, I, IndStorage, DataStorage> SpVecView<N, I>
-for CsVecBase<N, IndStorage, DataStorage>
+for CsVecBase<IndStorage, DataStorage>
 where IndStorage: Deref<Target=[I]>,
       DataStorage: Deref<Target=[N]>,
       I: SpIndex,

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -113,7 +113,7 @@ pub struct OuterIteratorMut<'iter, N: 'iter, I: 'iter> {
 impl <'iter, N: 'iter, I: 'iter + SpIndex>
 Iterator
 for OuterIterator<'iter, N, I> {
-    type Item = CsVecBase<N, &'iter[I], &'iter[N]>;
+    type Item = CsVecBase<&'iter[I], &'iter[N]>;
     #[inline]
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         match self.indptr_iter.next() {
@@ -145,7 +145,7 @@ impl <'iter, 'perm: 'iter, N: 'iter, I: 'iter + SpIndex>
 Iterator
 for OuterIteratorPerm<'iter, 'perm, N, I>
 {
-    type Item = (usize, CsVecBase<N, &'iter[I], &'iter[N]>);
+    type Item = (usize, CsVecBase<&'iter[I], &'iter[N]>);
     #[inline]
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         match self.outer_ind_iter.next() {
@@ -471,7 +471,7 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     }
 
     /// Append an outer dim to an existing matrix, provided by a sparse vector
-    pub fn append_outer_csvec(mut self, vec: CsVecBase<N,&[I],&[N]>) -> Self
+    pub fn append_outer_csvec(mut self, vec: CsVecBase<&[I], &[N]>) -> Self
     where N: Clone
     {
         assert_eq!(self.inner_dims(), vec.dim());

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -113,7 +113,7 @@ pub struct OuterIteratorMut<'iter, N: 'iter, I: 'iter> {
 impl <'iter, N: 'iter, I: 'iter + SpIndex>
 Iterator
 for OuterIterator<'iter, N, I> {
-    type Item = CsVec<N, &'iter[I], &'iter[N]>;
+    type Item = CsVecBase<N, &'iter[I], &'iter[N]>;
     #[inline]
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         match self.indptr_iter.next() {
@@ -124,7 +124,7 @@ for OuterIterator<'iter, N, I> {
                 let indices = &self.indices[inner_start..inner_end];
                 let data = &self.data[inner_start..inner_end];
                 // CsMat invariants imply CsVec invariants
-                Some(CsVec {
+                Some(CsVecBase {
                     dim: self.inner_len,
                     indices: indices,
                     data: data,
@@ -145,7 +145,7 @@ impl <'iter, 'perm: 'iter, N: 'iter, I: 'iter + SpIndex>
 Iterator
 for OuterIteratorPerm<'iter, 'perm, N, I>
 {
-    type Item = (usize, CsVec<N, &'iter[I], &'iter[N]>);
+    type Item = (usize, CsVecBase<N, &'iter[I], &'iter[N]>);
     #[inline]
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         match self.outer_ind_iter.next() {
@@ -157,7 +157,7 @@ for OuterIteratorPerm<'iter, 'perm, N, I>
                 let indices = &self.indices[inner_start..inner_end];
                 let data = &self.data[inner_start..inner_end];
                 // CsMat invariants imply CsVec invariants
-                let vec = CsVec {
+                let vec = CsVecBase {
                     dim: self.inner_len,
                     indices: indices,
                     data: data,
@@ -193,7 +193,7 @@ for OuterIteratorMut<'iter, N, I> {
                 self.data = next;
 
                 // CsMat invariants imply CsVec invariants
-                Some(CsVec {
+                Some(CsVecBase {
                     dim: self.inner_len,
                     indices: indices,
                     data: data,
@@ -228,7 +228,7 @@ for OuterIterator<'iter, N, I> {
                 let indices = &self.indices[inner_start..inner_end];
                 let data = &self.data[inner_start..inner_end];
                 // CsMat invariants imply CsVec invariants
-                Some(CsVec {
+                Some(CsVecBase {
                     dim: self.inner_len,
                     indices: indices,
                     data: data,
@@ -514,7 +514,7 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     }
 
     /// Append an outer dim to an existing matrix, provided by a sparse vector
-    pub fn append_outer_csvec(mut self, vec: CsVec<N,&[I],&[N]>) -> Self
+    pub fn append_outer_csvec(mut self, vec: CsVecBase<N,&[I],&[N]>) -> Self
     where N: Clone
     {
         assert_eq!(self.inner_dims(), vec.dim());
@@ -787,7 +787,7 @@ where I: SpIndex,
         let start = self.indptr[i].index();
         let stop = self.indptr[i+1].index();
         // CsMat invariants imply CsVec invariants
-        Some(CsVec {
+        Some(CsVecBase {
             dim: self.inner_dims(),
             indices: &self.indices[start..stop],
             data: &self.data[start..stop],
@@ -1112,7 +1112,7 @@ DataStorage: DerefMut<Target=[N]> {
         let start = self.indptr[i].index();
         let stop = self.indptr[i+1].index();
         // CsMat invariants imply CsVec invariants
-        Some(CsVec {
+        Some(CsVecBase {
             dim: self.inner_dims(),
             indices: &self.indices[start..stop],
             data: &mut self.data[start..stop],

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -178,7 +178,7 @@ for OuterIteratorPerm<'iter, 'perm, N, I>
 impl <'iter, N: 'iter, I: 'iter + SpIndex>
 Iterator
 for OuterIteratorMut<'iter, N, I> {
-    type Item = CsVecViewMut_<'iter, N, I>;
+    type Item = CsVecViewMutI<'iter, N, I>;
     #[inline]
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         match self.indptr_iter.next() {
@@ -1088,7 +1088,7 @@ DataStorage: DerefMut<Target=[N]> {
 
     /// Get a mutable view into the i-th outer dimension
     /// (eg i-th row for a CSR matrix)
-    pub fn outer_view_mut(&mut self, i: usize) -> Option<CsVecViewMut_<N, I>> {
+    pub fn outer_view_mut(&mut self, i: usize) -> Option<CsVecViewMutI<N, I>> {
         if i >= self.outer_dims() {
             return None;
         }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -919,7 +919,7 @@ where I: SpIndex,
                           outer_ind: usize,
                           inner_ind: usize
                          ) -> Option<&N> {
-        self.outer_view(outer_ind).and_then(|vec| vec.get_(inner_ind))
+        self.outer_view(outer_ind).and_then(|vec| vec.get_rbr(inner_ind))
     }
 
     /// Find the non-zero index of the element specified by row and col

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -319,7 +319,7 @@ where N: Copy + Num
 #[cfg(test)]
 mod test {
 
-    use sparse::{CsMat, CsVecOwned};
+    use sparse::{CsMat, CsVec};
     use stack::{self, DStack};
     use std::collections::HashSet;
 
@@ -398,7 +398,7 @@ mod test {
                                     vec![0, 2, 5, 6, 8, 9],
                                     vec![0, 1, 1, 2, 4, 2, 3, 4, 4],
                                     vec![1, 1, 2, 3, 2, 3, 7, 3, 5]);
-        let b = CsVecOwned::new(5, vec![1, 2, 4], vec![4, 9, 9]);
+        let b = CsVec::new(5, vec![1, 2, 4], vec![4, 9, 9]);
         let mut xw = vec![1; 5]; // inital values should not matter
         let mut visited = vec![false; 5]; // inital values matter here
         let mut dstack = DStack::with_capacity(2 * 5);
@@ -414,7 +414,7 @@ mod test {
                                   .map(|&i| (i, xw[i]))
                                   .collect();
 
-        let expected_output = CsVecOwned::new(5,
+        let expected_output = CsVec::new(5,
                                               vec![1, 2, 4],
                                               vec![2, 1, 1]);
         let expected_output = expected_output.to_set();
@@ -432,7 +432,7 @@ mod test {
                                vec![0, 2, 4, 6, 7, 9, 10, 11],
                                vec![0, 2, 1, 6, 2, 5, 3, 4, 6, 5, 6],
                                vec![1, 1, 2, 3, 3, 1, 7, 5, 2, 1, 2]);
-        let b = CsVecOwned::new(7,
+        let b = CsVec::new(7,
                                 vec![0, 2, 3, 5],
                                 vec![1, 7, 7, 3]);
         let mut dstack = DStack::with_capacity(2 * 7);
@@ -450,10 +450,9 @@ mod test {
                                   .map(|&i| (i, xw[i]))
                                   .collect();
 
-        let expected_output = CsVecOwned::new(7,
-                                              vec![0, 2, 3, 5],
-                                              vec![1, 2, 1, 1]
-                                             ).to_set();
+        let expected_output = CsVec::new(7,
+                                         vec![0, 2, 3, 5],
+                                         vec![1, 2, 1, 1]).to_set();
 
         assert_eq!(x, expected_output);
     }

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -319,7 +319,7 @@ where N: Copy + Num
 #[cfg(test)]
 mod test {
 
-    use sparse::{CsMatOwned, CsVecOwned};
+    use sparse::{CsMat, CsVecOwned};
     use stack::{self, DStack};
     use std::collections::HashSet;
 
@@ -328,10 +328,10 @@ mod test {
         // |1    | |3|   |3|
         // |0 2  | |1| = |2|
         // |1 0 1| |1|   |4|
-        let l = CsMatOwned::new((3, 3),
-                                vec![0, 1, 2, 4],
-                                vec![0, 1, 0, 2],
-                                vec![1, 2, 1, 1]);
+        let l = CsMat::new((3, 3),
+                           vec![0, 1, 2, 4],
+                           vec![0, 1, 0, 2],
+                           vec![1, 2, 1, 1]);
         let b = vec![3, 2, 4];
         let mut x = b.clone();
 
@@ -344,10 +344,10 @@ mod test {
         // |1    | |3|   |3|
         // |1 2  | |1| = |5|
         // |0 0 3| |1|   |3|
-        let l = CsMatOwned::new_csc((3, 3),
-                                    vec![0, 2, 3, 4],
-                                    vec![0, 1, 1, 2],
-                                    vec![1, 1, 2, 3]);
+        let l = CsMat::new_csc((3, 3),
+                               vec![0, 2, 3, 4],
+                               vec![0, 1, 1, 2],
+                               vec![1, 1, 2, 3]);
         let b = vec![3, 5, 3];
         let mut x = b.clone();
 
@@ -360,10 +360,10 @@ mod test {
         // |1 0 1| |3|   |4|
         // |  2 0| |1| = |2|
         // |    3| |1|   |3|
-        let u = CsMatOwned::new_csc((3, 3),
-                                    vec![0, 1, 2, 4],
-                                    vec![0, 1, 0, 2],
-                                    vec![1, 2, 1, 3]);
+        let u = CsMat::new_csc((3, 3),
+                               vec![0, 1, 2, 4],
+                               vec![0, 1, 0, 2],
+                               vec![1, 2, 1, 3]);
         let b = vec![4, 2, 3];
         let mut x = b.clone();
 
@@ -376,10 +376,10 @@ mod test {
         // |1 1 0| |3|   |4|
         // |  5 3| |1| = |8|
         // |    1| |1|   |1|
-        let u = CsMatOwned::new((3, 3),
-                                vec![0, 2, 4, 5],
-                                vec![0, 1, 1, 2, 2],
-                                vec![1, 1, 5, 3, 1]);
+        let u = CsMat::new((3, 3),
+                           vec![0, 2, 4, 5],
+                           vec![0, 1, 1, 2, 2],
+                           vec![1, 1, 5, 3, 1]);
         let b = vec![4, 8, 1];
         let mut x = b.clone();
 
@@ -394,7 +394,7 @@ mod test {
         // |  3 3    | |1|   |9|
         // |      7  | | |   | |
         // |  2   3 5| |1|   |9|
-        let l = CsMatOwned::new_csc((5, 5),
+        let l = CsMat::new_csc((5, 5),
                                     vec![0, 2, 5, 6, 8, 9],
                                     vec![0, 1, 1, 2, 4, 2, 3, 4, 4],
                                     vec![1, 1, 2, 3, 2, 3, 7, 3, 5]);
@@ -428,12 +428,10 @@ mod test {
         // |        5    | | |   | |
         // |    1     1  | |1|   |3|
         // |  3     2   2| | |   | |
-        let l = CsMatOwned::new_csc((7, 7),
-                                    vec![0, 2, 4, 6, 7, 9, 10, 11],
-                                    vec![0, 2, 1, 6, 2, 5, 3, 4, 6,
-                                         5, 6],
-                                    vec![1, 1, 2, 3, 3, 1, 7, 5, 2,
-                                         1, 2]);
+        let l = CsMat::new_csc((7, 7),
+                               vec![0, 2, 4, 6, 7, 9, 10, 11],
+                               vec![0, 2, 1, 6, 2, 5, 3, 4, 6, 5, 6],
+                               vec![1, 1, 2, 3, 3, 1, 7, 5, 2, 1, 2]);
         let b = CsVecOwned::new(7,
                                 vec![0, 2, 3, 5],
                                 vec![1, 7, 7, 3]);

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -141,6 +141,25 @@ pub type CsVec<N> = CsVecI<N, usize>;
 ///
 /// [`to_csc`]: struct.TriMatBase.html#method.to_csc
 /// [`to_csr`]: struct.TriMatBase.html#method.to_csr
+///
+/// The `TriMatBase` type is parameterized by the storage type for the row and
+/// column indices, `IStorage`, and by the storage type for the non-zero values
+/// `DStorage`. Convenient aliases are availaible to specify frequent variant:
+/// [`TriMat`] refers to a triplet matrix owning the storage of its indices and
+/// and values, [`TriMatView`] refers to a triplet matrix with slices to store
+/// its indices and values, while [`TriMatViewMut`] refers to a a triplet matrix
+/// using mutable slices.
+///
+/// Additionaly, the type aliases [`TriMatI`], [`TriMatViewI`] and
+/// [`TriMatViewMutI`] can be used to choose an index type different from the
+/// default `usize`.
+///
+/// [`TriMat`]: type.TriMat.html
+/// [`TriMatView`]: type.TriMatView.html
+/// [`TriMatViewMut`]: type.TriMatViewMut.html
+/// [`TriMatI`]: type.TriMatI.html
+/// [`TriMatViewI`]: type.TriMatViewI.html
+/// [`TriMatViewMutI`]: type.TriMatViewMutI.html
 #[derive(PartialEq, Debug)]
 pub struct TriMatBase<IStorage, DStorage> {
     rows: usize,

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -117,6 +117,47 @@ pub type CsVecView<'a, N> = CsVecViewI<'a, N, usize>;
 pub type CsVecViewMut<'a, N> = CsVecViewMut_<'a, N, usize>;
 pub type CsVec<N> = CsVecI<N, usize>;
 
+/// Sparse matrix in the triplet format.
+///
+/// Sparse matrices in the triplet format use three arrays of equal sizes (accessible through the
+/// methods [`row_inds`], [`col_inds`], [`data`]), the first one
+/// storing the row indices of non-zero values, the second storing the
+/// corresponding column indices and the last array storing the corresponding
+/// scalar value. If a non-zero location is repeated in the arrays, the
+/// non-zero value is taken as the sum of the corresponding scalar entries.
+///
+/// [`row_inds`]: struct.TriMatBase.html#method.row_inds
+/// [`col_inds`]: struct.TriMatBase.html#method.col_inds
+/// [`data`]: struct.TriMatBase.html#method.data
+///
+/// This format is useful for iteratively building a sparse matrix, since the
+/// various non-zero entries can be specified in any order, or even partially
+/// as is common in physics with partial derivatives equations.
+///
+/// This format cannot be used for arithmetic operations. Arithmetic operations
+/// are more efficient in the [compressed format](struct.CsMatBase.html).
+/// A matrix in the triplet format can be converted to the compressed format
+/// using the methods [`to_csc`] and [`to_csr`].
+///
+/// [`to_csc`]: struct.TriMatBase.html#method.to_csc
+/// [`to_csr`]: struct.TriMatBase.html#method.to_csr
+#[derive(PartialEq, Debug)]
+pub struct TriMatBase<IStorage, DStorage> {
+    rows: usize,
+    cols: usize,
+    row_inds: IStorage,
+    col_inds: IStorage,
+    data: DStorage,
+}
+
+pub type TriMatI<N, I> = TriMatBase<Vec<I>, Vec<N>>;
+pub type TriMatViewI<'a, N, I> = TriMatBase<&'a [I], &'a [N]>;
+pub type TriMatViewMutI<'a, N, I> = TriMatBase<&'a mut [I], &'a mut [N]>;
+
+pub type TriMat<N> = TriMatI<N, usize>;
+pub type TriMatView<'a, N> = TriMatViewI<'a, N, usize>;
+pub type TriMatViewMut<'a, N> = TriMatViewMutI<'a, N, usize>;
+
 mod prelude {
     pub use super::{
         CsMatBase,
@@ -135,6 +176,13 @@ mod prelude {
         CsVecViewMut,
         CsVecI,
         CsVec,
+        TriMatBase,
+        TriMat,
+        TriMatI,
+        TriMatView,
+        TriMatViewI,
+        TriMatViewMut,
+        TriMatViewMutI,
     };
 }
 

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -5,7 +5,7 @@ pub use self::csmat::{CompressedStorage};
 
 /// Compressed matrix in the CSR or CSC format.
 #[derive(PartialEq, Debug)]
-pub struct CsMat<N, I, IptrStorage, IndStorage, DataStorage>
+pub struct CsMatBase<N, I, IptrStorage, IndStorage, DataStorage>
 where I: SpIndex,
       IptrStorage: Deref<Target=[I]>,
       IndStorage: Deref<Target=[I]>,
@@ -18,12 +18,12 @@ where I: SpIndex,
     data : DataStorage
 }
 
-pub type CsMatOwnedI<N, I> = CsMat<N, I, Vec<I>, Vec<I>, Vec<N>>;
-pub type CsMatViewI<'a, N, I> = CsMat<N, I, &'a [I], &'a [I], &'a [N]>;
-pub type CsMatViewMutI<'a, N, I> = CsMat<N, I, &'a [I], &'a [I], &'a mut [N]>;
-pub type CsMatVecView_<'a, N, I> = CsMat<N, I, Vec<I>, &'a [I], &'a [N]>;
+pub type CsMatI<N, I> = CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>>;
+pub type CsMatViewI<'a, N, I> = CsMatBase<N, I, &'a [I], &'a [I], &'a [N]>;
+pub type CsMatViewMutI<'a, N, I> = CsMatBase<N, I, &'a [I], &'a [I], &'a mut [N]>;
+pub type CsMatVecView_<'a, N, I> = CsMatBase<N, I, Vec<I>, &'a [I], &'a [N]>;
 
-pub type CsMatOwned<N> = CsMatOwnedI<N, usize>;
+pub type CsMat<N> = CsMatI<N, usize>;
 pub type CsMatView<'a, N> = CsMatViewI<'a, N, usize>;
 pub type CsMatViewMut<'a, N> = CsMatViewMutI<'a, N, usize>;
 // FIXME: a fixed size array would be better, but no Deref impl
@@ -49,13 +49,13 @@ pub type CsVecOwned<N> = CsVecOwnedI<N, usize>;
 
 mod prelude {
     pub use super::{
-        CsMat,
+        CsMatBase,
         CsMatViewI,
         CsMatView,
         CsMatViewMutI,
         CsMatViewMut,
-        CsMatOwnedI,
-        CsMatOwned,
+        CsMatI,
+        CsMat,
         CsMatVecView_,
         CsMatVecView,
         CsVec,

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -100,7 +100,32 @@ pub type CsMatViewMut<'a, N> = CsMatViewMutI<'a, N, usize>;
 pub type CsMatVecView<'a, N> = CsMatVecView_<'a, N, usize>;
 
 /// A sparse vector, storing the indices of its non-zero data.
-/// The indices should be sorted.
+///
+/// A `CsVec` represents a sparse vector by storing a sorted `indices()` array
+/// containing the locations of the non-zero values and a `data()` array
+/// containing the corresponding values. The format is compatible with `CsMat`,
+/// ie a `CsVec` can represent the row of a CSR matrix without any copying.
+///
+/// Similar to [`CsMat`] and [`TriMat`], the `CsVecBase` type is parameterized
+/// over the indexing storage backend `IStorage` and the data storage backend
+/// `DStorage`. Type aliases are provided for common cases: [`CsVec`] represents
+/// a sparse vector owning its data, with `Vec`s as storage backends;
+/// [`CsVecView`] represents a sparse vector borrowing its data, using slices
+/// as storage backends; and [`CsVecViewMut`] represents a sparse vector that
+/// mutably borrows its data (but immutably borrows its indices).
+///
+/// Additionaly, the type aliases [`CsVecI`], [`CsVecViewI`], and
+/// [`CsVecViewMutI`] can be used to choose an index type different from the
+/// default `usize`.
+///
+/// [`CsMat`]: struct.CsMatBase.html
+/// [`TriMat`]: struct.TriMatBase.html
+/// [`CsVec`]: type.CsVec.html
+/// [`CsVecView`]: type.CsVecView.html
+/// [`CsVecViewMut`]: type.CsVecViewMut.html
+/// [`CsVecI`]: type.CsVecI.html
+/// [`CsVecViewI`]: type.CsVecViewI.html
+/// [`CsVecViewMutI`]: type.CsVecViewMutI.html
 #[derive(PartialEq, Debug)]
 pub struct CsVecBase<N, IStorage, DStorage>
 where DStorage: Deref<Target=[N]> {
@@ -109,12 +134,12 @@ where DStorage: Deref<Target=[N]> {
     data : DStorage
 }
 
-pub type CsVecViewI<'a, N, I> = CsVecBase<N, &'a [I], &'a [N]>;
-pub type CsVecViewMut_<'a, N, I> = CsVecBase<N, &'a [I], &'a mut [N]>;
 pub type CsVecI<N, I> = CsVecBase<N, Vec<I>, Vec<N>>;
+pub type CsVecViewI<'a, N, I> = CsVecBase<N, &'a [I], &'a [N]>;
+pub type CsVecViewMutI<'a, N, I> = CsVecBase<N, &'a [I], &'a mut [N]>;
 
 pub type CsVecView<'a, N> = CsVecViewI<'a, N, usize>;
-pub type CsVecViewMut<'a, N> = CsVecViewMut_<'a, N, usize>;
+pub type CsVecViewMut<'a, N> = CsVecViewMutI<'a, N, usize>;
 pub type CsVec<N> = CsVecI<N, usize>;
 
 /// Sparse matrix in the triplet format.
@@ -191,7 +216,7 @@ mod prelude {
         CsVecBase,
         CsVecViewI,
         CsVecView,
-        CsVecViewMut_,
+        CsVecViewMutI,
         CsVecViewMut,
         CsVecI,
         CsVec,

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -61,7 +61,19 @@ pub use self::csmat::{CompressedStorage};
 /// ## Construction
 ///
 /// A sparse matrix can be directly constructed by providing its index pointer,
-/// indices and data arrays.
+/// indices and data arrays. The coherence of the provided structure is then
+/// verified.
+///
+/// For situations where the compressed structure is hard to figure out up front,
+/// the [triplet format](struct.TriMatBase.html) can be used. A matrix in the
+/// triplet format can then be efficiently converted to a `CsMat`.
+///
+/// Alternately, a sparse matrix can be constructed from other sparse matrices
+/// using [`vstack`], [`hstack`] or [`bmat`].
+///
+/// [`vstack`]: fn.vstack.html
+/// [`hstack`]: fn.hstack.html
+/// [`bmat`]: fn.bmat.html
 #[derive(PartialEq, Debug)]
 pub struct CsMatBase<N, I, IptrStorage, IndStorage, DataStorage>
 where I: SpIndex,

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -127,16 +127,15 @@ pub type CsMatVecView<'a, N> = CsMatVecView_<'a, N, usize>;
 /// [`CsVecViewI`]: type.CsVecViewI.html
 /// [`CsVecViewMutI`]: type.CsVecViewMutI.html
 #[derive(PartialEq, Debug)]
-pub struct CsVecBase<N, IStorage, DStorage>
-where DStorage: Deref<Target=[N]> {
+pub struct CsVecBase<IStorage, DStorage> {
     dim: usize,
     indices : IStorage,
     data : DStorage
 }
 
-pub type CsVecI<N, I> = CsVecBase<N, Vec<I>, Vec<N>>;
-pub type CsVecViewI<'a, N, I> = CsVecBase<N, &'a [I], &'a [N]>;
-pub type CsVecViewMutI<'a, N, I> = CsVecBase<N, &'a [I], &'a mut [N]>;
+pub type CsVecI<N, I> = CsVecBase<Vec<I>, Vec<N>>;
+pub type CsVecViewI<'a, N, I> = CsVecBase<&'a [I], &'a [N]>;
+pub type CsVecViewMutI<'a, N, I> = CsVecBase<&'a [I], &'a mut [N]>;
 
 pub type CsVecView<'a, N> = CsVecViewI<'a, N, usize>;
 pub type CsVecViewMut<'a, N> = CsVecViewMutI<'a, N, usize>;

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -32,20 +32,20 @@ pub type CsMatVecView<'a, N> = CsMatVecView_<'a, N, usize>;
 /// A sparse vector, storing the indices of its non-zero data.
 /// The indices should be sorted.
 #[derive(PartialEq, Debug)]
-pub struct CsVec<N, IStorage, DStorage>
+pub struct CsVecBase<N, IStorage, DStorage>
 where DStorage: Deref<Target=[N]> {
     dim: usize,
     indices : IStorage,
     data : DStorage
 }
 
-pub type CsVecViewI<'a, N, I> = CsVec<N, &'a [I], &'a [N]>;
-pub type CsVecViewMut_<'a, N, I> = CsVec<N, &'a [I], &'a mut [N]>;
-pub type CsVecOwnedI<N, I> = CsVec<N, Vec<I>, Vec<N>>;
+pub type CsVecViewI<'a, N, I> = CsVecBase<N, &'a [I], &'a [N]>;
+pub type CsVecViewMut_<'a, N, I> = CsVecBase<N, &'a [I], &'a mut [N]>;
+pub type CsVecI<N, I> = CsVecBase<N, Vec<I>, Vec<N>>;
 
 pub type CsVecView<'a, N> = CsVecViewI<'a, N, usize>;
 pub type CsVecViewMut<'a, N> = CsVecViewMut_<'a, N, usize>;
-pub type CsVecOwned<N> = CsVecOwnedI<N, usize>;
+pub type CsVec<N> = CsVecI<N, usize>;
 
 mod prelude {
     pub use super::{
@@ -58,13 +58,13 @@ mod prelude {
         CsMat,
         CsMatVecView_,
         CsMatVecView,
-        CsVec,
+        CsVecBase,
         CsVecViewI,
         CsVecView,
         CsVecViewMut_,
         CsVecViewMut,
-        CsVecOwnedI,
-        CsVecOwned,
+        CsVecI,
+        CsVec,
     };
 }
 

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -67,7 +67,7 @@ where N: Num + Copy {
 pub fn csr_mul_csr<N, I, Mat1, Mat2>(lhs: &Mat1,
                                      rhs: &Mat2,
                                      workspace: &mut[N]
-                                    ) -> CsMatOwnedI<N, I>
+                                    ) -> CsMatI<N, I>
 where
 N: Num + Copy,
 I: SpIndex,
@@ -89,7 +89,7 @@ Mat2: SpMatView<N, I>
 pub fn csc_mul_csc<N, I, Mat1, Mat2>(lhs: &Mat1,
                                      rhs: &Mat2,
                                      workspace: &mut[N]
-                                    ) -> CsMatOwnedI<N, I>
+                                    ) -> CsMatI<N, I>
 where
 N: Num + Copy,
 I: SpIndex,
@@ -126,7 +126,7 @@ where N: Copy + Num,
 pub fn csr_mul_csr_impl<N, I>(lhs: CsMatViewI<N, I>,
                               rhs: CsMatViewI<N, I>,
                               workspace: &mut[N]
-                             ) -> CsMatOwnedI<N, I>
+                             ) -> CsMatI<N, I>
 where N: Num + Copy,
       I: SpIndex
 {
@@ -142,7 +142,7 @@ where N: Num + Copy,
         panic!("Storage mismatch");
     }
 
-    let mut res = CsMatOwnedI::empty(lhs.storage(), res_cols);
+    let mut res = CsMatI::empty(lhs.storage(), res_cols);
     res.reserve_nnz_exact(lhs.nnz() + rhs.nnz());
     for lvec in lhs.outer_iterator() {
         // reset the accumulators
@@ -164,7 +164,7 @@ where N: Num + Copy,
         // compress the row into the resulting matrix
         res = res.append_outer(&workspace);
     }
-    // TODO: shrink res storage? would need methods on CsMatOwned
+    // TODO: shrink res storage? would need methods on CsMat
     assert_eq!(res_rows, res.rows());
     res
 }
@@ -362,7 +362,7 @@ where N: 'a + Num + Copy,
 
 #[cfg(test)]
 mod test {
-    use sparse::{CsMat, CsMatOwned, CsVec};
+    use sparse::{CsMatView, CsMat, CsVec};
     use sparse::csmat::CompressedStorage::{CSC, CSR};
     use super::{mul_acc_mat_vec_csc, mul_acc_mat_vec_csr, csr_mul_csr};
     use test_data::{mat1, mat2, mat1_self_matprod, mat1_matprod_mat2,
@@ -378,7 +378,11 @@ mod test {
             0.35310881, 0.42380633, 0.28035896, 0.58082095,
             0.53350123, 0.88132896, 0.72527863];
 
-        let mat = CsMat::new_view(CSC, (5, 5), indptr, indices, data).unwrap();
+        let mat = CsMatView::new_view(CSC,
+                                      (5, 5),
+                                      indptr,
+                                      indices,
+                                      data).unwrap();
         let vector = vec![0.1, 0.2, -0.1, 0.3, 0.9];
         let mut res_vec = vec![0., 0., 0., 0., 0.];
         mul_acc_mat_vec_csc(mat, &vector, &mut res_vec);
@@ -400,7 +404,11 @@ mod test {
             0.75672424, 0.1649078, 0.30140296, 0.10358244,
             0.6283315, 0.39244208, 0.57202407];
 
-        let mat = CsMat::new_view(CSR, (5, 5), indptr, indices, data).unwrap();
+        let mat = CsMatView::new_view(CSR,
+                                      (5, 5),
+                                      indptr,
+                                      indices,
+                                      data).unwrap();
         let vector = vec![0.1, 0.2, -0.1, 0.3, 0.9];
         let mut res_vec = vec![0., 0., 0., 0., 0.];
         mul_acc_mat_vec_csr(mat, &vector, &mut res_vec);
@@ -416,7 +424,7 @@ mod test {
 
     #[test]
     fn mul_csr_csr_identity() {
-        let eye: CsMatOwned<i32> = CsMat::eye(10);
+        let eye: CsMat<i32> = CsMat::eye(10);
         let mut workspace = [0; 10];
         let res = csr_mul_csr(&eye, &eye, &mut workspace);
         assert_eq!(eye, res);
@@ -500,7 +508,7 @@ mod test {
     #[test]
     fn mul_csr_dense_rowmaj() {
         let a = Array::eye(3);
-        let e: CsMatOwned<f64> = CsMat::eye(3);
+        let e: CsMat<f64> = CsMat::eye(3);
         let mut res = Array::zeros((3, 3));
         super::csr_mulacc_dense_rowmaj(e.view(),
                                        a.view(),

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -171,14 +171,14 @@ where N: Num + Copy,
 
 /// CSR-vector multiplication
 pub fn csr_mul_csvec<N, I>(lhs: CsMatViewI<N, I>,
-                           rhs: CsVecViewI<N, I>) -> CsVecOwnedI<N, I>
+                           rhs: CsVecViewI<N, I>) -> CsVecI<N, I>
 where N: Copy + Num,
       I: SpIndex,
 {
     if lhs.cols() != rhs.dim() {
         panic!("Dimension mismatch");
     }
-    let mut res = CsVecOwnedI::empty(lhs.rows());
+    let mut res = CsVecI::empty(lhs.rows());
     for (row_ind, lvec) in lhs.outer_iterator().enumerate() {
         let val = lvec.dot(&rhs);
         if val != N::zero() {

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -9,10 +9,12 @@ use ::Ix2;
 
 /// Multiply a sparse CSC matrix with a dense vector and accumulate the result
 /// into another dense vector
-pub fn mul_acc_mat_vec_csc<N>(mat: CsMatView<N>,
-                              in_vec: &[N],
-                              res_vec: &mut[N])
-where N: Num + Copy {
+pub fn mul_acc_mat_vec_csc<N, I>(mat: CsMatViewI<N, I>,
+                                 in_vec: &[N],
+                                 res_vec: &mut[N])
+where N: Num + Copy,
+      I: SpIndex,
+{
     let mat = mat.view();
     if mat.cols() != in_vec.len() || mat.rows() != res_vec.len() {
         panic!("Dimension mismatch");
@@ -33,10 +35,12 @@ where N: Num + Copy {
 
 /// Multiply a sparse CSR matrix with a dense vector and accumulate the result
 /// into another dense vector
-pub fn mul_acc_mat_vec_csr<N>(mat: CsMatView<N>,
-                              in_vec: &[N],
-                              res_vec: &mut[N])
-where N: Num + Copy {
+pub fn mul_acc_mat_vec_csr<N, I>(mat: CsMatViewI<N, I>,
+                                 in_vec: &[N],
+                                 res_vec: &mut[N])
+where N: Num + Copy,
+      I: SpIndex,
+{
     if mat.cols() != in_vec.len() || mat.rows() != res_vec.len() {
         panic!("Dimension mismatch");
     }

--- a/src/sparse/symmetric.rs
+++ b/src/sparse/symmetric.rs
@@ -6,7 +6,7 @@ use sparse::prelude::*;
 use indexing::SpIndex;
 
 pub fn is_symmetric<N, I, IpStorage, IStorage, DStorage>(
-    mat: &CsMat<N, I, IpStorage, IStorage, DStorage>) -> bool
+    mat: &CsMatBase<N, I, IpStorage, IStorage, DStorage>) -> bool
 where
 N: Copy + PartialEq,
 I: SpIndex,
@@ -31,7 +31,7 @@ DStorage: Deref<Target=[N]> {
 
 #[cfg(test)]
 mod test {
-    use sparse::CsMat;
+    use sparse::CsMatView;
     use sparse::csmat::CompressedStorage::{CSR};
     use super::is_symmetric;
 
@@ -61,7 +61,11 @@ mod test {
             0.13, 0.52, 0.11, 1.4,
             0.01, 0.53, 0.56, 3.1];
 
-        let a = CsMat::new_view(CSR, (10, 10), indptr, indices, data).unwrap();
+        let a = CsMatView::new_view(CSR,
+                                    (10, 10),
+                                    indptr,
+                                    indices,
+                                    data).unwrap();
 
         assert!(is_symmetric(&a));
     }

--- a/src/sparse/to_dense.rs
+++ b/src/sparse/to_dense.rs
@@ -32,12 +32,12 @@ where N: Clone, I: SpIndex
 #[cfg(test)]
 mod test {
     use ndarray::{Array, arr2};
-    use ::CsMatOwned;
+    use ::CsMat;
     use test_data::{mat1};
 
     #[test]
     fn to_dense() {
-        let speye: CsMatOwned<f64> = CsMatOwned::eye(3);
+        let speye: CsMat<f64> = CsMat::eye(3);
         let mut deye = Array::zeros((3, 3));
 
         super::assign_to_dense(deye.view_mut(), speye.view());
@@ -45,7 +45,7 @@ mod test {
         let res = Array::eye(3);
         assert_eq!(deye, res);
 
-        let speye: CsMatOwned<f64> = CsMatOwned::eye_csc(3);
+        let speye: CsMat<f64> = CsMat::eye_csc(3);
         let mut deye = Array::zeros((3, 3));
 
         super::assign_to_dense(deye.view_mut(), speye.view());

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -2,14 +2,14 @@
 ///!
 ///! Useful for building a matrix, but not for computations. Therefore this
 ///! struct is mainly used to initialize a matrix before converting to
-///! to a CsMatOwned.
+///! to a CsMat.
 ///!
 ///! A triplet format matrix is formed of three arrays of equal length, storing
 ///! the row indices, the column indices, and the values of the non-zero
 ///! entries. By convention, duplicate locations are summed up when converting
-///! into CsMatOwned.
+///! into CsMat.
 
-use sparse::{csmat, CsMatOwnedI};
+use sparse::{csmat, CsMatI};
 use num_traits::Num;
 use indexing::SpIndex;
 
@@ -209,14 +209,14 @@ impl<N, I: SpIndex> TriMatBase<N, I> {
     }
 
     /// Create a CSC matrix from this triplet matrix
-    pub fn to_csc(&self) -> CsMatOwnedI<N, I>
+    pub fn to_csc(&self) -> CsMatI<N, I>
     where N: Clone + Num
     {
         self.borrowed().to_csc()
     }
 
     /// Create a CSR matrix from this triplet matrix
-    pub fn to_csr(&self) -> CsMatOwnedI<N, I>
+    pub fn to_csr(&self) -> CsMatI<N, I>
     where N: Clone + Num
     {
         self.borrowed().to_csr()
@@ -283,7 +283,7 @@ impl<'a, N, I: SpIndex> TriMatViewBase<'a, N, I> {
     }
 
     /// Create a CSC matrix from this triplet matrix
-    pub fn to_csc(&self) -> CsMatOwnedI<N, I>
+    pub fn to_csc(&self) -> CsMatI<N, I>
     where N: Clone + Num
     {
         let mut row_counts = vec![I::zero(); self.rows() + 1];
@@ -364,7 +364,7 @@ impl<'a, N, I: SpIndex> TriMatViewBase<'a, N, I> {
                                     &mut out_indptr,
                                     &mut out_indices,
                                     &mut out_data);
-        CsMatOwnedI {
+        CsMatI {
             storage: csmat::CompressedStorage::CSC,
             nrows: self.rows,
             ncols: self.cols,
@@ -375,7 +375,7 @@ impl<'a, N, I: SpIndex> TriMatViewBase<'a, N, I> {
     }
 
     /// Create a CSR matrix from this triplet matrix
-    pub fn to_csr(&self) -> CsMatOwnedI<N, I>
+    pub fn to_csr(&self) -> CsMatI<N, I>
     where N: Clone + Num
     {
         let res = self.transpose_view().to_csc();
@@ -449,14 +449,14 @@ impl<'a, N, I: SpIndex> TriMatViewMutBase<'a, N, I> {
     }
 
     /// Create a CSC matrix from this triplet matrix
-    pub fn to_csc(&self) -> CsMatOwnedI<N, I>
+    pub fn to_csc(&self) -> CsMatI<N, I>
     where N: Clone + Num
     {
         self.borrowed().to_csc()
     }
 
     /// Create a CSR matrix from this triplet matrix
-    pub fn to_csr(&self) -> CsMatOwnedI<N, I>
+    pub fn to_csr(&self) -> CsMatI<N, I>
     where N: Clone + Num
     {
         self.borrowed().to_csr()
@@ -467,7 +467,7 @@ impl<'a, N, I: SpIndex> TriMatViewMutBase<'a, N, I> {
 mod test {
 
     use super::{TriMat, TriMatI};
-    use sparse::{CsMatOwned, CsMatOwnedI};
+    use sparse::{CsMat, CsMatI};
 
     #[test]
     fn triplet_incremental() {
@@ -483,8 +483,8 @@ mod test {
         triplet_mat.add_triplet(3, 2, 5.);
         triplet_mat.add_triplet(3, 3, 6.);
 
-        let csc: CsMatOwnedI<_, i32> = triplet_mat.to_csc();
-        let expected = CsMatOwnedI::new_csc((4, 4),
+        let csc: CsMatI<_, i32> = triplet_mat.to_csc();
+        let expected = CsMatI::new_csc((4, 4),
                                             vec![0, 2, 3, 4, 6],
                                             vec![0, 1, 0, 3, 2, 3],
                                             vec![1., 3., 2., 5., 4., 6.]);
@@ -510,7 +510,7 @@ mod test {
         triplet_mat.add_triplet(3, 2, 5.);
 
         let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc((4, 4),
+        let expected = CsMat::new_csc((4, 4),
                                            vec![0, 2, 3, 4, 6],
                                            vec![0, 1, 0, 3, 2, 3],
                                            vec![1., 3., 2., 5., 4., 6.]);
@@ -536,7 +536,7 @@ mod test {
         triplet_mat.add_triplet(3, 2, 2.);
 
         let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc((4, 4),
+        let expected = CsMat::new_csc((4, 4),
                                            vec![0, 2, 3, 4, 6],
                                            vec![0, 1, 0, 3, 2, 3],
                                            vec![1., 3., 2., 5., 4., 6.]);
@@ -560,7 +560,7 @@ mod test {
                                                            data);
 
         let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc((5, 4),
+        let expected = CsMat::new_csc((5, 4),
                                            vec![0, 2, 4, 5, 8],
                                            vec![0, 1, 0, 4, 3, 2, 3, 4],
                                            vec![1, 3, 2, 7, 5, 4, 6, 8]);
@@ -584,7 +584,7 @@ mod test {
 
 
         let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc((4, 4),
+        let expected = CsMat::new_csc((4, 4),
                                            vec![0, 2, 3, 4, 6],
                                            vec![0, 1, 0, 3, 2, 3],
                                            vec![1., 3., 2., 5., 0., 6.]);
@@ -610,7 +610,7 @@ mod test {
         triplet_mat.add_triplet(3, 2, 2.);
 
         let csr = triplet_mat.to_csr();
-        let expected = CsMatOwned::new_csc((4, 4),
+        let expected = CsMat::new_csc((4, 4),
                                            vec![0, 2, 3, 4, 6],
                                            vec![0, 1, 0, 3, 2, 3],
                                            vec![1., 3., 2., 5., 4., 6.])
@@ -657,7 +657,7 @@ mod test {
 
         let csc = triplet_mat.to_csc();
 
-        let expected = CsMatOwned::new_csc((6, 9),
+        let expected = CsMat::new_csc((6, 9),
                                            vec![0, 6, 7, 8, 10, 11,
                                                 14, 15, 16, 22],
                                            vec![0, 1, 2, 3, 4, 5, 2,

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -485,9 +485,9 @@ mod test {
 
         let csc: CsMatI<_, i32> = triplet_mat.to_csc();
         let expected = CsMatI::new_csc((4, 4),
-                                            vec![0, 2, 3, 4, 6],
-                                            vec![0, 1, 0, 3, 2, 3],
-                                            vec![1., 3., 2., 5., 4., 6.]);
+                                       vec![0, 2, 3, 4, 6],
+                                       vec![0, 1, 0, 3, 2, 3],
+                                       vec![1., 3., 2., 5., 4., 6.]);
         assert_eq!(csc, expected);
     }
 
@@ -511,9 +511,9 @@ mod test {
 
         let csc = triplet_mat.to_csc();
         let expected = CsMat::new_csc((4, 4),
-                                           vec![0, 2, 3, 4, 6],
-                                           vec![0, 1, 0, 3, 2, 3],
-                                           vec![1., 3., 2., 5., 4., 6.]);
+                                      vec![0, 2, 3, 4, 6],
+                                      vec![0, 1, 0, 3, 2, 3],
+                                      vec![1., 3., 2., 5., 4., 6.]);
         assert_eq!(csc, expected);
     }
 
@@ -537,9 +537,9 @@ mod test {
 
         let csc = triplet_mat.to_csc();
         let expected = CsMat::new_csc((4, 4),
-                                           vec![0, 2, 3, 4, 6],
-                                           vec![0, 1, 0, 3, 2, 3],
-                                           vec![1., 3., 2., 5., 4., 6.]);
+                                      vec![0, 2, 3, 4, 6],
+                                      vec![0, 1, 0, 3, 2, 3],
+                                      vec![1., 3., 2., 5., 4., 6.]);
         assert_eq!(csc, expected);
     }
 
@@ -561,9 +561,9 @@ mod test {
 
         let csc = triplet_mat.to_csc();
         let expected = CsMat::new_csc((5, 4),
-                                           vec![0, 2, 4, 5, 8],
-                                           vec![0, 1, 0, 4, 3, 2, 3, 4],
-                                           vec![1, 3, 2, 7, 5, 4, 6, 8]);
+                                      vec![0, 2, 4, 5, 8],
+                                      vec![0, 1, 0, 4, 3, 2, 3, 4],
+                                      vec![1, 3, 2, 7, 5, 4, 6, 8]);
 
         assert_eq!(csc, expected);
     }
@@ -585,9 +585,9 @@ mod test {
 
         let csc = triplet_mat.to_csc();
         let expected = CsMat::new_csc((4, 4),
-                                           vec![0, 2, 3, 4, 6],
-                                           vec![0, 1, 0, 3, 2, 3],
-                                           vec![1., 3., 2., 5., 0., 6.]);
+                                      vec![0, 2, 3, 4, 6],
+                                      vec![0, 1, 0, 3, 2, 3],
+                                      vec![1., 3., 2., 5., 0., 6.]);
         assert_eq!(csc, expected);
     }
 
@@ -611,9 +611,9 @@ mod test {
 
         let csr = triplet_mat.to_csr();
         let expected = CsMat::new_csc((4, 4),
-                                           vec![0, 2, 3, 4, 6],
-                                           vec![0, 1, 0, 3, 2, 3],
-                                           vec![1., 3., 2., 5., 4., 6.])
+                                      vec![0, 2, 3, 4, 6],
+                                      vec![0, 1, 0, 3, 2, 3],
+                                      vec![1., 3., 2., 5., 4., 6.])
                            .to_csr();
         assert_eq!(csr, expected);
     }
@@ -658,16 +658,11 @@ mod test {
         let csc = triplet_mat.to_csc();
 
         let expected = CsMat::new_csc((6, 9),
-                                           vec![0, 6, 7, 8, 10, 11,
-                                                14, 15, 16, 22],
-                                           vec![0, 1, 2, 3, 4, 5, 2,
-                                                3, 2, 4, 0, 1, 3, 5,
-                                                2, 5, 0, 1, 2, 3, 4,
-                                                5],
-                                           vec![1, 1, 1, 1, 1, 1, 2,
-                                                9, 3, 5, 6, 1, 4, 7,
-                                                3, 8, 2, 2, 2, 2, 2,
-                                                2]);
+                                      vec![0, 6, 7, 8, 10, 11, 14, 15, 16, 22],
+                                      vec![0, 1, 2, 3, 4, 5, 2, 3, 2, 4, 0, 1,
+                                           3, 5, 2, 5, 0, 1, 2, 3, 4, 5],
+                                      vec![1, 1, 1, 1, 1, 1, 2, 9, 3, 5, 6, 1,
+                                           4, 7, 3, 8, 2, 2, 2, 2, 2, 2]);
 
         assert_eq!(csc, expected);
 

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -466,12 +466,12 @@ impl<'a, N, I: SpIndex> TripletMatViewMutBase<'a, N, I> {
 #[cfg(test)]
 mod test {
 
-    use super::TripletMat;
-    use sparse::CsMatOwned;
+    use super::{TripletMat, TripletMatI};
+    use sparse::{CsMatOwned, CsMatOwnedI};
 
     #[test]
     fn triplet_incremental() {
-        let mut triplet_mat = TripletMat::with_capacity((4, 4), 6);
+        let mut triplet_mat = TripletMatI::with_capacity((4, 4), 6);
         // |1 2    |
         // |3      |
         // |      4|
@@ -483,11 +483,11 @@ mod test {
         triplet_mat.add_triplet(3, 2, 5.);
         triplet_mat.add_triplet(3, 3, 6.);
 
-        let csc = triplet_mat.to_csc();
-        let expected = CsMatOwned::new_csc((4, 4),
-                                           vec![0, 2, 3, 4, 6],
-                                           vec![0, 1, 0, 3, 2, 3],
-                                           vec![1., 3., 2., 5., 4., 6.]);
+        let csc: CsMatOwnedI<_, i32> = triplet_mat.to_csc();
+        let expected = CsMatOwnedI::new_csc((4, 4),
+                                            vec![0, 2, 3, 4, 6],
+                                            vec![0, 1, 0, 3, 2, 3],
+                                            vec![1., 3., 2., 5., 4., 6.]);
         assert_eq!(csc, expected);
     }
 

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -18,7 +18,7 @@ use indexing::SpIndex;
 pub struct TripletIndex(pub usize);
 
 /// Triplet matrix owning its data
-pub struct TripletMatBase<N, I> {
+pub struct TriMatBase<N, I> {
     rows: usize,
     cols: usize,
     row_inds: Vec<I>,
@@ -27,7 +27,7 @@ pub struct TripletMatBase<N, I> {
 }
 
 /// Triplet matrix view
-pub struct TripletMatViewBase<'a, N: 'a, I: 'a> {
+pub struct TriMatViewBase<'a, N: 'a, I: 'a> {
     rows: usize,
     cols: usize,
     row_inds: &'a [I],
@@ -36,7 +36,7 @@ pub struct TripletMatViewBase<'a, N: 'a, I: 'a> {
 }
 
 /// Triplet matrix mutable view
-pub struct TripletMatViewMutBase<'a, N: 'a, I: 'a> {
+pub struct TriMatViewMutBase<'a, N: 'a, I: 'a> {
     rows: usize,
     cols: usize,
     row_inds: &'a mut [I],
@@ -44,18 +44,18 @@ pub struct TripletMatViewMutBase<'a, N: 'a, I: 'a> {
     data: &'a mut [N],
 }
 
-pub type TripletMat<N> = TripletMatBase<N, usize>;
-pub type TripletMatView<'a, N> = TripletMatViewBase<'a, N, usize>;
-pub type TripletMatViewMut<'a, N> = TripletMatViewMutBase<'a, N, usize>;
-pub type TripletMatI<N, I> = TripletMatBase<N, I>;
-pub type TripletMatViewI<'a, N, I> = TripletMatViewBase<'a, N, I>;
-pub type TripletMatViewMutI<'a, N, I> = TripletMatViewMutBase<'a, N, I>;
+pub type TriMat<N> = TriMatBase<N, usize>;
+pub type TriMatView<'a, N> = TriMatViewBase<'a, N, usize>;
+pub type TriMatViewMut<'a, N> = TriMatViewMutBase<'a, N, usize>;
+pub type TriMatI<N, I> = TriMatBase<N, I>;
+pub type TriMatViewI<'a, N, I> = TriMatViewBase<'a, N, I>;
+pub type TriMatViewMutI<'a, N, I> = TriMatViewMutBase<'a, N, I>;
 
 
-impl<N, I: SpIndex> TripletMatBase<N, I> {
+impl<N, I: SpIndex> TriMatBase<N, I> {
     /// Create a new triplet matrix of shape `(nb_rows, nb_cols)`
-    pub fn new(shape: (usize, usize)) -> TripletMatBase<N, I> {
-        TripletMatBase {
+    pub fn new(shape: (usize, usize)) -> TriMatBase<N, I> {
+        TriMatBase {
             rows: shape.0,
             cols: shape.1,
             row_inds: Vec::new(),
@@ -66,8 +66,8 @@ impl<N, I: SpIndex> TripletMatBase<N, I> {
 
     /// Create a new triplet matrix of shape `(nb_rows, nb_cols)`, and
     /// pre-allocate `cap` elements on the backing storage
-    pub fn with_capacity(shape: (usize, usize), cap: usize) -> TripletMatBase<N, I> {
-        TripletMatBase {
+    pub fn with_capacity(shape: (usize, usize), cap: usize) -> TriMatBase<N, I> {
+        TriMatBase {
             rows: shape.0,
             cols: shape.1,
             row_inds: Vec::with_capacity(cap),
@@ -87,7 +87,7 @@ impl<N, I: SpIndex> TripletMatBase<N, I> {
                          row_inds: Vec<I>,
                          col_inds: Vec<I>,
                          data: Vec<N>)
-                         -> TripletMatBase<N, I> {
+                         -> TriMatBase<N, I> {
         assert!(row_inds.len() == col_inds.len(),
                 "all inputs should have the same length");
         assert!(data.len() == col_inds.len(),
@@ -98,7 +98,7 @@ impl<N, I: SpIndex> TripletMatBase<N, I> {
                 "row indices should be within shape");
         assert!(col_inds.iter().all(|&j| j.index() < shape.1),
                 "col indices should be within shape");
-        TripletMatBase {
+        TriMatBase {
             rows: shape.0,
             cols: shape.1,
             row_inds: row_inds,
@@ -148,8 +148,8 @@ impl<N, I: SpIndex> TripletMatBase<N, I> {
     }
 
     /// Return a view of this matrix
-    pub fn borrowed(&self) -> TripletMatViewBase<N, I> {
-        TripletMatViewBase {
+    pub fn borrowed(&self) -> TriMatViewBase<N, I> {
+        TriMatViewBase {
             rows: self.rows,
             cols: self.cols,
             row_inds: &self.row_inds[..],
@@ -170,8 +170,8 @@ impl<N, I: SpIndex> TripletMatBase<N, I> {
     }
 
     /// Get a mutable view into this matrix.
-    pub fn borrowed_mut(&mut self) -> TripletMatViewMutBase<N, I> {
-        TripletMatViewMutBase {
+    pub fn borrowed_mut(&mut self) -> TriMatViewMutBase<N, I> {
+        TriMatViewMutBase {
             rows: self.rows,
             cols: self.cols,
             row_inds: &mut self.row_inds[..],
@@ -181,7 +181,7 @@ impl<N, I: SpIndex> TripletMatBase<N, I> {
     }
 
     /// Get a transposed view of this matrix
-    pub fn transpose_view(&self) -> TripletMatViewBase<N, I> {
+    pub fn transpose_view(&self) -> TriMatViewBase<N, I> {
         self.borrowed().transpose_view()
     }
 
@@ -224,7 +224,7 @@ impl<N, I: SpIndex> TripletMatBase<N, I> {
 }
 
 
-impl<'a, N, I: SpIndex> TripletMatViewBase<'a, N, I> {
+impl<'a, N, I: SpIndex> TriMatViewBase<'a, N, I> {
     /// The number of rows of the matrix
     pub fn rows(&self) -> usize {
         self.rows
@@ -272,8 +272,8 @@ impl<'a, N, I: SpIndex> TripletMatViewBase<'a, N, I> {
     }
 
     /// Get a transposed view of this matrix
-    pub fn transpose_view(&self) -> TripletMatViewBase<'a, N, I> {
-        TripletMatViewBase {
+    pub fn transpose_view(&self) -> TriMatViewBase<'a, N, I> {
+        TriMatViewBase {
             rows: self.cols,
             cols: self.rows,
             row_inds: self.col_inds,
@@ -384,7 +384,7 @@ impl<'a, N, I: SpIndex> TripletMatViewBase<'a, N, I> {
 }
 
 
-impl<'a, N, I: SpIndex> TripletMatViewMutBase<'a, N, I> {
+impl<'a, N, I: SpIndex> TriMatViewMutBase<'a, N, I> {
     /// The number of rows of the matrix
     pub fn rows(&self) -> usize {
         self.borrowed().rows()
@@ -421,8 +421,8 @@ impl<'a, N, I: SpIndex> TripletMatViewMutBase<'a, N, I> {
     }
 
     /// Return a view of this matrix
-    pub fn borrowed(&self) -> TripletMatViewBase<N, I> {
-        TripletMatViewBase {
+    pub fn borrowed(&self) -> TriMatViewBase<N, I> {
+        TriMatViewBase {
             rows: self.rows,
             cols: self.cols,
             row_inds: &self.row_inds[..],
@@ -432,7 +432,7 @@ impl<'a, N, I: SpIndex> TripletMatViewMutBase<'a, N, I> {
     }
 
     /// Get a transposed view of this matrix
-    pub fn transpose_view(&self) -> TripletMatViewBase<N, I> {
+    pub fn transpose_view(&self) -> TriMatViewBase<N, I> {
         self.borrowed().transpose_view()
     }
 
@@ -466,12 +466,12 @@ impl<'a, N, I: SpIndex> TripletMatViewMutBase<'a, N, I> {
 #[cfg(test)]
 mod test {
 
-    use super::{TripletMat, TripletMatI};
+    use super::{TriMat, TriMatI};
     use sparse::{CsMatOwned, CsMatOwnedI};
 
     #[test]
     fn triplet_incremental() {
-        let mut triplet_mat = TripletMatI::with_capacity((4, 4), 6);
+        let mut triplet_mat = TriMatI::with_capacity((4, 4), 6);
         // |1 2    |
         // |3      |
         // |      4|
@@ -493,7 +493,7 @@ mod test {
 
     #[test]
     fn triplet_unordered() {
-        let mut triplet_mat = TripletMat::with_capacity((4, 4), 6);
+        let mut triplet_mat = TriMat::with_capacity((4, 4), 6);
         // |1 2    |
         // |3      |
         // |      4|
@@ -519,7 +519,7 @@ mod test {
 
     #[test]
     fn triplet_additions() {
-        let mut triplet_mat = TripletMat::with_capacity((4, 4), 6);
+        let mut triplet_mat = TriMat::with_capacity((4, 4), 6);
         // |1 2    |
         // |3      |
         // |      4|
@@ -554,7 +554,7 @@ mod test {
         let col_inds = vec![0, 1, 0, 3, 2, 3, 1, 3];
         let data = vec![1, 2, 3, 4, 5, 6, 7, 8];
 
-        let triplet_mat = super::TripletMat::from_triplets((5, 4),
+        let triplet_mat = super::TriMat::from_triplets((5, 4),
                                                            row_inds,
                                                            col_inds,
                                                            data);
@@ -570,7 +570,7 @@ mod test {
 
     #[test]
     fn triplet_mutate_entry() {
-        let mut triplet_mat = TripletMat::with_capacity((4, 4), 6);
+        let mut triplet_mat = TriMat::with_capacity((4, 4), 6);
         triplet_mat.add_triplet(0, 0, 1.);
         triplet_mat.add_triplet(0, 1, 2.);
         triplet_mat.add_triplet(1, 0, 3.);
@@ -593,7 +593,7 @@ mod test {
 
     #[test]
     fn triplet_to_csr() {
-        let mut triplet_mat = TripletMat::with_capacity((4, 4), 6);
+        let mut triplet_mat = TriMat::with_capacity((4, 4), 6);
         // |1 2    |
         // |3      |
         // |      4|
@@ -626,7 +626,7 @@ mod test {
         // |1   9     4     2|
         // |1     5         2|
         // |1         7   8 2|
-        let mut triplet_mat = TripletMat::with_capacity((6, 9), 22);
+        let mut triplet_mat = TriMat::with_capacity((6, 9), 22);
 
         triplet_mat.add_triplet(5, 8, 1); // (a) push 1 later
         triplet_mat.add_triplet(0, 0, 1);

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -364,10 +364,10 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsVecViewI<'a, N, I> {
     /// Create a borrowed CsVec over slice data.
     pub fn new_view(
         n: usize,
-        indices: &'a [usize],
+        indices: &'a [I],
         data: &'a [N])
-    -> Result<CsVecView<'a, N>, SprsError> {
-        let v = CsVecView {
+    -> Result<CsVecViewI<'a, N, I>, SprsError> {
+        let v = CsVecViewI {
             dim: n,
             indices: indices,
             data: data,
@@ -398,10 +398,10 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsVecViewI<'a, N, I> {
     /// perform unchecked slice access.
     pub unsafe fn new_view_raw(n: usize,
                                nnz: usize,
-                               indices: *const usize,
+                               indices: *const I,
                                data: *const N,
-                              ) -> CsVecView<'a, N> {
-        CsVecView {
+                              ) -> CsVecViewI<'a, N, I> {
+        CsVecViewI {
             dim: n,
             indices: slice::from_raw_parts(indices, nnz),
             data: slice::from_raw_parts(data, nnz),

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -700,7 +700,7 @@ where N: 'a,
         &mut self.data[..]
     }
 
-    pub fn view_mut(&mut self) -> CsVecViewMut_<N, I> {
+    pub fn view_mut(&mut self) -> CsVecViewMutI<N, I> {
         CsVecBase {
             dim: self.dim,
             indices: &self.indices[..],

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -588,7 +588,7 @@ where I: SpIndex,
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = vec![I::zero(), I::from_usize(self.indices.len())];
-        CsMat {
+        CsMatBase {
             storage: CSR,
             nrows: 1,
             ncols: self.dim,
@@ -603,7 +603,7 @@ where I: SpIndex,
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = vec![I::zero(), I::from_usize(self.indices.len())];
-        CsMat {
+        CsMatBase {
             storage: CSC,
             nrows: self.dim,
             ncols: 1,
@@ -760,7 +760,7 @@ where N: 'a {
 }
 
 impl<'a, 'b, N, I, IS1, DS1, IpS2, IS2, DS2>
-Mul<&'b CsMat<N, I, IpS2, IS2, DS2>>
+Mul<&'b CsMatBase<N, I, IpS2, IS2, DS2>>
 for &'a CsVec<N, IS1, DS1>
 where N: 'a + Copy + Num + Default,
       I: 'a + SpIndex,
@@ -772,14 +772,14 @@ where N: 'a + Copy + Num + Default,
 
     type Output = CsVecOwnedI<N, I>;
 
-    fn mul(self, rhs: &CsMat<N, I, IpS2, IS2, DS2>) -> CsVecOwnedI<N, I> {
+    fn mul(self, rhs: &CsMatBase<N, I, IpS2, IS2, DS2>) -> CsVecOwnedI<N, I> {
         (&self.row_view() * rhs).outer_view(0).unwrap().to_owned()
     }
 }
 
 impl<'a, 'b, N, I, IpS1, IS1, DS1, IS2, DS2>
 Mul<&'b CsVec<N, IS2, DS2>>
-for &'a CsMat<N, I, IpS1, IS1, DS1>
+for &'a CsMatBase<N, I, IpS1, IS1, DS1>
 where N: Copy + Num + Default,
       I: SpIndex,
       IpS1: Deref<Target=[I]>,

--- a/src/test_data.rs
+++ b/src/test_data.rs
@@ -1,44 +1,44 @@
 //! Some matrices used in tests
 
-use sparse::{CsMat, CsMatOwned};
+use sparse::CsMat;
 use ndarray::{arr2, Array, Ix2, ShapeBuilder};
 
-pub fn mat1() -> CsMatOwned<f64> {
+pub fn mat1() -> CsMat<f64> {
     let indptr = vec![0, 2, 4, 5, 6, 7];
     let indices = vec![2, 3, 3, 4, 2, 1, 3];
     let data = vec![3., 4., 2., 5., 5., 8., 7.];
     CsMat::new((5, 5), indptr, indices, data)
 }
 
-pub fn mat1_csc() -> CsMatOwned<f64> {
+pub fn mat1_csc() -> CsMat<f64> {
     let indptr = vec![0, 0, 1, 3, 6, 7];
     let indices = vec![3, 0, 2, 0, 1, 4, 1];
     let data = vec![8.,  3.,  5.,  4.,  2.,  7.,  5.];
     CsMat::new_csc((5, 5), indptr, indices, data)
 }
 
-pub fn mat2() -> CsMatOwned<f64> {
+pub fn mat2() -> CsMat<f64> {
     let indptr = vec![0,  4,  6,  6,  8, 10];
     let indices = vec![0, 1, 2, 4, 0, 3, 2, 3, 1, 2];
     let data = vec![6.,  7.,  3.,  3.,  8., 9.,  2.,  4.,  4.,  4.];
     CsMat::new((5, 5), indptr, indices, data)
 }
 
-pub fn mat3() -> CsMatOwned<f64> {
+pub fn mat3() -> CsMat<f64> {
     let indptr = vec![0, 2, 4, 5, 6, 7];
     let indices = vec![2, 3, 2, 3, 2, 1, 3];
     let data = vec![3., 4., 2., 5., 5., 8., 7.];
     CsMat::new((5, 4), indptr, indices, data)
 }
 
-pub fn mat4() -> CsMatOwned<f64> {
+pub fn mat4() -> CsMat<f64> {
     let indptr = vec![0,  4,  6,  6,  8, 10];
     let indices = vec![0, 1, 2, 4, 0, 3, 2, 3, 1, 2];
     let data = vec![6.,  7.,  3.,  3.,  8., 9.,  2.,  4.,  4.,  4.];
     CsMat::new_csc((5, 5), indptr, indices, data)
 }
 
-pub fn mat5() -> CsMatOwned<f64> {
+pub fn mat5() -> CsMat<f64> {
     let indptr = vec![0, 5, 11, 14, 20, 22];
     let indices = vec![1, 2, 6, 7, 13, 3, 4, 6, 8, 13, 14, 7, 11, 13, 3, 8, 9,
                        10, 11, 14, 4, 12];
@@ -48,7 +48,7 @@ pub fn mat5() -> CsMatOwned<f64> {
 }
 
 /// Returns the scalar product of mat1 and mat2
-pub fn mat1_times_2() -> CsMatOwned<f64> {
+pub fn mat1_times_2() -> CsMat<f64> {
     let indptr = vec![0, 2, 4, 5, 6, 7];
     let indices = vec![2, 3, 3, 4, 2, 1, 3];
     let data = vec![6., 8., 4., 10., 10., 16., 14.];
@@ -56,21 +56,21 @@ pub fn mat1_times_2() -> CsMatOwned<f64> {
 }
 
 // Matrix product of mat1 with itself
-pub fn mat1_self_matprod() -> CsMatOwned<f64> {
+pub fn mat1_self_matprod() -> CsMat<f64> {
     let indptr = vec![0, 2, 4, 5, 7, 8];
     let indices = vec![1, 2, 1, 3, 2, 3, 4, 1];
     let data = vec![32., 15., 16., 35., 25., 16., 40., 56.];
     CsMat::new((5, 5), indptr, indices, data)
 }
 
-pub fn mat1_matprod_mat2() -> CsMatOwned<f64> {
+pub fn mat1_matprod_mat2() -> CsMat<f64> {
     let indptr = vec![0, 2, 5, 5, 7, 9];
     let indices = vec![2, 3, 1, 2, 3, 0, 3, 2, 3];
     let data = vec![8., 16., 20., 24.,  8., 64., 72., 14., 28.];
     CsMat::new((5, 5), indptr, indices, data)
 }
 
-pub fn mat1_csc_matprod_mat4() -> CsMatOwned<f64> {
+pub fn mat1_csc_matprod_mat4() -> CsMat<f64> {
     let indptr = vec![0,  4,  7,  7, 11, 14];
     let indices = vec![0, 1, 2, 3, 0, 1, 4, 0, 1, 2, 4, 0, 2, 3];
     let data = vec![9., 15., 15., 56., 36., 18., 63., 22.,


### PR DESCRIPTION
Better documentation after the indexing refactor. Now each of the main types (`CsMat`, `TriMat`, `CsVec`) have dedicated documentations. Still a lot to document better but that's a step forward :)