### PR TITLE
faster implementation of sparse/sparse dot product

### DIFF
--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -767,10 +767,25 @@ where
                 .map(|(idx, val)| *val * *rhs.index(idx.index()))
                 .sum()
         } else {
-            self.iter()
-                .nnz_zip(rhs.into_sparse_vec_iter())
-                .map(|(_, &lval, &rval)| lval * rval)
-                .fold(N::zero(), |x, y| x + y)
+            let mut lhs_iter = self.iter();
+            let mut rhs_iter = rhs.into_sparse_vec_iter().into_iter();
+            let mut sum = N::zero();
+            let mut left_nnz = lhs_iter.next();
+            let mut right_nnz = rhs_iter.next();
+            while left_nnz.is_some() && right_nnz.is_some() {
+                let (left_ind, left_val) = left_nnz.unwrap();
+                let (right_ind, right_val) = right_nnz.unwrap();
+                if left_ind == right_ind {
+                    sum = sum + *left_val * *right_val;
+                }
+                if left_ind <= right_ind {
+                    left_nnz = lhs_iter.next();
+                }
+                if left_ind >= right_ind {
+                    right_nnz = rhs_iter.next();
+                }
+            }
+            sum
         }
     }
 


### PR DESCRIPTION
Previous implementation was leveraging the same logic as the csvec sum,
but this meant that it was visiting the union of nnz states, then
filtering the ones that didn't match. This new implementation inspired
by @tomtung's implementation in #151 is more straightforward and faster.

Results with the small benchmark program by @tomtung:

old version:

```
CsVecBase::dot  6783668708ns
csvec_dot       2281289626ns

CsVecBase::dot  6730220391ns
csvec_dot       2314367501ns

CsVecBase::dot  7211901147ns
csvec_dot       2668089989ns

CsVecBase::dot  2016792998ns
csvec_dot       698307619ns

CsVecBase::dot  3474910028ns
csvec_dot       1231625617ns

CsVecBase::dot  1608800699ns
csvec_dot       594631255ns

CsVecBase::dot  5704293971ns
csvec_dot       2099393986ns

CsVecBase::dot  635824615ns
csvec_dot       211984526ns

CsVecBase::dot  4556805203ns
csvec_dot       1542749671ns

CsVecBase::dot  338015913ns
csvec_dot       88687883ns
```

new version:

```
CsVecBase::dot  207550895ns
csvec_dot       276401060ns

CsVecBase::dot  764978214ns
csvec_dot       1309583828ns

CsVecBase::dot  1697712616ns
csvec_dot       1784569385ns

CsVecBase::dot  2016016796ns
csvec_dot       2598775764ns

CsVecBase::dot  955876272ns
csvec_dot       1394577636ns

CsVecBase::dot  200513408ns
csvec_dot       304527108ns

CsVecBase::dot  3107829898ns
csvec_dot       3099964662ns

CsVecBase::dot  2437027204ns
csvec_dot       2558698952ns

CsVecBase::dot  2284435840ns
csvec_dot       3067460468ns

CsVecBase::dot  1061899090ns
csvec_dot       1042598131ns
```

So the new version is equivalent to @tomtung's implementation, sometimes slightly slower, sometimes faster probably due to some optimizer choices.