### PR TITLE
change ndarray version from 0.10.0 to 0.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["alga"]
 
 [dependencies]
 num-traits = "0.1.32"
-ndarray = "0.10.0"
+ndarray = "0.11.2"
 alga = { version = "0.5", optional = true }
 num-complex = "0.1.36"
 


### PR DESCRIPTION
Using the old ndarray dependency conflicts with the most recent version.

Upgrade seems straightforward. All tests pass.