### PR TITLE
use a fixed size array for storing indptr in CsMatVecView

### DIFF
--- a/src/array_backend.rs
+++ b/src/array_backend.rs
@@ -1,0 +1,25 @@
+//! Fixed size arrays usable for sparse matrices.
+//!
+//! Mainly useful to create a sparse matrix view over a sparse vector
+//! without allocation.
+
+use std::ops::{Deref, DerefMut};
+
+/// Wrapper around a size 2 array, with `Deref` implementation.
+pub struct Array2<T> {
+    pub data: [T; 2],
+}
+
+impl<T> Deref for Array2<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        &self.data[..]
+    }
+}
+
+impl<T> DerefMut for Array2<T> {
+    fn deref_mut(&mut self) -> &mut[T] {
+        &mut self.data[..]
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ mod sparse;
 pub mod errors;
 pub mod stack;
 pub mod indexing;
+pub mod array_backend;
 
 /// Deprecated type alias, will be removed on next breaking change
 pub type Ix_ = ndarray::Ix1;

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -18,6 +18,7 @@ use ndarray::{self, ArrayBase, Array, ShapeBuilder};
 use ::{Ix1, Ix2, Shape};
 
 use indexing::SpIndex;
+use array_backend::Array2;
 
 use sparse::prelude::*;
 use sparse::permutation::PermViewI;
@@ -1336,15 +1337,16 @@ impl<'a, N:'a, I: 'a + SpIndex> CsMatBase<N, I, Vec<I>, &'a [I], &'a [N]> {
     /// perform unchecked slice access.
     pub unsafe fn new_vecview_raw(
         storage: CompressedStorage, nrows : usize, ncols: usize,
-        indptr : Vec<I>, indices : *const I, data : *const N
+        indptr : *const I, indices : *const I, data : *const N
         )
     -> CsMatVecView_<'a, N, I> {
+        let indptr = slice::from_raw_parts(indptr, 2);
         let nnz = indptr[1].index();
         CsMatVecView_ {
             storage: storage,
             nrows : nrows,
             ncols: ncols,
-            indptr : indptr,
+            indptr : Array2 {data: [indptr[0], indptr[1]]},
             indices : slice::from_raw_parts(indices, nnz),
             data : slice::from_raw_parts(data, nnz),
         }

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -1,5 +1,6 @@
 use std::ops::Deref;
 use indexing::SpIndex;
+use array_backend::Array2;
 
 pub use self::csmat::{CompressedStorage};
 
@@ -91,7 +92,7 @@ where I: SpIndex,
 pub type CsMatI<N, I> = CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>>;
 pub type CsMatViewI<'a, N, I> = CsMatBase<N, I, &'a [I], &'a [I], &'a [N]>;
 pub type CsMatViewMutI<'a, N, I> = CsMatBase<N, I, &'a [I], &'a [I], &'a mut [N]>;
-pub type CsMatVecView_<'a, N, I> = CsMatBase<N, I, Vec<I>, &'a [I], &'a [N]>;
+pub type CsMatVecView_<'a, N, I> = CsMatBase<N, I, Array2<I>, &'a [I], &'a [N]>;
 
 pub type CsMat<N> = CsMatI<N, usize>;
 pub type CsMatView<'a, N> = CsMatViewI<'a, N, usize>;

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -30,6 +30,7 @@ use ::{Ix1};
 use num_traits::Num;
 
 use indexing::SpIndex;
+use array_backend::Array2;
 use sparse::permutation::PermViewI;
 use sparse::{prod, binop};
 use sparse::utils;
@@ -533,7 +534,9 @@ where I: SpIndex,
     pub fn row_view(&self) -> CsMatVecView_<N, I> {
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
-        let indptr = vec![I::zero(), I::from_usize(self.indices.len())];
+        let indptr = Array2 {
+            data: [I::zero(), I::from_usize(self.indices.len())],
+        };
         CsMatBase {
             storage: CSR,
             nrows: 1,
@@ -548,7 +551,9 @@ where I: SpIndex,
     pub fn col_view(&self) -> CsMatVecView_<N, I> {
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
-        let indptr = vec![I::zero(), I::from_usize(self.indices.len())];
+        let indptr = Array2 {
+            data: [I::zero(), I::from_usize(self.indices.len())],
+        };
         CsMatBase {
             storage: CSC,
             nrows: self.dim,


### PR DESCRIPTION
This avoids unnecessary heap allocations.