### PR TITLE
Alga integration: additive group for sparse vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,10 @@ default = ["alga"]
 num-traits = "0.1.32"
 ndarray = "0.10.0"
 alga = { version = "0.5", optional = true }
+
+[dev-dependencies]
+bencher = "0.1"
+
+[[bench]]
+name = "suite"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,10 @@ exclude = [
     "data/*"
 ]
 
+[features]
+default = ["alga"]
+
 [dependencies]
-
 num-traits = "0.1.32"
-
-
-[dependencies.ndarray]
-version = "0.10.0"
-
+ndarray = "0.10.0"
+alga = { version = "0.5", optional = true }

--- a/benches/suite.rs
+++ b/benches/suite.rs
@@ -1,0 +1,25 @@
+#[macro_use]
+extern crate bencher;
+extern crate sprs;
+extern crate alga;
+
+use bencher::Bencher;
+use sprs::CsVec;
+use alga::general::{Inverse, Additive};
+
+fn csvec_neg(bench: &mut Bencher) {
+    let vector = CsVec::new(10000, (10..9000).collect::<Vec<_>>(), vec![-1.3; 8990]);
+    bench.iter(|| {
+        -vector.clone()
+    });
+}
+
+fn csvec_additive_inverse(bench: &mut Bencher) {
+    let vector = CsVec::new(10000, (10..9000).collect::<Vec<_>>(), vec![-1.3; 8990]);
+    bench.iter(|| {
+        Inverse::<Additive>::inverse(&vector)
+    });
+}
+
+benchmark_group!(benches, csvec_neg, csvec_additive_inverse);
+benchmark_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@ assert_eq!(a, b.to_csc());
 
 extern crate num_traits;
 extern crate ndarray;
+#[cfg(feature = "alga")]
+extern crate alga;
 
 mod sparse;
 pub mod errors;

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -127,7 +127,7 @@ pub type CsMatVecView<'a, N> = CsMatVecView_<'a, N, usize>;
 /// [`CsVecI`]: type.CsVecI.html
 /// [`CsVecViewI`]: type.CsVecViewI.html
 /// [`CsVecViewMutI`]: type.CsVecViewMutI.html
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct CsVecBase<IStorage, DStorage> {
     dim: usize,
     indices : IStorage,

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -993,6 +993,8 @@ mod alga_impls {
     }
 
     impl<N: Copy + Num, I: SpIndex> AbstractSemigroup<Additive> for CsVecI<N, I> {}
+
+    impl<N: Copy + Num, I: SpIndex> AbstractMonoid<Additive> for CsVecI<N, I> {}
 }
 
 #[cfg(test)]

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1012,7 +1012,11 @@ mod alga_impls {
               I: SpIndex
     {
         fn inverse(&self) -> CsVecI<N, I> {
-            -self.clone()
+            CsVecBase {
+                data: self.data.iter().map(|x| -*x).collect(),
+                indices: self.indices.clone(),
+                dim: self.dim
+            }
         }
     }
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1016,6 +1016,12 @@ mod alga_impls {
         }
     }
 
+    impl<N: Copy + Num + Neg<Output=N>, I: SpIndex> AbstractQuasigroup<Additive> for CsVecI<N, I> {}
+
+    impl<N: Copy + Num + Neg<Output=N>, I: SpIndex> AbstractLoop<Additive> for CsVecI<N, I> {}
+
+    impl<N: Copy + Num + Neg<Output=N>, I: SpIndex> AbstractGroup<Additive> for CsVecI<N, I> {}
+
     #[cfg(test)]
     mod test {
         use super::*;

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -991,6 +991,8 @@ mod alga_impls {
             CsVecI::zero()
         }
     }
