### PR TITLE
Support recycling internal containers of vectors & matrices

### DIFF
--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -816,6 +816,27 @@ where
         &self.data[..]
     }
 
+    /// Destruct the matrix object and recycle its storage containers.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use sprs::{CsMat};
+    /// let (indptr, indices, data) = CsMat::<i32>::eye(3).into_raw_storage();
+    /// assert_eq!(indptr, vec![0, 1, 2, 3]);
+    /// assert_eq!(indices, vec![0, 1, 2]);
+    /// assert_eq!(data, vec![1, 1, 1]);
+    /// ```
+    pub fn into_raw_storage(self) -> (IptrStorage, IndStorage, DataStorage) {
+        let Self {
+            indptr,
+            indices,
+            data,
+            ..
+        } = self;
+        (indptr, indices, data)
+    }
+
     /// Test whether the matrix is in CSC storage
     pub fn is_csc(&self) -> bool {
         self.storage == CSC

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -606,6 +606,12 @@ where
         &self.data
     }
 
+    /// Destruct the vector object and recycle its storage containers.
+    pub fn into_raw_storage(self) -> (IStorage, DStorage) {
+        let Self { indices, data, .. } = self;
+        (indices, data)
+    }
+
     /// The dimension of this vector.
     pub fn dim(&self) -> usize {
         self.dim


### PR DESCRIPTION
The obvious use case is when one only wants to keep some internal storage of a vector / matrix object (e.g. non-zero values stored in `data`) and doesn't need the object itself any more.

This also makes vector / matrix transformation more flexible. E.g. one might wants to map inner indices with some bijective function, and the resulting indices could go beyond the original dimension, which would cause `modify` to panic. With `into_raw_storage`, one can pull out the guts of a matrix / vector object, perform arbitrary transformations while avoiding memory copying / allocation if possible, and create a new object using these old storage objects when they are done.