### PR TITLE
update to rustfmt 1.0 (Rust 1.31)

### DIFF
--- a/.travis_rustfmt
+++ b/.travis_rustfmt
@@ -5,6 +5,6 @@ set -ev
 if [ -z ${RUN_RUSTFMT+x} ]; then
     echo "Not on stable channel: skipping rustfmt."
 else
-    rustup component add rustfmt-preview
+    rustup component add rustfmt
     cargo fmt --all -- --check -v
 fi

--- a/Guidelines.rst
+++ b/Guidelines.rst
@@ -36,7 +36,7 @@ using ``rustfmt`` on the latest stable Rust channel:
 .. code-block:: console
 
   rustup default stable
-  rustup component add rustfmt-preview
+  rustup component add rustfmt
   cargo fmt --all
 
 .. _rustfmt: https://github.com/rust-lang-nursery/rustfmt

--- a/sprs-ldl/src/lib.rs
+++ b/sprs-ldl/src/lib.rs
@@ -606,7 +606,8 @@ mod test {
             &expected_lp,
             &expected_li,
             &expected_lx,
-        ).unwrap();
+        )
+        .unwrap();
         super::ldl_lsolve(&l, &mut x);
         assert_eq!(&x, &expected_lsolve_res1());
         linalg::diag_solve(&expected_d, &mut x);

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -121,7 +121,8 @@ where
             row.as_ref().iter().fold(0, |nrows, mopt| {
                 mopt.as_ref().map_or(nrows, |m| cmp::max(nrows, m.rows()))
             })
-        }).collect();
+        })
+        .collect();
     let cols_per_col: Vec<_> = (0..super_cols)
         .map(|j| {
             mats.iter().fold(0, |ncols, row| {
@@ -129,7 +130,8 @@ where
                     .as_ref()
                     .map_or(ncols, |m| cmp::max(ncols, m.cols()))
             })
-        }).collect();
+        })
+        .collect();
     let mut to_vstack = Vec::new();
     to_vstack.reserve(super_rows);
     for (i, row) in mats.iter().enumerate() {
@@ -140,7 +142,8 @@ where
             .map(|(j, m)| {
                 let shape = (rows_per_row[i], cols_per_col[j]);
                 m.as_ref().map_or(CsMat::zero(shape), |x| x.to_owned())
-            }).collect();
+            })
+            .collect();
         let borrows: Vec<_> = with_zeros.iter().map(|x| x.view()).collect();
         let stacked = hstack(&borrows);
         to_vstack.push(stacked);

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -2050,14 +2050,22 @@ mod test {
             0.05734571, 0.15543348, 0.75628258, 0.83054515, 0.71851547,
             0.46202352,
         ];
-        assert!(
-            CsMatView::new_view(CSR, (3, 4), indptr_ok, indices_ok, data_ok)
-                .is_ok()
-        );
-        assert!(
-            CsMatView::new_view(CSC, (4, 3), indptr_ok, indices_ok, data_ok)
-                .is_ok()
-        );
+        assert!(CsMatView::new_view(
+            CSR,
+            (3, 4),
+            indptr_ok,
+            indices_ok,
+            data_ok
+        )
+        .is_ok());
+        assert!(CsMatView::new_view(
+            CSC,
+            (4, 3),
+            indptr_ok,
+            indices_ok,
+            data_ok
+        )
+        .is_ok());
     }
 
     #[test]
@@ -2079,10 +2087,14 @@ mod test {
         let indptr_ok = vec![0, 1, 2, 3];
         let indices_ok = vec![0, 1, 2];
         let data_ok: Vec<f64> = vec![1., 1., 1.];
-        assert!(
-            CsMatView::new_view(CSR, (3, 3), &indptr_ok, &indices_ok, &data_ok)
-                .is_ok()
-        );
+        assert!(CsMatView::new_view(
+            CSR,
+            (3, 3),
+            &indptr_ok,
+            &indices_ok,
+            &data_ok
+        )
+        .is_ok());
     }
 
     #[test]
@@ -2115,9 +2127,7 @@ mod test {
             0.75672424, 0.1649078, 0.30140296, 0.10358244, 0.6283315,
             0.39244208, 0.57202407,
         ];
