### PR TITLE
install suitesparse in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
 
+before_install:
+    - sudo apt-get install libsuitesparse-dev
+
 matrix:
   include:
     - rust: stable


### PR DESCRIPTION
The travis CI build used to silently fail because of this. Having all tests run properly has highlighted the missing dependency.