### PR TITLE
Permutation knows its dimention

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,8 @@ Changelog
     - refactor triplet matrix to use the same idioms used in compressed matrix
       **breaking change**
     - enhance documentation of main data structures
+    - permutation constructor for identity permutation now requires the dimension
+      on which the permutation should operate **breaking change**
 - 0.5.0
     - adapt to breaking changes in ndarray 0.7
 - 0.4.1:

--- a/sprs-ldl/src/lib.rs
+++ b/sprs-ldl/src/lib.rs
@@ -106,7 +106,8 @@ impl<I: SpIndex> LdlSymbolic<I> {
     pub fn new<N>(mat: CsMatViewI<N, I>) -> LdlSymbolic<I>
     where N: Copy + PartialEq,
     {
-        let perm: Permutation<I, Vec<I>> = Permutation::identity();
+        assert_eq!(mat.rows(), mat.cols());
+        let perm: Permutation<I, Vec<I>> = Permutation::identity(mat.rows());
         LdlSymbolic::new_perm(mat, perm)
     }
 
@@ -533,7 +534,7 @@ mod test {
         let mut parents = linalg::etree::ParentsOwned::new(10);
         let mut l_nz = [0; 10];
         let mut flag_workspace = [0; 10];
-        let perm: Permutation<usize, &[usize]> = Permutation::identity();
+        let perm: Permutation<usize, &[usize]> = Permutation::identity(10);
         let mat = test_mat1();
         super::ldl_symbolic(mat.view(),
                             &perm,

--- a/suitesparse_bindings/sprs_suitesparse_ldl/src/lib.rs
+++ b/suitesparse_bindings/sprs_suitesparse_ldl/src/lib.rs
@@ -57,7 +57,9 @@ macro_rules! ldl_impl {
             where N: Clone + Into<f64>,
                   I: SpIndex,
             {
-                $Symbolic::new_perm(mat, PermOwnedI::identity())
+                assert_eq!(mat.rows(), mat.cols());
+                let n = mat.rows();
+                $Symbolic::new_perm(mat, PermOwnedI::identity(n))
             }
 
             /// Compute the symbolic decomposition L D L^T = P A P^T
@@ -84,8 +86,8 @@ macro_rules! ldl_impl {
                 let valid_mat = unsafe { $valid_matrix(n_, ap, ai) };
                 assert!(valid_mat == 1);
                 let perm = perm.to_other_idx_type();
-                let p = perm.vec(n_);
-                let pinv = perm.inv_vec(n_);
+                let p = perm.vec();
+                let pinv = perm.inv_vec();
                 let mut flag = vec![0; n];
                 let valid_p = unsafe {
                     $valid_perm(n_, p.as_ptr(), flag.as_mut_ptr())


### PR DESCRIPTION
This means less disparity between the identity case and the rest. Now
an identity permutation cannot be used to permute any vector/matrix, but
only those of matching dimension.

Fixes #113.