-        assert!(
-            CsMatView::new_view(CSR, (5, 5), indptr, indices, data).is_ok()
-        );
+        assert!(CsMatView::new_view(CSR, (5, 5), indptr, indices, data).is_ok());
     }
 
     #[test]

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -440,7 +440,8 @@ mod test {
             &mut dstack,
             &mut xw,
             &mut visited,
-        ).unwrap();
+        )
+        .unwrap();
 
         let x: HashSet<_> = dstack
             .iter_right()
@@ -477,7 +478,8 @@ mod test {
             &mut dstack,
             &mut xw,
             &mut visited,
-        ).unwrap();
+        )
+        .unwrap();
         let x: HashSet<_> = dstack
             .iter_right()
             .map(stack::extract_stack_val)

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -383,12 +383,10 @@ mod test {
 
         let epsilon = 1e-7; // TODO: get better values and increase precision
 
-        assert!(
-            res_vec
-                .iter()
-                .zip(expected_output.iter())
-                .all(|(x, y)| (*x - *y).abs() < epsilon)
-        );
+        assert!(res_vec
+            .iter()
+            .zip(expected_output.iter())
+            .all(|(x, y)| (*x - *y).abs() < epsilon));
     }
 
     #[test]
@@ -411,12 +409,10 @@ mod test {
 
         let epsilon = 1e-7; // TODO: get better values and increase precision
 
-        assert!(
-            res_vec
-                .iter()
-                .zip(expected_output.iter())
-                .all(|(x, y)| (*x - *y).abs() < epsilon)
-        );
+        assert!(res_vec
+            .iter()
+            .zip(expected_output.iter())
+            .all(|(x, y)| (*x - *y).abs() < epsilon));
     }
 
     #[test]
@@ -543,11 +539,10 @@ mod test {
             [43.4, 54.1, 12.65, 44.35, 39.9, 23.4, 76.6],
         ]);
         let eps = 1e-8;
-        assert!(
-            res.iter()
-                .zip(expected_output.iter())
-                .all(|(&x, &y)| (x - y).abs() <= eps)
-        );
+        assert!(res
+            .iter()
+            .zip(expected_output.iter())
+            .all(|(&x, &y)| (x - y).abs() <= eps));
     }
 
     #[test]

--- a/src/sparse/symmetric.rs
+++ b/src/sparse/symmetric.rs
@@ -21,9 +21,11 @@ where
         for (inner_ind, &value) in vec.iter() {
             match mat.get_outer_inner(inner_ind, outer_ind) {
                 None => return false,
-                Some(&transposed_val) => if transposed_val != value {
-                    return false;
-                },
+                Some(&transposed_val) => {
+                    if transposed_val != value {
+                        return false;
+                    }
+                }
             }
         }
     }

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -483,7 +483,8 @@ mod test {
             vec![0, 2, 3, 4, 6],
             vec![0, 1, 0, 3, 2, 3],
             vec![1., 3., 2., 5., 4., 6.],
-        ).to_csr();
+        )
+        .to_csr();
         assert_eq!(csr, expected);
     }
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1184,19 +1184,23 @@ mod alga_impls {
 
     impl<N: Copy + Num + Neg<Output = N>, I: SpIndex>
         AbstractQuasigroup<Additive> for CsVecI<N, I>
-    {}
+    {
+    }
 
     impl<N: Copy + Num + Neg<Output = N>, I: SpIndex> AbstractLoop<Additive>
         for CsVecI<N, I>
-    {}
+    {
+    }
 
     impl<N: Copy + Num + Neg<Output = N>, I: SpIndex> AbstractGroup<Additive>
         for CsVecI<N, I>
-    {}
+    {
+    }
 
     impl<N: Copy + Num + Neg<Output = N>, I: SpIndex>
         AbstractGroupAbelian<Additive> for CsVecI<N, I>
-    {}
+    {
+    }
 
     #[cfg(test)]
     mod test {


### PR DESCRIPTION
[Rustfmt 1.0](https://blog.rust-lang.org/2018/12/17/Rust-2018-dev-tools.html#rustfmt)

Now that Rustfmt is 1.0, this should be the last regular update required to keep up with Rust versions for a while (update may be required for the eventual Rustfmt 2.0 release expected "some time in late 2019"). Rustmft will continue to add new features, but they will be featured gated for all Rustfmt 1.x versions.