### PR TITLE
expand ndarray version req: work with 0.11.x and 0.12.x. Fixes #142

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["alga"]
 
 [dependencies]
 num-traits = "0.1.32"
-ndarray = "0.11.2"
+ndarray = ">=0.11, <0.13"
 alga = { version = "0.5", optional = true }
 num-complex = "0.1.36"
 


### PR DESCRIPTION
Fixes #142