### PR TITLE
Improve verbosity of panic messages in CsMat

### DIFF
--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1077,14 +1077,26 @@ where
         let outer = self.outer_dims();
 
         if self.indptr.len() != outer + 1 {
-            panic!("Indptr length does not match dimension");
+            panic!(
+                "Indptr length does not match dimension: {} != {}",
+                self.indptr.len(),
+                outer + 1
+            );
         }
         if self.indices.len() != self.data.len() {
-            panic!("Indices and data lengths do not match");
+            panic!(
+                "Indices and data lengths do not match: {} != {}",
+                self.indices.len(),
+                self.data.len()
+            );
         }
         let nnz = self.indices.len();
         if nnz != self.nnz() {
-            panic!("Indices length and inpdtr's nnz do not match");
+            panic!(
+                "Indices length and inpdtr's nnz do not match: {} != {}",
+                nnz,
+                self.nnz()
+            );
         }
         if let Some(&max_indptr) = self.indptr.iter().max() {
             if max_indptr.index() > nnz {


### PR DESCRIPTION
This improves verbosity of some panic messages in `CsMat`.

Currently, on the following example,
```rust
use sprs::CsMat;

let indptr = vec![0, 5, 8];
let indices = vec![761698, 328290, 828689, 761698, 780185, 901149, 780185, 144749, 258307];
let data = vec![1, 1, 1, 1, 1, 1, 1, 1, 1];
let a = CsMat::new_csc((2, 1000000), indptr, indices, data);
```

I'm getting an obscure `Indptr length does not match dimension` panic message, so this improves the verbosity of such messages a bit, to show the lengths.