+
+    impl<N: Copy + Num, I: SpIndex> AbstractSemigroup<Additive> for CsVecI<N, I> {}
 }
 
 #[cfg(test)]

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1006,6 +1006,26 @@ mod alga_impls {
     impl<N: Copy + Num, I: SpIndex> AbstractSemigroup<Additive> for CsVecI<N, I> {}
 
     impl<N: Copy + Num, I: SpIndex> AbstractMonoid<Additive> for CsVecI<N, I> {}
+
+    impl<N, I> Inverse<Additive> for CsVecI<N, I>
+        where N: Clone + Neg<Output=N> + Copy + Num,
+              I: SpIndex
+    {
+        fn inverse(&self) -> CsVecI<N, I> {
+            -self.clone()
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn additive_inverse_is_negated() {
+            let vector = CsVec::new(2, vec![0], vec![2.]);
+            assert_eq!(-vector.clone(), Inverse::<Additive>::inverse(&vector));
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -975,6 +975,18 @@ impl<N: Num + Copy, I: SpIndex> Zero for CsVecI<N, I> {
     }
 }
 
+#[cfg(feature = "alga")]
+mod alga_impls {
+    use super::*;
+    use alga::general::*;
+
+    impl<N: Clone + Copy + Num, I: Clone + SpIndex> AbstractMagma<Additive> for CsVecI<N, I> {
+        fn operate(&self, right: &CsVecI<N, I>) -> CsVecI<N, I> {
+            self + right
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use sparse::{CsVec, CsVecI};

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -985,6 +985,12 @@ mod alga_impls {
             self + right
         }
     }
+
+    impl<N: Copy + Num, I: SpIndex> Identity<Additive> for CsVecI<N, I> {
+        fn identity() -> CsVecI<N, I> {
+            CsVecI::zero()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -17,7 +17,7 @@
 /// ```
 
 use std::iter::{Zip, Peekable, FilterMap, IntoIterator, Enumerate};
-use std::ops::{Deref, DerefMut, Mul, Add, Sub, Index, IndexMut};
+use std::ops::{Deref, DerefMut, Mul, Add, Sub, Index, IndexMut, Neg};
 use std::convert::AsRef;
 use std::cmp;
 use std::slice::{self, Iter, IterMut};
@@ -923,6 +923,17 @@ where N: Copy + Num,
     }
 }
 
+impl<N: Num + Copy + Neg<Output=N>, I: SpIndex> Neg for CsVecI<N, I> {
+    type Output = CsVecI<N, I>;
+
+    fn neg(mut self) -> CsVecI<N, I> {
+        for value in &mut self.data {
+            *value = -*value;
+        }
+        self
+    }
+}
+
 impl<N, IS, DS> Index<usize> for CsVecBase<IS, DS>
 where IS: Deref<Target=[usize]>,
       DS: Deref<Target=[N]> {
@@ -1202,6 +1213,13 @@ mod test {
             vec![0, 1, 3, 4, 5, 7],
             vec![2., 4., -1., -3., 8., -1.]);
         (a, b, expected_sum)
+    }
+
+    #[test]
+    fn negates_vectors() {
+        let vector = CsVec::new(4, vec![0, 3], vec![2., -3.]);
+        let negated = CsVec::new(4, vec![0, 3], vec![-2., 3.]);
+        assert_eq!(-vector, negated);
     }
 
     #[test]

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1027,6 +1027,18 @@ mod alga_impls {
         use super::*;
 
         #[test]
+        fn additive_operator_is_addition() {
+            let a = CsVec::new(2, vec![0], vec![2.]);
+            let b = CsVec::new(2, vec![0], vec![3.]);
+            assert_eq!(AbstractMagma::<Additive>::operate(&a, &b), &a + &b);
+        }
+
+        #[test]
+        fn additive_identity_is_zero() {
+            assert_eq!(CsVec::<f64>::zero(), Identity::<Additive>::identity());
+        }
+
+        #[test]
         fn additive_inverse_is_negated() {
             let vector = CsVec::new(2, vec![0], vec![2.]);
             assert_eq!(-vector.clone(), Inverse::<Additive>::inverse(&vector));

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1022,6 +1022,8 @@ mod alga_impls {
 
     impl<N: Copy + Num + Neg<Output=N>, I: SpIndex> AbstractGroup<Additive> for CsVecI<N, I> {}
 
+    impl<N: Copy + Num + Neg<Output=N>, I: SpIndex> AbstractGroupAbelian<Additive> for CsVecI<N, I> {}
+
     #[cfg(test)]
     mod test {
         use super::*;


### PR DESCRIPTION
So far for now. I added alga as an optional dependency that is part of the default features. The implementation so far only covers the algebraic structure up to an additive group. It was necessary to implement the negation operator for vectors as well.

Note that this is based on #120.