### PR TITLE
Introduce a zero-sized vector as a "universal zero"

### DIFF
--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -179,6 +179,9 @@ pub fn csr_mul_csvec<N, I>(lhs: CsMatViewI<N, I>,
 where N: Copy + Num,
       I: SpIndex,
 {
+    if rhs.dim == 0 {
+        return rhs.to_owned();
+    }
     if lhs.cols() != rhs.dim() {
         panic!("Dimension mismatch");
     }
@@ -480,6 +483,12 @@ mod test {
         let res = &a * &v;
         let expected_output = CsVec::new(5, vec![0, 1, 2], vec![3., 5., 5.]);
         assert_eq!(expected_output, res);
+    }
+
+    #[test]
+    fn mul_csr_zero_csvec() {
+        let zero = CsVec::new(0, vec![], vec![]);
+        assert_eq!(&mat1() * &zero, zero);
     }
 
     #[test]

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -511,6 +511,10 @@ where I: SpIndex,
             return Err(SprsError::NonSortedIndices);
         }
 
+        if self.dim == 0 && self.indices.len() == 0 && self.data.len() == 0 {
+            return Ok(());
+        }
+
         let max_ind = self.indices.iter().max().unwrap_or(&I::zero()).index();
         if max_ind >= self.dim {
             panic!("Out of bounds index");
@@ -1165,5 +1169,10 @@ mod test {
             vec![0, 1, 3, 4, 5, 7],
             vec![2., 4., -1., -3., 8., -1.]);
         (a, b, expected_sum)
+    }
+
+    #[test]
+    fn can_construct_zero_sized_vectors() {
+        CsVec::<f64>::new(0, vec![], vec![]);
     }
 }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -27,7 +27,7 @@ use std::marker::PhantomData;
 use ndarray::{self, ArrayBase};
 use ::{Ix1};
 
-use num_traits::Num;
+use num_traits::{Num, Zero};
 
 use indexing::SpIndex;
 use array_backend::Array2;
@@ -965,11 +965,22 @@ where IS: Deref<Target=[usize]>,
     }
 }
 
+impl<N: Num + Copy, I: SpIndex> Zero for CsVecI<N, I> {
+    fn zero() -> CsVecI<N, I> {
+        CsVecI::new(0, vec![], vec![])
+    }
+
+    fn is_zero(&self) -> bool {
+        self.data.iter().all(|x| x.is_zero())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use sparse::{CsVec, CsVecI};
     use super::SparseIterTools;
     use ndarray::Array;
+    use num_traits::Zero;
 
     fn test_vec1() -> CsVec<f64> {
         let n = 8;
@@ -1174,5 +1185,23 @@ mod test {
     #[test]
     fn can_construct_zero_sized_vectors() {
         CsVec::<f64>::new(0, vec![], vec![]);
+    }
+
+    #[test]
+    fn zero_element_vanishes_when_added() {
+        let zero = CsVec::<f64>::zero();
+        let vector = CsVec::new(3, vec![0, 2], vec![1., 2.]);
+        assert_eq!(&vector + &zero, vector);
+    }
+
+    #[test]
+    fn zero_element_is_identified_as_zero() {
+        assert!(CsVec::<f32>::zero().is_zero());
+    }
+
+    #[test]
+    fn larger_zero_vector_is_identified_as_zero() {
+        let vector = CsVec::new(3, vec![1, 2], vec![0., 0.]);
+        assert!(vector.is_zero());
     }
 }


### PR DESCRIPTION
See the discussion in #118 for motivation.

~~`Zero` from num-traits has not been implemented yet~~

Also left out was the multiplication of that vector to a matrix from the left. It is more involved, as the left vector is treated like a matrix. A possible solution would be to extend the universal zero concept to matrices.

For now, the above step seems out-of-scope for this PR.

**EDIT:** changed my mind to include the `Zero` trait impl.