### PR TITLE
Fix some `cargo clippy` warnings

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -83,7 +83,7 @@ enum DataType {
     Complex,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum SymmetryMode {
     General,
     Hermitian,
@@ -151,7 +151,7 @@ where
     loop {
         line.clear();
         let len = reader.read_line(&mut line)?;
-        if len == 0 || line.starts_with("%") {
+        if len == 0 || line.starts_with('%') {
             continue;
         } else {
             break;
@@ -291,19 +291,19 @@ where
         NumKind::Float => "real",
         NumKind::Complex => "complex",
     };
-    write!(
+    writeln!(
         writer,
-        "%%MatrixMarket matrix coordinate {} general\n",
+        "%%MatrixMarket matrix coordinate {} general",
         data_type
     )?;
-    write!(writer, "% written by sprs\n")?;
+    writeln!(writer, "% written by sprs")?;
 
     // dimensions and nnz
-    write!(writer, "{} {} {}\n", rows, cols, nnz)?;
+    writeln!(writer, "{} {} {}", rows, cols, nnz)?;
 
     // entries
     for (val, (row, col)) in mat.into_iter() {
-        write!(writer, "{} {} {}\n", row.index() + 1, col.index() + 1, val)?;
+        writeln!(writer, "{} {} {}", row.index() + 1, col.index() + 1, val)?;
     }
     Ok(())
 }
@@ -346,12 +346,12 @@ where
         SymmetryMode::SkewSymmetric => "skew-symmetric",
         SymmetryMode::Hermitian => "hermitian",
     };
-    write!(
+    writeln!(
         writer,
-        "%%MatrixMarket matrix coordinate {} {}\n",
+        "%%MatrixMarket matrix coordinate {} {}",
         data_type, mode
     )?;
-    write!(writer, "% written by sprs\n")?;
+    writeln!(writer, "% written by sprs")?;
 
     // We cannot know in advance how many entries will be written since
     // this is affected by the symmetry mode. However, we do know that it
@@ -361,16 +361,16 @@ where
     // replacing possible extra digits by spaces.
     let dim_header_pos = writer.seek(SeekFrom::Current(0))?;
     // dimensions and nnz
-    write!(writer, "{} {} {}\n", rows, cols, nnz)?;
+    writeln!(writer, "{} {} {}", rows, cols, nnz)?;
 
     // entries
     let mut entries = 0;
     match sym {
         SymmetryMode::General => {
             for (val, (row, col)) in mat.into_iter() {
-                write!(
+                writeln!(
                     writer,
-                    "{} {} {}\n",
+                    "{} {} {}",
                     row.index() + 1,
                     col.index() + 1,
                     val
@@ -382,9 +382,9 @@ where
             for (val, (row, col)) in
                 mat.into_iter().filter(|&(_, (r, c))| r < c)
             {
-                write!(
+                writeln!(
                     writer,
-                    "{} {} {}\n",
+                    "{} {} {}",
                     row.index() + 1,
                     col.index() + 1,
                     val
@@ -396,9 +396,9 @@ where
             for (val, (row, col)) in
                 mat.into_iter().filter(|&(_, (r, c))| r <= c)
             {
-                write!(
+                writeln!(
                     writer,
-                    "{} {} {}\n",
+                    "{} {} {}",
                     row.index() + 1,
                     col.index() + 1,
                     val
@@ -415,7 +415,7 @@ where
     if new_size < dim_header_size {
         let nb_spaces = dim_header_size - new_size;
         for _ in 0..nb_spaces {
-            writer.write(b" ")?;
+            writer.write_all(b" ")?;
         }
     }
     Ok(())

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -89,11 +89,11 @@ where
 {
     let nrows = lhs.rows();
     let ncols = lhs.cols();
-    let storage_type = lhs.storage();
+    let storage = lhs.storage();
     if nrows != rhs.rows() || ncols != rhs.cols() {
         panic!("Dimension mismatch");
     }
-    if storage_type != rhs.storage() {
+    if storage != rhs.storage() {
         panic!("Storage mismatch");
     }
 
@@ -120,9 +120,9 @@ where
     out_indices.truncate(nnz);
     out_data.truncate(nnz);
     CsMatI {
-        storage: storage_type,
-        nrows: nrows,
-        ncols: ncols,
+        storage,
+        nrows,
+        ncols,
         indptr: out_indptr,
         indices: out_indices,
         data: out_data,
@@ -189,9 +189,10 @@ where
     D: ndarray::Data<Elem = N>,
 {
     let shape = (rhs.shape()[0], rhs.shape()[1]);
-    let mut res = match rhs.is_standard_layout() {
-        true => Array::zeros(shape),
-        false => Array::zeros(shape.f()),
+    let mut res = if rhs.is_standard_layout() {
+        Array::zeros(shape)
+    } else {
+        Array::zeros(shape.f())
     };
     csmat_binop_dense_raw(
         lhs.view(),
@@ -216,9 +217,10 @@ where
     D: ndarray::Data<Elem = N>,
 {
     let shape = (rhs.shape()[0], rhs.shape()[1]);
-    let mut res = match rhs.is_standard_layout() {
-        true => Array::zeros(shape),
-        false => Array::zeros(shape.f()),
+    let mut res = if rhs.is_standard_layout() {
+        Array::zeros(shape)
+    } else {
+        Array::zeros(shape.f())
     };
     csmat_binop_dense_raw(
         lhs.view(),

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -16,7 +16,7 @@ where
     MatArray: AsRef<[CsMatViewI<'a, N, I>]>,
 {
     let mats = mats.as_ref();
-    if mats.len() == 0 {
+    if mats.is_empty() {
         panic!("Empty stacking list");
     }
     let inner_dim = mats[0].inner_dims();
@@ -28,8 +28,8 @@ where
         panic!("Storage mismatch");
     }
 
-    let outer_dim = mats.iter().map(|x| x.outer_dims()).fold(0, |x, y| x + y);
-    let nnz = mats.iter().map(|x| x.nnz()).fold(0, |x, y| x + y);
+    let outer_dim = mats.iter().map(|x| x.outer_dims()).sum::<usize>();
+    let nnz = mats.iter().map(|x| x.nnz()).sum::<usize>();
 
     let mut res = CsMatI::empty(storage_type, inner_dim);
     res.reserve_outer_dim_exact(outer_dim);

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -41,22 +41,19 @@ impl<I: SpIndex> Permutation<I, Vec<I>> {
         }
         PermOwnedI {
             dim: perm.len(),
-            storage: FinitePerm {
-                perm: perm,
-                perm_inv: perm_inv,
-            },
+            storage: FinitePerm { perm, perm_inv },
         }
     }
 }
 
 impl<'a, I: SpIndex> Permutation<I, &'a [I]> {
     pub fn reborrow(&self) -> PermViewI<'a, I> {
-        match &self.storage {
-            &Identity => PermViewI {
+        match self.storage {
+            Identity => PermViewI {
                 dim: self.dim,
                 storage: Identity,
             },
-            &FinitePerm {
+            FinitePerm {
                 perm: ref p,
                 perm_inv: ref p_,
             } => PermViewI {
@@ -70,12 +67,12 @@ impl<'a, I: SpIndex> Permutation<I, &'a [I]> {
     }
 
     pub fn reborrow_inv(&self) -> PermViewI<'a, I> {
-        match &self.storage {
-            &Identity => PermViewI {
+        match self.storage {
+            Identity => PermViewI {
                 dim: self.dim,
                 storage: Identity,
             },
-            &FinitePerm {
+            FinitePerm {
                 perm: ref p,
                 perm_inv: ref p_,
             } => PermViewI {
@@ -95,18 +92,18 @@ where
 {
     pub fn identity(dim: usize) -> Permutation<I, IndStorage> {
         Permutation {
-            dim: dim,
+            dim,
             storage: Identity,
         }
     }
 
     pub fn inv(&self) -> PermViewI<I> {
-        match &self.storage {
-            &Identity => PermViewI {
+        match self.storage {
+            Identity => PermViewI {
                 dim: self.dim,
                 storage: Identity,
             },
-            &FinitePerm {
+            FinitePerm {
                 perm: ref p,
                 perm_inv: ref p_,
             } => PermViewI {
@@ -120,12 +117,12 @@ where
     }
 
     pub fn view(&self) -> PermViewI<I> {
-        match &self.storage {
-            &Identity => PermViewI {
+        match self.storage {
+            Identity => PermViewI {
                 dim: self.dim,
                 storage: Identity,
             },
-            &FinitePerm {
+            FinitePerm {
                 perm: ref p,
                 perm_inv: ref p_,
             } => PermViewI {
@@ -139,12 +136,12 @@ where
     }
 
     pub fn owned_clone(&self) -> PermOwnedI<I> {
-        match &self.storage {
-            &Identity => PermOwnedI {
+        match self.storage {
+            Identity => PermOwnedI {
                 dim: self.dim,
                 storage: Identity,
             },
-            &FinitePerm {
+            FinitePerm {
                 perm: ref p,
                 perm_inv: ref p_,
             } => PermOwnedI {
@@ -159,44 +156,36 @@ where
 
     pub fn at(&self, index: usize) -> usize {
         assert!(index < self.dim);
-        match &self.storage {
-            &Identity => index,
-            &FinitePerm {
-                perm: ref p,
-                perm_inv: _,
-            } => p[index].index(),
+        match self.storage {
+            Identity => index,
+            FinitePerm { perm: ref p, .. } => p[index].index(),
         }
     }
 
     pub fn at_inv(&self, index: usize) -> usize {
         assert!(index < self.dim);
-        match &self.storage {
-            &Identity => index,
-            &FinitePerm {
-                perm: _,
-                perm_inv: ref p_,
+        match self.storage {
+            Identity => index,
+            FinitePerm {
+                perm_inv: ref p_, ..
             } => p_[index].index(),
         }
     }
 
     /// Get a vector representing this permutation
     pub fn vec(&self) -> Vec<I> {
-        match &self.storage {
-            &Identity => (0..self.dim).map(I::from_usize).collect(),
-            &FinitePerm {
-                perm: ref p,
-                perm_inv: _,
-            } => p.to_vec(),
+        match self.storage {
+            Identity => (0..self.dim).map(I::from_usize).collect(),
+            FinitePerm { perm: ref p, .. } => p.to_vec(),
         }
     }
 
     /// Get a vector representing the inverse of this permutation
     pub fn inv_vec(&self) -> Vec<I> {
-        match &self.storage {
-            &Identity => (0..self.dim).map(I::from_usize).collect(),
-            &FinitePerm {
-                perm: _,
-                perm_inv: ref p_,
+        match self.storage {
+            Identity => (0..self.dim).map(I::from_usize).collect(),
+            FinitePerm {
+                perm_inv: ref p_, ..
             } => p_.to_vec(),
         }
     }
@@ -205,9 +194,9 @@ where
     where
         I2: SpIndex,
     {
-        match &self.storage {
-            &Identity => PermOwnedI::identity(self.dim),
-            &FinitePerm {
+        match self.storage {
+            Identity => PermOwnedI::identity(self.dim),
+            FinitePerm {
                 perm: ref p,
                 perm_inv: ref p_,
             } => {
@@ -217,10 +206,7 @@ where
                     p_.iter().map(|i| I2::from_usize(i.index())).collect();
                 PermOwnedI {
                     dim: self.dim,
-                    storage: FinitePerm {
-                        perm: perm,
-                        perm_inv: perm_inv,
-                    },
+                    storage: FinitePerm { perm, perm_inv },
                 }
             }
         }
@@ -237,12 +223,9 @@ where
     fn mul(self, rhs: &'a [N]) -> Vec<N> {
         assert_eq!(self.dim, rhs.len());
         let mut res = rhs.to_vec();
-        match &self.storage {
-            &Identity => res,
-            &FinitePerm {
-                perm: ref p,
-                perm_inv: _,
-            } => {
+        match self.storage {
+            Identity => res,
+            FinitePerm { perm: ref p, .. } => {
                 for (pi, r) in p.iter().zip(res.iter_mut()) {
                     *r = rhs[pi.index()];
                 }

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -120,16 +120,19 @@ impl<N, I: SpIndex> TriMatBase<Vec<I>, Vec<N>> {
         col_inds: Vec<I>,
         data: Vec<N>,
     ) -> TriMatI<N, I> {
-        assert!(
-            row_inds.len() == col_inds.len(),
+        assert_eq!(
+            row_inds.len(),
+            col_inds.len(),
             "all inputs should have the same length"
         );
-        assert!(
-            data.len() == col_inds.len(),
+        assert_eq!(
+            data.len(),
+            col_inds.len(),
             "all inputs should have the same length"
         );
-        assert!(
-            row_inds.len() == data.len(),
+        assert_eq!(
+            row_inds.len(),
+            data.len(),
             "all inputs should have the same length"
         );
         assert!(
@@ -143,9 +146,9 @@ impl<N, I: SpIndex> TriMatBase<Vec<I>, Vec<N>> {
         TriMatI {
             rows: shape.0,
             cols: shape.1,
-            row_inds: row_inds,
-            col_inds: col_inds,
-            data: data,
+            row_inds,
+            col_inds,
+            data,
         }
     }
 

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -48,10 +48,10 @@ where
         Self {
             rows: shape.0,
             cols: shape.1,
-            nnz: nnz,
-            row_inds: row_inds,
-            col_inds: col_inds,
-            data: data,
+            nnz,
+            row_inds,
+            col_inds,
+            data,
         }
     }
 
@@ -118,7 +118,7 @@ where
         }
         let mut indptr = row_counts.clone();
         // cum sum
-        for i in 1..(self.rows() + 1) {
+        for i in 1..=self.rows() {
             indptr[i] += indptr[i - 1];
         }
         let nnz_max = indptr[self.rows()].index();

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -490,8 +490,8 @@ impl<N, I: SpIndex> CsVecBase<Vec<I>, Vec<N>> {
         );
         let v = CsVecI {
             dim: n,
-            indices: indices,
-            data: data,
+            indices,
+            data,
         };
         v.check_structure().and(Ok(v)).unwrap()
     }
@@ -499,7 +499,7 @@ impl<N, I: SpIndex> CsVecBase<Vec<I>, Vec<N>> {
     /// Create an empty CsVec, which can be used for incremental construction
     pub fn empty(dim: usize) -> CsVecI<N, I> {
         CsVecI {
-            dim: dim,
+            dim,
             indices: Vec::new(),
             data: Vec::new(),
         }
@@ -592,7 +592,7 @@ where
     {
         VectorIteratorPerm {
             ind_data: self.indices.iter().zip(self.data.iter()),
-            perm: perm,
+            perm,
         }
     }
 
@@ -669,11 +669,11 @@ where
             .iter()
             .map(|i| I2::from_usize(i.index()))
             .collect();
-        let data = self.data.iter().map(|x| x.clone().into()).collect();
+        let data = self.data.iter().cloned().collect();
         CsVecI {
             dim: self.dim,
-            indices: indices,
-            data: data,
+            indices,
+            data,
         }
     }
 
@@ -688,7 +688,7 @@ where
             storage: CSR,
             nrows: 1,
             ncols: self.dim,
-            indptr: indptr,
+            indptr,
             indices: &self.indices[..],
             data: &self.data[..],
         }
@@ -705,7 +705,7 @@ where
             storage: CSC,
             nrows: self.dim,
             ncols: 1,
-            indptr: indptr,
+            indptr,
             indices: &self.indices[..],
             data: &self.data[..],
         }
@@ -807,7 +807,7 @@ where
     }
 
     /// Transform this vector into a set of (index, value) tuples
-    pub fn to_set(self) -> HashSet<(usize, N)>
+    pub fn to_set(&self) -> HashSet<(usize, N)>
     where
         N: Hash + Eq + Clone,
     {
@@ -891,8 +891,8 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsVecBase<&'a [I], &'a [N]> {
     ) -> Result<CsVecViewI<'a, N, I>, SprsError> {
         let v = CsVecViewI {
             dim: n,
-            indices: indices,
-            data: data,
+            indices,
+            data,
         };
         v.check_structure().and(Ok(v))
     }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -120,7 +120,7 @@ where
     }
 
     /// Iterates along the right stack without removing items
-    pub fn iter_right<'a>(&'a self) -> slice::Iter<'a, I> {
+    pub fn iter_right(&self) -> slice::Iter<I> {
         self.stacks[self.right_head..].iter()
     }
 
@@ -141,8 +141,8 @@ where
 
 /// Enable extraction of stack val from iterators
 pub fn extract_stack_val<I>(stack_val: &StackVal<I>) -> &I {
-    match stack_val {
-        &StackVal::Enter(ref i) => &i,
-        &StackVal::Exit(ref i) => &i,
+    match *stack_val {
+        StackVal::Enter(ref i) => &i,
+        StackVal::Exit(ref i) => &i,
     }
 }


### PR DESCRIPTION
Fixing the rest would require changing the current public interface (mostly passing refs instead of values when the latter is unnecessary), so leaving them as is for now.