### PR TITLE
fix borrow warning on nightly

### DIFF
--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -119,7 +119,7 @@ where
         let mut indptr = row_counts.clone();
         // cum sum
         for i in 1..=self.rows() {
-            indptr[i] += indptr[i - 1];
+            indptr[i] = indptr[i] + indptr[i - 1];
         }
         let nnz_max = indptr[self.rows()].index();
         let mut indices = vec![I::zero(); nnz_max];


### PR DESCRIPTION
this line is giving the following warning on the nightly compiler. This patch fixes the warning:
```
warning[E0502]: cannot borrow `indptr` as immutable because it is also borrowed as mutable
   --> src/sparse/triplet_iter.rs:122:26
    |
122 |             indptr[i] += indptr[i - 1];
    |             -------------^^^^^^-------
    |             |            |
    |             |            immutable borrow occurs here
    |             mutable borrow occurs here
    |             mutable borrow later used here
    |
    = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
    = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
```