### PR TITLE
sprs to version 0.6.5, sprs-ldl to version 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "sprs"
 description = "A sparse matrix library"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["Vincent Barrielle <vincent.barrielle@m4x.org>"]
 
 readme = "README.rst"

--- a/changelog.rst
+++ b/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+- 0.6.5
+  - faster triplet format to compressed storage conversion
+  - fix borrow checker issue flagged by new NLL
+  - can read Matrix Market files from an ``io::BufRead``
+  - improve ``CsMat::map`` to enable changing the storage type
 - 0.6.4
   - add specialized sparse/sparse vector dot product using binary search
     for vectors where the number of non-zeros is very different.

--- a/sprs-ldl/Cargo.toml
+++ b/sprs-ldl/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "sprs-ldl"
 description = "Sparse cholesky factorization"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Vincent Barrielle"]
 
 readme = "README.rst"
@@ -17,6 +17,6 @@ num-traits = "0.1.32"
 
 
 [dependencies.sprs]
-version = "0.6.0"
+version = "0.6.5"
 path = ".."
 


### PR DESCRIPTION
Aside from new features, this version fixes the warning reported by the transition mode of the borrow checker (see https://github.com/rust-lang/rust/issues/60680). This will enable dependent crates to upgrade and be able to continue building once the transition is over.