### PR TITLE
Support having different types for indptr & indices in CsMatBase

### DIFF
--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -14,53 +14,57 @@ use Ix2;
 use SpRes;
 
 /// Sparse matrix addition, with matrices sharing the same storage type
-pub fn add_mat_same_storage<N, I, Mat1, Mat2>(
+pub fn add_mat_same_storage<N, I, Iptr, Mat1, Mat2>(
     lhs: &Mat1,
     rhs: &Mat2,
-) -> CsMatI<N, I>
+) -> CsMatI<N, I, Iptr>
 where
     N: Num + Copy,
     I: SpIndex,
-    Mat1: SpMatView<N, I>,
-    Mat2: SpMatView<N, I>,
+    Iptr: SpIndex,
+    Mat1: SpMatView<N, I, Iptr>,
+    Mat2: SpMatView<N, I, Iptr>,
 {
     csmat_binop(lhs.view(), rhs.view(), |&x, &y| x + y)
 }
 
 /// Sparse matrix subtraction, with same storage type
-pub fn sub_mat_same_storage<N, I, Mat1, Mat2>(
+pub fn sub_mat_same_storage<N, I, Iptr, Mat1, Mat2>(
     lhs: &Mat1,
     rhs: &Mat2,
-) -> CsMatI<N, I>
+) -> CsMatI<N, I, Iptr>
 where
     N: Num + Copy,
     I: SpIndex,
-    Mat1: SpMatView<N, I>,
-    Mat2: SpMatView<N, I>,
+    Iptr: SpIndex,
+    Mat1: SpMatView<N, I, Iptr>,
+    Mat2: SpMatView<N, I, Iptr>,
 {
     csmat_binop(lhs.view(), rhs.view(), |&x, &y| x - y)
 }
 
 /// Sparse matrix scalar multiplication, with same storage type
-pub fn mul_mat_same_storage<N, I, Mat1, Mat2>(
+pub fn mul_mat_same_storage<N, I, Iptr, Mat1, Mat2>(
     lhs: &Mat1,
     rhs: &Mat2,
-) -> CsMatI<N, I>
+) -> CsMatI<N, I, Iptr>
 where
     N: Num + Copy,
     I: SpIndex,
-    Mat1: SpMatView<N, I>,
-    Mat2: SpMatView<N, I>,
+    Iptr: SpIndex,
+    Mat1: SpMatView<N, I, Iptr>,
+    Mat2: SpMatView<N, I, Iptr>,
 {
     csmat_binop(lhs.view(), rhs.view(), |&x, &y| x * y)
 }
 
 /// Sparse matrix multiplication by a scalar
-pub fn scalar_mul_mat<N, I, Mat>(mat: &Mat, val: N) -> CsMatI<N, I>
+pub fn scalar_mul_mat<N, I, Iptr, Mat>(mat: &Mat, val: N) -> CsMatI<N, I, Iptr>
 where
     N: Num + Copy,
     I: SpIndex,
-    Mat: SpMatView<N, I>,
+    Iptr: SpIndex,
+    Mat: SpMatView<N, I, Iptr>,
 {
     let mat = mat.view();
     mat.map(|&x| x * val)
@@ -77,14 +81,15 @@ where
 ///
 /// - on incompatible dimensions
 /// - on incomatible storage
-pub fn csmat_binop<N, I, F>(
-    lhs: CsMatViewI<N, I>,
-    rhs: CsMatViewI<N, I>,
+pub fn csmat_binop<N, I, Iptr, F>(
+    lhs: CsMatViewI<N, I, Iptr>,
+    rhs: CsMatViewI<N, I, Iptr>,
     binop: F,
-) -> CsMatI<N, I>
+) -> CsMatI<N, I, Iptr>
 where
     N: Num,
     I: SpIndex,
+    Iptr: SpIndex,
     F: Fn(&N, &N) -> N,
 {
     let nrows = lhs.rows();
@@ -98,7 +103,7 @@ where
     }
 
     let max_nnz = lhs.nnz() + rhs.nnz();
-    let mut out_indptr = vec![I::zero(); lhs.outer_dims() + 1];
+    let mut out_indptr = vec![Iptr::zero(); lhs.outer_dims() + 1];
     let mut out_indices = vec![I::zero(); max_nnz];
 
     // Sadly the vec! macro requires Clone, but we don't want to force
@@ -133,17 +138,18 @@ where
 /// sharing the same storage. The output arrays are assumed to be preallocated
 ///
 /// Returns the nnz count
-pub fn csmat_binop_same_storage_raw<N, I, F>(
-    lhs: CsMatViewI<N, I>,
-    rhs: CsMatViewI<N, I>,
+pub fn csmat_binop_same_storage_raw<N, I, Iptr, F>(
+    lhs: CsMatViewI<N, I, Iptr>,
+    rhs: CsMatViewI<N, I, Iptr>,
     binop: F,
-    out_indptr: &mut [I],
+    out_indptr: &mut [Iptr],
     out_indices: &mut [I],
     out_data: &mut [N],
 ) -> usize
 where
     N: Num,
     I: SpIndex,
+    Iptr: SpIndex,
     F: Fn(&N, &N) -> N,
 {
     assert_eq!(lhs.cols(), rhs.cols());
@@ -154,7 +160,7 @@ where
     assert!(out_data.len() >= max_nnz);
     assert!(out_indices.len() >= max_nnz);
     let mut nnz = 0;
-    out_indptr[0] = I::zero();
+    out_indptr[0] = Iptr::zero();
     let iter = lhs.outer_iterator().zip(rhs.outer_iterator()).enumerate();
     for (dim, (lv, rv)) in iter {
         for elem in lv.iter().nnz_or_zip(rv.iter()) {
@@ -169,14 +175,14 @@ where
                 nnz += 1;
             }
         }
-        out_indptr[dim + 1] = I::from_usize(nnz);
+        out_indptr[dim + 1] = Iptr::from_usize(nnz);
     }
     nnz
 }
 
 /// Compute alpha * lhs + beta * rhs with lhs a sparse matrix and rhs dense
 /// and alpha and beta scalars
-pub fn add_dense_mat_same_ordering<N, I, Mat, D>(
+pub fn add_dense_mat_same_ordering<N, I, Iptr, Mat, D>(
     lhs: &Mat,
     rhs: &ArrayBase<D, Ix2>,
     alpha: N,
@@ -185,7 +191,8 @@ pub fn add_dense_mat_same_ordering<N, I, Mat, D>(
 where
     N: Num + Copy,
     I: SpIndex,
-    Mat: SpMatView<N, I>,
+    Iptr: SpIndex,
+    Mat: SpMatView<N, I, Iptr>,
     D: ndarray::Data<Elem = N>,
 {
     let shape = (rhs.shape()[0], rhs.shape()[1]);
@@ -205,7 +212,7 @@ where
 
 /// Compute coeff wise `alpha * lhs * rhs` with `lhs` a sparse matrix,
 /// `rhs` a dense matrix, and `alpha` a scalar
-pub fn mul_dense_mat_same_ordering<N, I, Mat, D>(
+pub fn mul_dense_mat_same_ordering<N, I, Iptr, Mat, D>(
     lhs: &Mat,
     rhs: &ArrayBase<D, Ix2>,
     alpha: N,
@@ -213,7 +220,8 @@ pub fn mul_dense_mat_same_ordering<N, I, Mat, D>(
 where
     N: Num + Copy,
     I: SpIndex,
-    Mat: SpMatView<N, I>,
+    Iptr: SpIndex,
+    Mat: SpMatView<N, I, Iptr>,
     D: ndarray::Data<Elem = N>,
 {
     let shape = (rhs.shape()[0], rhs.shape()[1]);
@@ -233,14 +241,15 @@ where
 
 /// Raw implementation of sparse/dense binary operations with the same
 /// ordering
-pub fn csmat_binop_dense_raw<'a, N, I, F>(
-    lhs: CsMatViewI<'a, N, I>,
+pub fn csmat_binop_dense_raw<'a, N, I, Iptr, F>(
+    lhs: CsMatViewI<'a, N, I, Iptr>,
     rhs: ArrayView<'a, N, Ix2>,
     binop: F,
     mut out: ArrayViewMut<'a, N, Ix2>,
 ) where
     N: 'a + Num,
     I: 'a + SpIndex,
+    Iptr: 'a + SpIndex,
     F: Fn(&N, &N) -> N,
 {
     if lhs.cols() != rhs.shape()[1]

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -5,27 +5,28 @@ use std::ops::Deref;
 
 /// The SpMatView trait describes data that can be seen as a view
 /// into a CsMat
-pub trait SpMatView<N, I: SpIndex> {
+pub trait SpMatView<N, I: SpIndex, Iptr: SpIndex = I> {
     /// Return a view into the current matrix
-    fn view(&self) -> CsMatViewI<N, I>;
+    fn view(&self) -> CsMatViewI<N, I, Iptr>;
 
     /// Return a view into the current matrix
-    fn transpose_view(&self) -> CsMatViewI<N, I>;
+    fn transpose_view(&self) -> CsMatViewI<N, I, Iptr>;
 }
 
-impl<N, I, IpStorage, IndStorage, DataStorage> SpMatView<N, I>
-    for CsMatBase<N, I, IpStorage, IndStorage, DataStorage>
+impl<N, I, Iptr, IpStorage, IndStorage, DataStorage> SpMatView<N, I, Iptr>
+    for CsMatBase<N, I, IpStorage, IndStorage, DataStorage, Iptr>
 where
     I: SpIndex,
-    IpStorage: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IpStorage: Deref<Target = [Iptr]>,
     IndStorage: Deref<Target = [I]>,
     DataStorage: Deref<Target = [N]>,
 {
-    fn view(&self) -> CsMatViewI<N, I> {
+    fn view(&self) -> CsMatViewI<N, I, Iptr> {
         self.view()
     }
 
-    fn transpose_view(&self) -> CsMatViewI<N, I> {
+    fn transpose_view(&self) -> CsMatViewI<N, I, Iptr> {
         self.transpose_view()
     }
 }

--- a/src/sparse/construct.rs
+++ b/src/sparse/construct.rs
@@ -7,13 +7,14 @@ use std::default::Default;
 
 /// Stack the given matrices into a new one, using the most efficient stacking
 /// direction (ie vertical stack for CSR matrices, horizontal stack for CSC)
-pub fn same_storage_fast_stack<'a, N, I, MatArray>(
+pub fn same_storage_fast_stack<'a, N, I, Iptr, MatArray>(
     mats: &MatArray,
-) -> CsMatI<N, I>
+) -> CsMatI<N, I, Iptr>
 where
     N: 'a + Clone,
     I: 'a + SpIndex,
-    MatArray: AsRef<[CsMatViewI<'a, N, I>]>,
+    Iptr: 'a + SpIndex,
+    MatArray: AsRef<[CsMatViewI<'a, N, I, Iptr>]>,
 {
     let mats = mats.as_ref();
     if mats.is_empty() {
@@ -44,11 +45,12 @@ where
 }
 
 /// Construct a sparse matrix by vertically stacking other matrices
-pub fn vstack<'a, N, I, MatArray>(mats: &MatArray) -> CsMatI<N, I>
+pub fn vstack<'a, N, I, Iptr, MatArray>(mats: &MatArray) -> CsMatI<N, I, Iptr>
 where
     N: 'a + Clone + Default,
     I: 'a + SpIndex,
-    MatArray: AsRef<[CsMatViewI<'a, N, I>]>,
+    Iptr: 'a + SpIndex,
+    MatArray: AsRef<[CsMatViewI<'a, N, I, Iptr>]>,
 {
     let mats = mats.as_ref();
     if mats.iter().all(|x| x.is_csr()) {
@@ -61,11 +63,12 @@ where
 }
 
 /// Construct a sparse matrix by horizontally stacking other matrices
-pub fn hstack<'a, N, MatArray, I>(mats: &MatArray) -> CsMatI<N, I>
+pub fn hstack<'a, N, I, Iptr, MatArray>(mats: &MatArray) -> CsMatI<N, I, Iptr>
 where
     N: 'a + Clone + Default,
     I: 'a + SpIndex,
-    MatArray: AsRef<[CsMatViewI<'a, N, I>]>,
+    Iptr: 'a + SpIndex,
+    MatArray: AsRef<[CsMatViewI<'a, N, I, Iptr>]>,
 {
     let mats = mats.as_ref();
     if mats.iter().all(|x| x.is_csc()) {
@@ -88,12 +91,15 @@ where
 ///                      [None, Some(b.view())]]);
 /// assert_eq!(c.rows(), 7);
 /// ```
-pub fn bmat<'a, N, I, OuterArray, InnerArray>(mats: &OuterArray) -> CsMatI<N, I>
+pub fn bmat<'a, N, I, Iptr, OuterArray, InnerArray>(
+    mats: &OuterArray,
+) -> CsMatI<N, I, Iptr>
 where
     N: 'a + Clone + Default,
     I: 'a + SpIndex,
+    Iptr: 'a + SpIndex,
     OuterArray: 'a + AsRef<[InnerArray]>,
-    InnerArray: 'a + AsRef<[Option<CsMatViewI<'a, N, I>>]>,
+    InnerArray: 'a + AsRef<[Option<CsMatViewI<'a, N, I, Iptr>>]>,
 {
     let mats = mats.as_ref();
     let super_rows = mats.len();

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -85,19 +85,25 @@ pub struct NnzIndex(pub usize);
 
 /// Iterator on the matrix' outer dimension
 /// Implemented over an iterator on the indptr array
-pub struct OuterIterator<'iter, N: 'iter, I: 'iter> {
+pub struct OuterIterator<'iter, N: 'iter, I: 'iter, Iptr: 'iter = I> {
     inner_len: usize,
-    indptr_iter: Windows<'iter, I>,
+    indptr_iter: Windows<'iter, Iptr>,
     indices: &'iter [I],
     data: &'iter [N],
 }
 
 /// Iterator on the matrix' outer dimension, permuted
 /// Implemented over an iterator on the indptr array
-pub struct OuterIteratorPerm<'iter, 'perm: 'iter, N: 'iter, I: 'perm> {
+pub struct OuterIteratorPerm<
+    'iter,
+    'perm: 'iter,
+    N: 'iter,
+    I: 'perm,
+    Iptr: 'perm = I,
+> {
     inner_len: usize,
     outer_ind_iter: Range<usize>,
-    indptr: &'iter [I],
+    indptr: &'iter [Iptr],
     indices: &'iter [I],
     data: &'iter [N],
     perm: PermViewI<'perm, I>,
@@ -105,9 +111,9 @@ pub struct OuterIteratorPerm<'iter, 'perm: 'iter, N: 'iter, I: 'perm> {
 
 /// Iterator on the matrix' outer dimension
 /// Implemented over an iterator on the indptr array
-pub struct OuterIteratorMut<'iter, N: 'iter, I: 'iter> {
+pub struct OuterIteratorMut<'iter, N: 'iter, I: 'iter, Iptr: 'iter = I> {
     inner_len: usize,
-    indptr_iter: Windows<'iter, I>,
+    indptr_iter: Windows<'iter, Iptr>,
     indices: &'iter [I],
     data: &'iter mut [N],
 }
@@ -115,8 +121,8 @@ pub struct OuterIteratorMut<'iter, N: 'iter, I: 'iter> {
 /// Outer iteration on a compressed matrix yields
 /// a tuple consisting of the outer index and of a sparse vector
 /// containing the associated inner dimension
-impl<'iter, N: 'iter, I: 'iter + SpIndex> Iterator
-    for OuterIterator<'iter, N, I>
+impl<'iter, N: 'iter, I: 'iter + SpIndex, Iptr: 'iter + SpIndex> Iterator
+    for OuterIterator<'iter, N, I, Iptr>
 {
     type Item = CsVecBase<&'iter [I], &'iter [N]>;
     #[inline]
@@ -146,8 +152,13 @@ impl<'iter, N: 'iter, I: 'iter + SpIndex> Iterator
 /// Permuted outer iteration on a compressed matrix yields
 /// a tuple consisting of the outer index and of a sparse vector
 /// containing the associated inner dimension
-impl<'iter, 'perm: 'iter, N: 'iter, I: 'iter + SpIndex> Iterator
-    for OuterIteratorPerm<'iter, 'perm, N, I>
+impl<
+        'iter,
+        'perm: 'iter,
+        N: 'iter,
+        I: 'iter + SpIndex,
+        Iptr: 'iter + SpIndex,
+    > Iterator for OuterIteratorPerm<'iter, 'perm, N, I, Iptr>
 {
     type Item = (usize, CsVecBase<&'iter [I], &'iter [N]>);
     #[inline]
@@ -179,8 +190,8 @@ impl<'iter, 'perm: 'iter, N: 'iter, I: 'iter + SpIndex> Iterator
 /// Mutable outer iteration on a compressed matrix yields
 /// a tuple consisting of the outer index and of a mutable sparse vector view
 /// containing the associated inner dimension
-impl<'iter, N: 'iter, I: 'iter + SpIndex> Iterator
-    for OuterIteratorMut<'iter, N, I>
+impl<'iter, N: 'iter, I: 'iter + SpIndex, Iptr: 'iter + SpIndex> Iterator
+    for OuterIteratorMut<'iter, N, I, Iptr>
 {
     type Item = CsVecViewMutI<'iter, N, I>;
     #[inline]
@@ -218,8 +229,8 @@ impl<'iter, N: 'iter, I: 'iter + SpIndex> Iterator
 /// Only the outer dimension iteration is reverted. If you wish to also
 /// revert the inner dimension, you should call rev() again when iterating
 /// the vector.
-impl<'iter, N: 'iter, I: 'iter + SpIndex> DoubleEndedIterator
-    for OuterIterator<'iter, N, I>
+impl<'iter, N: 'iter, I: 'iter + SpIndex, Iptr: 'iter + SpIndex>
+    DoubleEndedIterator for OuterIterator<'iter, N, I, Iptr>
 {
     #[inline]
     fn next_back(&mut self) -> Option<<Self as Iterator>::Item> {
@@ -241,24 +252,25 @@ impl<'iter, N: 'iter, I: 'iter + SpIndex> DoubleEndedIterator
     }
 }
 
-impl<'iter, N: 'iter, I: 'iter + SpIndex> ExactSizeIterator
-    for OuterIterator<'iter, N, I>
+impl<'iter, N: 'iter, I: 'iter + SpIndex, Iptr: 'iter + SpIndex>
+    ExactSizeIterator for OuterIterator<'iter, N, I, Iptr>
 {
     fn len(&self) -> usize {
         self.indptr_iter.len()
     }
 }
 
-pub struct CsIter<'a, N: 'a, I: 'a> {
+pub struct CsIter<'a, N: 'a, I: 'a, Iptr: 'a = I> {
     storage: CompressedStorage,
     cur_outer: I,
-    indptr: &'a [I],
+    indptr: &'a [Iptr],
     inner_iter: Enumerate<Zip<Iter<'a, I>, Iter<'a, N>>>,
 }
 
-impl<'a, N, I> Iterator for CsIter<'a, N, I>
+impl<'a, N, I, Iptr> Iterator for CsIter<'a, N, I, Iptr>
 where
     I: SpIndex,
+    Iptr: SpIndex,
     N: 'a,
 {
     type Item = (&'a N, (I, I));
@@ -292,7 +304,9 @@ where
 }
 
 /// # Constructor methods for owned sparse matrices
-impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
+impl<N, I: SpIndex, Iptr: SpIndex>
+    CsMatBase<N, I, Vec<Iptr>, Vec<I>, Vec<N>, Iptr>
+{
     /// Identity matrix, stored as a CSR matrix.
     ///
     /// ```rust
@@ -303,12 +317,12 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     /// let y = &eye * &x;
     /// assert_eq!(x, y);
     /// ```
-    pub fn eye(dim: usize) -> CsMatI<N, I>
+    pub fn eye(dim: usize) -> CsMatI<N, I, Iptr>
     where
         N: Num + Clone,
     {
         let n = dim;
-        let indptr = (0..=n).map(I::from_usize).collect();
+        let indptr = (0..=n).map(Iptr::from_usize).collect();
         let indices = (0..n).map(I::from_usize).collect();
         let data = vec![N::one(); n];
         CsMatI {
@@ -331,12 +345,12 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     /// let y = &eye * &x;
     /// assert_eq!(x, y);
     /// ```
-    pub fn eye_csc(dim: usize) -> CsMatI<N, I>
+    pub fn eye_csc(dim: usize) -> CsMatI<N, I, Iptr>
     where
         N: Num + Clone,
     {
         let n = dim;
-        let indptr = (0..=n).map(I::from_usize).collect();
+        let indptr = (0..=n).map(Iptr::from_usize).collect();
         let indices = (0..n).map(I::from_usize).collect();
         let data = vec![N::one(); n];
         CsMatI {
@@ -352,7 +366,7 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     pub fn empty(
         storage: CompressedStorage,
         inner_size: usize,
-    ) -> CsMatI<N, I> {
+    ) -> CsMatI<N, I, Iptr> {
         let (nrows, ncols) = match storage {
             CSR => (0, inner_size),
             CSC => (inner_size, 0),
@@ -361,7 +375,7 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
             storage,
             nrows,
             ncols,
-            indptr: vec![I::zero(); 1],
+            indptr: vec![Iptr::zero(); 1],
             indices: Vec::new(),
             data: Vec::new(),
         }
@@ -369,13 +383,13 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
 
     /// Create a new CsMat representing the zero matrix.
     /// Hence it has no non-zero elements.
-    pub fn zero(shape: Shape) -> CsMatI<N, I> {
+    pub fn zero(shape: Shape) -> CsMatI<N, I, Iptr> {
         let (nrows, ncols) = shape;
         CsMatI {
             storage: CSR,
             nrows,
             ncols,
-            indptr: vec![I::zero(); nrows + 1],
+            indptr: vec![Iptr::zero(); nrows + 1],
             indices: Vec::new(),
             data: Vec::new(),
         }
@@ -424,10 +438,10 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     ///   columns.
     pub fn new(
         shape: Shape,
-        indptr: Vec<I>,
+        indptr: Vec<Iptr>,
         indices: Vec<I>,
         data: Vec<N>,
-    ) -> CsMatI<N, I>
+    ) -> CsMatI<N, I, Iptr>
     where
         N: Copy,
     {
@@ -455,10 +469,10 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     ///   columns.
     pub fn new_csc(
         shape: Shape,
-        indptr: Vec<I>,
+        indptr: Vec<Iptr>,
         indices: Vec<I>,
         data: Vec<N>,
-    ) -> CsMatI<N, I>
+    ) -> CsMatI<N, I, Iptr>
     where
         N: Copy,
     {
@@ -468,10 +482,10 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     fn new_(
         storage: CompressedStorage,
         shape: Shape,
-        indptr: Vec<I>,
+        indptr: Vec<Iptr>,
         indices: Vec<I>,
         data: Vec<N>,
-    ) -> Result<CsMatI<N, I>, SprsError>
+    ) -> Result<CsMatI<N, I, Iptr>, SprsError>
     where
         N: Copy,
     {
@@ -490,7 +504,10 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     /// Create a CSR matrix from a dense matrix, ignoring elements lower than `epsilon`.
     ///
     /// If epsilon is negative, it will be clamped to zero.
-    pub fn csr_from_dense(m: ArrayView<N, Ix2>, epsilon: N) -> CsMatI<N, I>
+    pub fn csr_from_dense(
+        m: ArrayView<N, Ix2>,
+        epsilon: N,
+    ) -> CsMatI<N, I, Iptr>
     where
         N: Num + Clone + cmp::PartialOrd + Signed,
     {
@@ -502,11 +519,11 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
         let nrows = m.shape()[0];
         let ncols = m.shape()[1];
 
-        let mut indptr = vec![I::zero(); nrows + 1];
+        let mut indptr = vec![Iptr::zero(); nrows + 1];
         let mut nnz = 0;
         for (row, row_count) in m.outer_iter().zip(&mut indptr[1..]) {
             nnz += row.iter().filter(|&x| x.abs() > epsilon).count();
-            *row_count = I::from_usize(nnz);
+            *row_count = Iptr::from_usize(nnz);
         }
 
         let mut indices = Vec::with_capacity(nnz);
@@ -532,7 +549,10 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
     /// Create a CSC matrix from a dense matrix, ignoring elements lower than `epsilon`.
     ///
     /// If epsilon is negative, it will be clamped to zero.
-    pub fn csc_from_dense(m: ArrayView<N, Ix2>, epsilon: N) -> CsMatI<N, I>
+    pub fn csc_from_dense(
+        m: ArrayView<N, Ix2>,
+        epsilon: N,
+    ) -> CsMatI<N, I, Iptr>
     where
         N: Num + Clone + cmp::PartialOrd + Signed,
     {
@@ -573,7 +593,7 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
             CSR => self.nrows += 1,
             CSC => self.ncols += 1,
         }
-        self.indptr.push(I::from_usize(nnz));
+        self.indptr.push(Iptr::from_usize(nnz));
         self
     }
 
@@ -591,7 +611,7 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
             CSR => self.nrows += 1,
             CSC => self.ncols += 1,
         }
-        let nnz = *self.indptr.last().unwrap() + I::from_usize(vec.nnz());
+        let nnz = *self.indptr.last().unwrap() + Iptr::from_usize(vec.nnz());
         self.indptr.push(nnz);
         self
     }
@@ -628,7 +648,7 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
                 self.indptr.push(last_nnz);
             }
             self.set_outer_dims(outer_ind + 1);
-            self.indptr.push(last_nnz + I::one());
+            self.indptr.push(last_nnz + Iptr::one());
             self.indices.push(inner_ind_idx);
             self.data.push(val);
         } else {
@@ -648,7 +668,7 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
                     self.indices.insert(ind, inner_ind_idx);
                     self.data.insert(ind, val);
                     for k in (outer_ind + 1)..=outer_dims {
-                        self.indptr[k] += I::one();
+                        self.indptr[k] += Iptr::one();
                     }
                 }
             }
@@ -678,16 +698,18 @@ impl<N, I: SpIndex> CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>> {
 ///
 /// These constructors can be used to create views over non-matrix data
 /// such as slices.
-impl<'a, N: 'a, I: 'a + SpIndex> CsMatBase<N, I, &'a [I], &'a [I], &'a [N]> {
+impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
+    CsMatBase<N, I, &'a [Iptr], &'a [I], &'a [N], Iptr>
+{
     /// Create a borrowed CsMat matrix from sliced data,
     /// checking their validity
     pub fn new_view(
         storage: CompressedStorage,
         shape: Shape,
-        indptr: &'a [I],
+        indptr: &'a [Iptr],
         indices: &'a [I],
         data: &'a [N],
-    ) -> Result<CsMatViewI<'a, N, I>, SprsError> {
+    ) -> Result<CsMatViewI<'a, N, I, Iptr>, SprsError> {
         let m = CsMatViewI {
             storage,
             nrows: shape.0,
@@ -709,10 +731,10 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsMatBase<N, I, &'a [I], &'a [I], &'a [N]> {
     pub unsafe fn new_view_raw(
         storage: CompressedStorage,
         shape: Shape,
-        indptr: *const I,
+        indptr: *const Iptr,
         indices: *const I,
         data: *const N,
-    ) -> CsMatViewI<'a, N, I> {
+    ) -> CsMatViewI<'a, N, I, Iptr> {
         let (nrows, ncols) = shape;
         let outer = match storage {
             CSR => nrows,
@@ -737,7 +759,7 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsMatBase<N, I, &'a [I], &'a [I], &'a [N]> {
         &self,
         i: usize,
         count: usize,
-    ) -> CsMatViewI<'a, N, I> {
+    ) -> CsMatViewI<'a, N, I, Iptr> {
         if count == 0 {
             panic!("Empty view");
         }
@@ -760,7 +782,7 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsMatBase<N, I, &'a [I], &'a [I], &'a [N]> {
     ///
     /// This method will yield the correct lifetime for iterating over a sparse
     /// matrix view.
-    pub fn iter_rbr(&self) -> CsIter<'a, N, I> {
+    pub fn iter_rbr(&self) -> CsIter<'a, N, I, Iptr> {
         CsIter {
             storage: self.storage,
             cur_outer: I::from_usize(0),
@@ -771,11 +793,12 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsMatBase<N, I, &'a [I], &'a [I], &'a [N]> {
 }
 
 /// # Common methods for all variants of compressed sparse matrices.
-impl<N, I, IptrStorage, IndStorage, DataStorage>
-    CsMatBase<N, I, IptrStorage, IndStorage, DataStorage>
+impl<N, I, Iptr, IptrStorage, IndStorage, DataStorage>
+    CsMatBase<N, I, IptrStorage, IndStorage, DataStorage, Iptr>
 where
     I: SpIndex,
-    IptrStorage: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IptrStorage: Deref<Target = [Iptr]>,
     IndStorage: Deref<Target = [I]>,
     DataStorage: Deref<Target = [N]>,
 {
@@ -855,7 +878,7 @@ where
     /// assert_eq!(eye.indices()[loc], 3);
     /// assert_eq!(eye.data()[loc], 1.);
     /// ```
-    pub fn indptr(&self) -> &[I] {
+    pub fn indptr(&self) -> &[Iptr] {
         &self.indptr[..]
     }
 
@@ -918,7 +941,7 @@ where
 
     /// Transposed view of this matrix
     /// No allocation required (this is simply a storage order change)
-    pub fn transpose_view(&self) -> CsMatViewI<N, I> {
+    pub fn transpose_view(&self) -> CsMatViewI<N, I, Iptr> {
         CsMatViewI {
             storage: self.storage.other_storage(),
             nrows: self.ncols,
@@ -931,7 +954,7 @@ where
 
     /// Get an owned version of this matrix. If the matrix was already
     /// owned, this will make a deep copy.
-    pub fn to_owned(&self) -> CsMatI<N, I>
+    pub fn to_owned(&self) -> CsMatI<N, I, Iptr>
     where
         N: Clone,
     {
@@ -951,15 +974,16 @@ where
     ///
     /// If the indices or indptr values cannot be represented by the requested
     /// integer type.
-    pub fn to_other_types<I2, N2>(&self) -> CsMatI<N2, I2>
+    pub fn to_other_types<I2, N2, Iptr2>(&self) -> CsMatI<N2, I2, Iptr2>
     where
         N: Clone + Into<N2>,
         I2: SpIndex,
+        Iptr2: SpIndex,
     {
         let indptr = self
             .indptr
             .iter()
-            .map(|i| I2::from_usize(i.index()))
+            .map(|i| Iptr2::from_usize(i.index()))
             .collect();
         let indices = self
             .indices
@@ -978,7 +1002,7 @@ where
     }
 
     /// Return a view into the current matrix
-    pub fn view(&self) -> CsMatViewI<N, I> {
+    pub fn view(&self) -> CsMatViewI<N, I, Iptr> {
         CsMatViewI {
             storage: self.storage,
             nrows: self.nrows,
@@ -1012,7 +1036,7 @@ where
     ///     assert_eq!(val, 1.);
     /// }
     /// ```
-    pub fn outer_iterator(&self) -> OuterIterator<N, I> {
+    pub fn outer_iterator(&self) -> OuterIterator<N, I, Iptr> {
         let inner_len = match self.storage {
             CSR => self.ncols,
             CSC => self.nrows,
@@ -1031,7 +1055,7 @@ where
     pub fn outer_iterator_perm<'a, 'perm: 'a>(
         &'a self,
         perm: PermViewI<'perm, I>,
-    ) -> OuterIteratorPerm<'a, 'perm, N, I> {
+    ) -> OuterIteratorPerm<'a, 'perm, N, I, Iptr> {
         let (inner_len, oriented_perm) = match self.storage {
             CSR => (self.ncols, perm.reborrow()),
             CSC => (self.nrows, perm.reborrow_inv()),
@@ -1066,7 +1090,7 @@ where
     pub fn outer_block_iter(
         &self,
         block_size: usize,
-    ) -> ChunkOuterBlocks<N, I> {
+    ) -> ChunkOuterBlocks<N, I, Iptr> {
         let m = CsMatBase {
             storage: self.storage,
             nrows: self.rows(),
@@ -1083,7 +1107,7 @@ where
     }
 
     /// Return a new sparse matrix with the same sparsity pattern, with all non-zero values mapped by the function `f`.
-    pub fn map<F, N2>(&self, f: F) -> CsMatI<N2, I>
+    pub fn map<F, N2>(&self, f: F) -> CsMatI<N2, I, Iptr>
     where
         F: FnMut(&N) -> N2,
     {
@@ -1216,7 +1240,7 @@ where
 
     /// Get an iterator that yields the non-zero locations and values stored in
     /// this matrix, in the fastest iteration order.
-    pub fn iter(&self) -> CsIter<N, I> {
+    pub fn iter(&self) -> CsIter<N, I, Iptr> {
         CsIter {
             storage: self.storage,
             cur_outer: I::from_usize(0),
@@ -1227,22 +1251,23 @@ where
 }
 
 /// # Methods to convert between storage orders
-impl<N, I, IptrStorage, IndStorage, DataStorage>
-    CsMatBase<N, I, IptrStorage, IndStorage, DataStorage>
+impl<N, I, Iptr, IptrStorage, IndStorage, DataStorage>
+    CsMatBase<N, I, IptrStorage, IndStorage, DataStorage, Iptr>
 where
     N: Default,
     I: SpIndex,
-    IptrStorage: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IptrStorage: Deref<Target = [Iptr]>,
     IndStorage: Deref<Target = [I]>,
     DataStorage: Deref<Target = [N]>,
 {
     /// Create a matrix mathematically equal to this one, but with the
     /// opposed storage (a CSC matrix will be converted to CSR, and vice versa)
-    pub fn to_other_storage(&self) -> CsMatI<N, I>
+    pub fn to_other_storage(&self) -> CsMatI<N, I, Iptr>
     where
         N: Clone,
     {
-        let mut indptr = vec![I::zero(); self.inner_dims() + 1];
+        let mut indptr = vec![Iptr::zero(); self.inner_dims() + 1];
         let mut indices = vec![I::zero(); self.nnz()];
         let mut data = vec![N::default(); self.nnz()];
         raw::convert_mat_storage(
@@ -1263,7 +1288,7 @@ where
 
     /// Create a new CSC matrix equivalent to this one.
     /// A new matrix will be created even if this matrix was already CSC.
-    pub fn to_csc(&self) -> CsMatI<N, I>
+    pub fn to_csc(&self) -> CsMatI<N, I, Iptr>
     where
         N: Clone,
     {
@@ -1275,7 +1300,7 @@ where
 
     /// Create a new CSR matrix equivalent to this one.
     /// A new matrix will be created even if this matrix was already CSR.
-    pub fn to_csr(&self) -> CsMatI<N, I>
+    pub fn to_csr(&self) -> CsMatI<N, I, Iptr>
     where
         N: Clone,
     {
@@ -1287,11 +1312,12 @@ where
 }
 
 /// # Methods for sparse matrices holding mutable access to their values.
-impl<N, I, IptrStorage, IndStorage, DataStorage>
-    CsMatBase<N, I, IptrStorage, IndStorage, DataStorage>
+impl<N, I, Iptr, IptrStorage, IndStorage, DataStorage>
+    CsMatBase<N, I, IptrStorage, IndStorage, DataStorage, Iptr>
 where
     I: SpIndex,
-    IptrStorage: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IptrStorage: Deref<Target = [Iptr]>,
     IndStorage: Deref<Target = [I]>,
     DataStorage: DerefMut<Target = [N]>,
 {
@@ -1397,7 +1423,7 @@ where
     /// This iterator yields mutable sparse vector views for each outer
     /// dimension. Only the non-zero values can be modified, the
     /// structure is kept immutable.
-    pub fn outer_iterator_mut(&mut self) -> OuterIteratorMut<N, I> {
+    pub fn outer_iterator_mut(&mut self) -> OuterIteratorMut<N, I, Iptr> {
         let inner_len = match self.storage {
             CSR => self.ncols,
             CSC => self.nrows,
@@ -1411,11 +1437,12 @@ where
     }
 }
 
-impl<N, I, IptrStorage, IndStorage, DataStorage>
-    CsMatBase<N, I, IptrStorage, IndStorage, DataStorage>
+impl<N, I, Iptr, IptrStorage, IndStorage, DataStorage>
+    CsMatBase<N, I, IptrStorage, IndStorage, DataStorage, Iptr>
 where
     I: SpIndex,
-    IptrStorage: DerefMut<Target = [I]>,
+    Iptr: SpIndex,
+    IptrStorage: DerefMut<Target = [Iptr]>,
     IndStorage: DerefMut<Target = [I]>,
     DataStorage: DerefMut<Target = [N]>,
 {
@@ -1454,7 +1481,7 @@ where
     /// ```
     pub fn modify<F>(&mut self, mut f: F)
     where
-        F: FnMut(&mut [I], &mut [I], &mut [N]),
+        F: FnMut(&mut [Iptr], &mut [I], &mut [N]),
     {
         f(
             &mut self.indptr[..],
@@ -1526,9 +1553,9 @@ pub mod raw {
     ///
     /// Panics if the output slices don't match the input matrices'
     /// corresponding slices.
-    pub fn convert_mat_storage<N: Clone, I: SpIndex>(
-        mat: CsMatViewI<N, I>,
-        indptr: &mut [I],
+    pub fn convert_mat_storage<N: Clone, I: SpIndex, Iptr: SpIndex>(
+        mat: CsMatViewI<N, I, Iptr>,
+        indptr: &mut [Iptr],
         indices: &mut [I],
         data: &mut [N],
     ) {
@@ -1536,15 +1563,15 @@ pub mod raw {
         assert_eq!(indices.len(), mat.indices().len());
         assert_eq!(data.len(), mat.data().len());
 
-        assert!(indptr.iter().all(|x| *x == I::zero()));
+        assert!(indptr.iter().all(|x| x.is_zero()));
 
         for vec in mat.outer_iterator() {
             for (inner_dim, _) in vec.iter() {
-                indptr[inner_dim] += I::one();
+                indptr[inner_dim] += Iptr::one();
             }
         }
 
-        let mut cumsum = I::zero();
+        let mut cumsum = Iptr::zero();
         for iptr in indptr.iter_mut() {
             let tmp = *iptr;
             *iptr = cumsum;
@@ -1559,18 +1586,20 @@ pub mod raw {
                 let dest = indptr[inner_dim].index();
                 data[dest] = val.clone();
                 indices[dest] = I::from_usize(outer_dim);
-                indptr[inner_dim] += I::one();
+                indptr[inner_dim] += Iptr::one();
             }
         }
 
-        let mut last = I::zero();
+        let mut last = Iptr::zero();
         for iptr in indptr.iter_mut() {
             swap(iptr, &mut last);
         }
     }
 }
 
-impl<'a, N: 'a, I: 'a + SpIndex> CsMatBase<N, I, Vec<I>, &'a [I], &'a [N]> {
+impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
+    CsMatBase<N, I, Vec<Iptr>, &'a [I], &'a [N], Iptr>
+{
     /// Create a borrowed row or column CsMat matrix from raw data,
     /// without checking their validity
     ///
@@ -1582,10 +1611,10 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsMatBase<N, I, Vec<I>, &'a [I], &'a [N]> {
         storage: CompressedStorage,
         nrows: usize,
         ncols: usize,
-        indptr: *const I,
+        indptr: *const Iptr,
         indices: *const I,
         data: *const N,
-    ) -> CsMatVecView_<'a, N, I> {
+    ) -> CsMatVecView_<'a, N, I, Iptr> {
         let indptr = slice::from_raw_parts(indptr, 2);
         let nnz = indptr[1].index();
         CsMatVecView_ {
@@ -1601,22 +1630,26 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsMatBase<N, I, Vec<I>, &'a [I], &'a [N]> {
     }
 }
 
-impl<'a, 'b, N, I, IpStorage, IStorage, DStorage, IpS2, IS2, DS2>
-    Add<&'b CsMatBase<N, I, IpS2, IS2, DS2>>
-    for &'a CsMatBase<N, I, IpStorage, IStorage, DStorage>
+impl<'a, 'b, N, I, Iptr, IpStorage, IStorage, DStorage, IpS2, IS2, DS2>
+    Add<&'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>>
+    for &'a CsMatBase<N, I, IpStorage, IStorage, DStorage, Iptr>
 where
     N: 'a + Copy + Num + Default,
     I: 'a + SpIndex,
-    IpStorage: 'a + Deref<Target = [I]>,
+    Iptr: 'a + SpIndex,
+    IpStorage: 'a + Deref<Target = [Iptr]>,
     IStorage: 'a + Deref<Target = [I]>,
     DStorage: 'a + Deref<Target = [N]>,
-    IpS2: 'a + Deref<Target = [I]>,
+    IpS2: 'a + Deref<Target = [Iptr]>,
     IS2: 'a + Deref<Target = [I]>,
     DS2: 'a + Deref<Target = [N]>,
 {
-    type Output = CsMatI<N, I>;
+    type Output = CsMatI<N, I, Iptr>;
 
-    fn add(self, rhs: &'b CsMatBase<N, I, IpS2, IS2, DS2>) -> CsMatI<N, I> {
+    fn add(
+        self,
+        rhs: &'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>,
+    ) -> CsMatI<N, I, Iptr> {
         if self.storage() != rhs.view().storage() {
             return binop::add_mat_same_storage(
                 self,
@@ -1627,19 +1660,20 @@ where
     }
 }
 
-impl<'a, 'b, N, I, IpStorage, IStorage, DStorage, Mat> Sub<&'b Mat>
-    for &'a CsMatBase<N, I, IpStorage, IStorage, DStorage>
+impl<'a, 'b, N, I, Iptr, IpStorage, IStorage, DStorage, Mat> Sub<&'b Mat>
+    for &'a CsMatBase<N, I, IpStorage, IStorage, DStorage, Iptr>
 where
     N: 'a + Copy + Num + Default,
     I: 'a + SpIndex,
-    IpStorage: 'a + Deref<Target = [I]>,
+    Iptr: 'a + SpIndex,
+    IpStorage: 'a + Deref<Target = [Iptr]>,
     IStorage: 'a + Deref<Target = [I]>,
     DStorage: 'a + Deref<Target = [N]>,
-    Mat: SpMatView<N, I>,
+    Mat: SpMatView<N, I, Iptr>,
 {
-    type Output = CsMatI<N, I>;
+    type Output = CsMatI<N, I, Iptr>;
 
-    fn sub(self, rhs: &'b Mat) -> CsMatI<N, I> {
+    fn sub(self, rhs: &'b Mat) -> CsMatI<N, I, Iptr> {
         if self.storage() != rhs.view().storage() {
             return binop::sub_mat_same_storage(
                 self,
@@ -1652,17 +1686,18 @@ where
 
 macro_rules! sparse_scalar_mul {
     ($scalar: ident) => {
-        impl<'a, I, IpStorage, IStorage, DStorage> Mul<$scalar>
-            for &'a CsMatBase<$scalar, I, IpStorage, IStorage, DStorage>
+        impl<'a, I, Iptr, IpStorage, IStorage, DStorage> Mul<$scalar>
+            for &'a CsMatBase<$scalar, I, IpStorage, IStorage, DStorage, Iptr>
         where
             I: 'a + SpIndex,
-            IpStorage: 'a + Deref<Target = [I]>,
+            Iptr: 'a + SpIndex,
+            IpStorage: 'a + Deref<Target = [Iptr]>,
             IStorage: 'a + Deref<Target = [I]>,
             DStorage: 'a + Deref<Target = [$scalar]>,
         {
-            type Output = CsMatI<$scalar, I>;
+            type Output = CsMatI<$scalar, I, Iptr>;
 
-            fn mul(self, rhs: $scalar) -> CsMatI<$scalar, I> {
+            fn mul(self, rhs: $scalar) -> CsMatI<$scalar, I, Iptr> {
                 binop::scalar_mul_mat(self, rhs)
             }
         }
@@ -1678,22 +1713,26 @@ sparse_scalar_mul!(usize);
 sparse_scalar_mul!(f32);
 sparse_scalar_mul!(f64);
 
-impl<'a, 'b, N, I, IpS1, IS1, DS1, IpS2, IS2, DS2>
-    Mul<&'b CsMatBase<N, I, IpS2, IS2, DS2>>
-    for &'a CsMatBase<N, I, IpS1, IS1, DS1>
+impl<'a, 'b, N, I, Iptr, IpS1, IS1, DS1, IpS2, IS2, DS2>
+    Mul<&'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>>
+    for &'a CsMatBase<N, I, IpS1, IS1, DS1, Iptr>
 where
     N: 'a + Copy + Num + Default,
     I: 'a + SpIndex,
-    IpS1: 'a + Deref<Target = [I]>,
+    Iptr: 'a + SpIndex,
+    IpS1: 'a + Deref<Target = [Iptr]>,
     IS1: 'a + Deref<Target = [I]>,
     DS1: 'a + Deref<Target = [N]>,
-    IpS2: 'b + Deref<Target = [I]>,
+    IpS2: 'b + Deref<Target = [Iptr]>,
     IS2: 'b + Deref<Target = [I]>,
     DS2: 'b + Deref<Target = [N]>,
 {
-    type Output = CsMatI<N, I>;
+    type Output = CsMatI<N, I, Iptr>;
 
-    fn mul(self, rhs: &'b CsMatBase<N, I, IpS2, IS2, DS2>) -> CsMatI<N, I> {
+    fn mul(
+        self,
+        rhs: &'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>,
+    ) -> CsMatI<N, I, Iptr> {
         match (self.storage(), rhs.storage()) {
             (CSR, CSR) => {
                 let mut workspace = prod::workspace_csr(self, rhs);
@@ -1715,12 +1754,13 @@ where
     }
 }
 
-impl<'a, 'b, N, I, IpS, IS, DS, DS2> Add<&'b ArrayBase<DS2, Ix2>>
-    for &'a CsMatBase<N, I, IpS, IS, DS>
+impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Add<&'b ArrayBase<DS2, Ix2>>
+    for &'a CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     N: 'a + Copy + Num + Default,
     I: 'a + SpIndex,
-    IpS: 'a + Deref<Target = [I]>,
+    Iptr: 'a + SpIndex,
+    IpS: 'a + Deref<Target = [Iptr]>,
     IS: 'a + Deref<Target = [I]>,
     DS: 'a + Deref<Target = [N]>,
     DS2: 'b + ndarray::Data<Elem = N>,
@@ -1763,12 +1803,13 @@ where
     }
 }
 
-impl<'a, 'b, N, I, IpS, IS, DS, DS2> Mul<&'b ArrayBase<DS2, Ix2>>
-    for &'a CsMatBase<N, I, IpS, IS, DS>
+impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Mul<&'b ArrayBase<DS2, Ix2>>
+    for &'a CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     N: 'a + Copy + Num + Default,
     I: 'a + SpIndex,
-    IpS: 'a + Deref<Target = [I]>,
+    Iptr: 'a + SpIndex,
+    IpS: 'a + Deref<Target = [Iptr]>,
     IS: 'a + Deref<Target = [I]>,
     DS: 'a + Deref<Target = [N]>,
     DS2: 'b + ndarray::Data<Elem = N>,
@@ -1823,12 +1864,13 @@ where
     }
 }
 
-impl<'a, 'b, N, I, IpS, IS, DS, DS2> Dot<ArrayBase<DS2, Ix2>>
-    for CsMatBase<N, I, IpS, IS, DS>
+impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Dot<ArrayBase<DS2, Ix2>>
+    for CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     N: 'a + Copy + Num + Default,
     I: 'a + SpIndex,
-    IpS: 'a + Deref<Target = [I]>,
+    Iptr: 'a + SpIndex,
+    IpS: 'a + Deref<Target = [Iptr]>,
     IS: 'a + Deref<Target = [I]>,
     DS: 'a + Deref<Target = [N]>,
     DS2: 'b + ndarray::Data<Elem = N>,
@@ -1840,12 +1882,13 @@ where
     }
 }
 
-impl<'a, 'b, N, I, IpS, IS, DS, DS2> Mul<&'b ArrayBase<DS2, Ix1>>
-    for &'a CsMatBase<N, I, IpS, IS, DS>
+impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Mul<&'b ArrayBase<DS2, Ix1>>
+    for &'a CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     N: 'a + Copy + Num + Default,
     I: 'a + SpIndex,
-    IpS: 'a + Deref<Target = [I]>,
+    Iptr: 'a + SpIndex,
+    IpS: 'a + Deref<Target = [Iptr]>,
     IS: 'a + Deref<Target = [I]>,
     DS: 'a + Deref<Target = [N]>,
     DS2: 'b + ndarray::Data<Elem = N>,
@@ -1880,12 +1923,13 @@ where
     }
 }
 
-impl<'a, 'b, N, I, IpS, IS, DS, DS2> Dot<ArrayBase<DS2, Ix1>>
-    for CsMatBase<N, I, IpS, IS, DS>
+impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Dot<ArrayBase<DS2, Ix1>>
+    for CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     N: 'a + Copy + Num + Default,
     I: 'a + SpIndex,
-    IpS: 'a + Deref<Target = [I]>,
+    Iptr: 'a + SpIndex,
+    IpS: 'a + Deref<Target = [Iptr]>,
     IS: 'a + Deref<Target = [I]>,
     DS: 'a + Deref<Target = [N]>,
     DS2: 'b + ndarray::Data<Elem = N>,
@@ -1897,10 +1941,12 @@ where
     }
 }
 
-impl<N, I, IpS, IS, DS> Index<[usize; 2]> for CsMatBase<N, I, IpS, IS, DS>
+impl<N, I, Iptr, IpS, IS, DS> Index<[usize; 2]>
+    for CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     I: SpIndex,
-    IpS: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IpS: Deref<Target = [Iptr]>,
     IS: Deref<Target = [I]>,
     DS: Deref<Target = [N]>,
 {
@@ -1913,10 +1959,12 @@ where
     }
 }
 
-impl<N, I, IpS, IS, DS> IndexMut<[usize; 2]> for CsMatBase<N, I, IpS, IS, DS>
+impl<N, I, Iptr, IpS, IS, DS> IndexMut<[usize; 2]>
+    for CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     I: SpIndex,
-    IpS: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IpS: Deref<Target = [Iptr]>,
     IS: Deref<Target = [I]>,
     DS: DerefMut<Target = [N]>,
 {
@@ -1927,10 +1975,12 @@ where
     }
 }
 
-impl<N, I, IpS, IS, DS> Index<NnzIndex> for CsMatBase<N, I, IpS, IS, DS>
+impl<N, I, Iptr, IpS, IS, DS> Index<NnzIndex>
+    for CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     I: SpIndex,
-    IpS: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IpS: Deref<Target = [Iptr]>,
     IS: Deref<Target = [I]>,
     DS: Deref<Target = [N]>,
 {
@@ -1942,10 +1992,12 @@ where
     }
 }
 
-impl<N, I, IpS, IS, DS> IndexMut<NnzIndex> for CsMatBase<N, I, IpS, IS, DS>
+impl<N, I, Iptr, IpS, IS, DS> IndexMut<NnzIndex>
+    for CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     I: SpIndex,
-    IpS: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IpS: Deref<Target = [Iptr]>,
     IS: Deref<Target = [I]>,
     DS: DerefMut<Target = [N]>,
 {
@@ -1955,10 +2007,11 @@ where
     }
 }
 
-impl<N, I, IpS, IS, DS> SparseMat for CsMatBase<N, I, IpS, IS, DS>
+impl<N, I, Iptr, IpS, IS, DS> SparseMat for CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     I: SpIndex,
-    IpS: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IpS: Deref<Target = [Iptr]>,
     IS: Deref<Target = [I]>,
     DS: Deref<Target = [N]>,
 {
@@ -1975,11 +2028,13 @@ where
     }
 }
 
-impl<'a, N, I, IpS, IS, DS> SparseMat for &'a CsMatBase<N, I, IpS, IS, DS>
+impl<'a, N, I, Iptr, IpS, IS, DS> SparseMat
+    for &'a CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     I: 'a + SpIndex,
+    Iptr: 'a + SpIndex,
     N: 'a,
-    IpS: Deref<Target = [I]>,
+    IpS: Deref<Target = [Iptr]>,
     IS: Deref<Target = [I]>,
     DS: Deref<Target = [N]>,
 {
@@ -1996,28 +2051,31 @@ where
     }
 }
 
-impl<'a, N, I, IpS, IS, DS> IntoIterator for &'a CsMatBase<N, I, IpS, IS, DS>
+impl<'a, N, I, IpS, IS, DS, Iptr> IntoIterator
+    for &'a CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     I: 'a + SpIndex,
+    Iptr: 'a + SpIndex,
     N: 'a,
-    IpS: Deref<Target = [I]>,
+    IpS: Deref<Target = [Iptr]>,
     IS: Deref<Target = [I]>,
     DS: Deref<Target = [N]>,
 {
     type Item = (&'a N, (I, I));
-    type IntoIter = CsIter<'a, N, I>;
+    type IntoIter = CsIter<'a, N, I, Iptr>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl<'a, N, I> IntoIterator for CsMatViewI<'a, N, I>
+impl<'a, N, I, Iptr> IntoIterator for CsMatViewI<'a, N, I, Iptr>
 where
     I: 'a + SpIndex,
+    Iptr: 'a + SpIndex,
     N: 'a,
 {
     type Item = (&'a N, (I, I));
-    type IntoIter = CsIter<'a, N, I>;
+    type IntoIter = CsIter<'a, N, I, Iptr>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter_rbr()
     }
@@ -2025,14 +2083,17 @@ where
 
 /// An iterator over non-overlapping blocks of a matrix,
 /// along the least-varying dimension
-pub struct ChunkOuterBlocks<'a, N: 'a, I: 'a + SpIndex> {
-    mat: CsMatViewI<'a, N, I>,
+pub struct ChunkOuterBlocks<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex = I>
+{
+    mat: CsMatViewI<'a, N, I, Iptr>,
     dims_in_bloc: usize,
     bloc_count: usize,
 }
 
-impl<'a, N: 'a, I: 'a + SpIndex> Iterator for ChunkOuterBlocks<'a, N, I> {
-    type Item = CsMatViewI<'a, N, I>;
+impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex> Iterator
+    for ChunkOuterBlocks<'a, N, I, Iptr>
+{
+    type Item = CsMatViewI<'a, N, I, Iptr>;
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         let cur_dim = self.dims_in_bloc * self.bloc_count;
         let end_dim = self.dims_in_bloc + cur_dim;
@@ -2546,7 +2607,7 @@ mod test {
             vec![1, 0, 2, 2],
             vec![1.; 4],
         );
-        let mat_: CsMatI<f32, usize> = mat.to_other_types();
+        let mat_: CsMatI<f32, usize, u32> = mat.to_other_types();
         assert_eq!(mat_.indptr(), &[0, 1, 3, 4]);
         assert_eq!(mat_.data(), &[1.0f32, 1., 1., 1.]);
     }

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -8,13 +8,14 @@ use stack::{self, DStack, StackVal};
 /// Sparse triangular solves
 use std::ops::IndexMut;
 
-fn check_solver_dimensions<N, I, V: ?Sized>(
-    lower_tri_mat: &CsMatViewI<N, I>,
+fn check_solver_dimensions<N, I, Iptr, V: ?Sized>(
+    lower_tri_mat: &CsMatViewI<N, I, Iptr>,
     rhs: &V,
 ) where
     N: Copy + Num,
     V: vec::VecDim<N>,
     I: SpIndex,
+    Iptr: SpIndex,
 {
     let (cols, rows) = (lower_tri_mat.cols(), lower_tri_mat.rows());
     if cols != rows {
@@ -32,14 +33,15 @@ fn check_solver_dimensions<N, I, V: ?Sized>(
 ///
 /// This solve does not assume the input matrix to actually be
 /// triangular, instead it ignores the upper triangular part.
-pub fn lsolve_csr_dense_rhs<N, I, V: ?Sized>(
-    lower_tri_mat: CsMatViewI<N, I>,
+pub fn lsolve_csr_dense_rhs<N, I, Iptr, V: ?Sized>(
+    lower_tri_mat: CsMatViewI<N, I, Iptr>,
     rhs: &mut V,
 ) -> Result<(), SprsError>
 where
     N: Copy + Num,
     V: IndexMut<usize, Output = N> + vec::VecDim<N>,
     I: SpIndex,
+    Iptr: SpIndex,
 {
     check_solver_dimensions(&lower_tri_mat, rhs);
     if !lower_tri_mat.is_csr() {
@@ -84,14 +86,15 @@ where
 /// is the diagonal element (thus actual sorted lower triangular matrices work
 /// best). Otherwise, logarithmic search for the diagonal element
 /// has to be performed for each column.
-pub fn lsolve_csc_dense_rhs<N, I, V: ?Sized>(
-    lower_tri_mat: CsMatViewI<N, I>,
+pub fn lsolve_csc_dense_rhs<N, I, Iptr, V: ?Sized>(
+    lower_tri_mat: CsMatViewI<N, I, Iptr>,
     rhs: &mut V,
 ) -> Result<(), SprsError>
 where
     N: Copy + Num,
     V: IndexMut<usize, Output = N> + vec::VecDim<N>,
     I: SpIndex,
+    Iptr: SpIndex,
 {
     check_solver_dimensions(&lower_tri_mat, rhs);
     if !lower_tri_mat.is_csc() {
@@ -151,14 +154,15 @@ where
 /// is the diagonal element (thus actual sorted lower triangular matrices work
 /// best). Otherwise, logarithmic search for the diagonal element
 /// has to be performed for each column.
-pub fn usolve_csc_dense_rhs<N, I, V: ?Sized>(
-    upper_tri_mat: CsMatViewI<N, I>,
+pub fn usolve_csc_dense_rhs<N, I, Iptr, V: ?Sized>(
+    upper_tri_mat: CsMatViewI<N, I, Iptr>,
     rhs: &mut V,
 ) -> Result<(), SprsError>
 where
     N: Copy + Num,
     V: IndexMut<usize, Output = N> + vec::VecDim<N>,
     I: SpIndex,
+    Iptr: SpIndex,
 {
     check_solver_dimensions(&upper_tri_mat, rhs);
     if !upper_tri_mat.is_csc() {
@@ -203,14 +207,15 @@ where
 ///
 /// This solve does not assume the input matrix to actually be
 /// triangular, instead it ignores the upper triangular part.
-pub fn usolve_csr_dense_rhs<N, I, V: ?Sized>(
-    upper_tri_mat: CsMatViewI<N, I>,
+pub fn usolve_csr_dense_rhs<N, I, Iptr, V: ?Sized>(
+    upper_tri_mat: CsMatViewI<N, I, Iptr>,
     rhs: &mut V,
 ) -> Result<(), SprsError>
 where
     N: Copy + Num,
     V: IndexMut<usize, Output = N> + vec::VecDim<N>,
     I: SpIndex,
+    Iptr: SpIndex,
 {
     check_solver_dimensions(&upper_tri_mat, rhs);
     if !upper_tri_mat.is_csr() {
@@ -266,8 +271,8 @@ where
 /// * if dstack is not empty
 /// * if w_workspace is not of length n
 ///
-pub fn lsolve_csc_sparse_rhs<N, I>(
-    lower_tri_mat: CsMatViewI<N, I>,
+pub fn lsolve_csc_sparse_rhs<N, I, Iptr>(
+    lower_tri_mat: CsMatViewI<N, I, Iptr>,
     rhs: CsVecViewI<N, I>,
     dstack: &mut DStack<StackVal<usize>>,
     x_workspace: &mut [N],
@@ -276,6 +281,7 @@ pub fn lsolve_csc_sparse_rhs<N, I>(
 where
     N: Copy + Num,
     I: SpIndex,
+    Iptr: SpIndex,
 {
     if !lower_tri_mat.is_csc() {
         panic!("Storage mismatch");

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -76,10 +76,11 @@ pub use self::csmat::CompressedStorage;
 /// [`hstack`]: fn.hstack.html
 /// [`bmat`]: fn.bmat.html
 #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
-pub struct CsMatBase<N, I, IptrStorage, IndStorage, DataStorage>
+pub struct CsMatBase<N, I, IptrStorage, IndStorage, DataStorage, Iptr = I>
 where
     I: SpIndex,
-    IptrStorage: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IptrStorage: Deref<Target = [Iptr]>,
     IndStorage: Deref<Target = [I]>,
     DataStorage: Deref<Target = [N]>,
 {
@@ -91,11 +92,14 @@ where
     data: DataStorage,
 }
 
-pub type CsMatI<N, I> = CsMatBase<N, I, Vec<I>, Vec<I>, Vec<N>>;
-pub type CsMatViewI<'a, N, I> = CsMatBase<N, I, &'a [I], &'a [I], &'a [N]>;
-pub type CsMatViewMutI<'a, N, I> =
-    CsMatBase<N, I, &'a [I], &'a [I], &'a mut [N]>;
-pub type CsMatVecView_<'a, N, I> = CsMatBase<N, I, Array2<I>, &'a [I], &'a [N]>;
+pub type CsMatI<N, I, Iptr = I> =
+    CsMatBase<N, I, Vec<Iptr>, Vec<I>, Vec<N>, Iptr>;
+pub type CsMatViewI<'a, N, I, Iptr = I> =
+    CsMatBase<N, I, &'a [Iptr], &'a [I], &'a [N], Iptr>;
+pub type CsMatViewMutI<'a, N, I, Iptr = I> =
+    CsMatBase<N, I, &'a [Iptr], &'a [I], &'a mut [N], Iptr>;
+pub type CsMatVecView_<'a, N, I, Iptr = I> =
+    CsMatBase<N, I, Array2<Iptr>, &'a [I], &'a [N], Iptr>;
 
 pub type CsMat<N> = CsMatI<N, usize>;
 pub type CsMatView<'a, N> = CsMatViewI<'a, N, usize>;

--- a/src/sparse/symmetric.rs
+++ b/src/sparse/symmetric.rs
@@ -4,13 +4,14 @@ use std::ops::Deref;
 use indexing::SpIndex;
 use sparse::prelude::*;
 
-pub fn is_symmetric<N, I, IpStorage, IStorage, DStorage>(
-    mat: &CsMatBase<N, I, IpStorage, IStorage, DStorage>,
+pub fn is_symmetric<N, I, Iptr, IpStorage, IStorage, DStorage>(
+    mat: &CsMatBase<N, I, IpStorage, IStorage, DStorage, Iptr>,
 ) -> bool
 where
     N: Copy + PartialEq,
     I: SpIndex,
-    IpStorage: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IpStorage: Deref<Target = [Iptr]>,
     IStorage: Deref<Target = [I]>,
     DStorage: Deref<Target = [N]>,
 {

--- a/src/sparse/to_dense.rs
+++ b/src/sparse/to_dense.rs
@@ -8,12 +8,13 @@ use Ix2;
 ///
 /// The dense matrix will not be zeroed prior to assignment,
 /// so existing values not corresponding to non-zeroes will be preserved.
-pub fn assign_to_dense<N, I>(
+pub fn assign_to_dense<N, I, Iptr>(
     mut array: ArrayViewMut<N, Ix2>,
-    spmat: CsMatViewI<N, I>,
+    spmat: CsMatViewI<N, I, Iptr>,
 ) where
     N: Clone,
     I: SpIndex,
+    Iptr: SpIndex,
 {
     if spmat.cols() != array.shape()[1] {
         panic!("Dimension mismatch");

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -678,11 +678,11 @@ where
     }
 
     /// View this vector as a matrix with only one row.
-    pub fn row_view(&self) -> CsMatVecView_<N, I> {
+    pub fn row_view<Iptr: SpIndex>(&self) -> CsMatVecView_<N, I, Iptr> {
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = Array2 {
-            data: [I::zero(), I::from_usize(self.indices.len())],
+            data: [Iptr::zero(), Iptr::from_usize(self.indices.len())],
         };
         CsMatBase {
             storage: CSR,
@@ -695,11 +695,11 @@ where
     }
 
     /// View this vector as a matrix with only one column.
-    pub fn col_view(&self) -> CsMatVecView_<N, I> {
+    pub fn col_view<Iptr: SpIndex>(&self) -> CsMatVecView_<N, I, Iptr> {
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = Array2 {
-            data: [I::zero(), I::from_usize(self.indices.len())],
+            data: [Iptr::zero(), Iptr::from_usize(self.indices.len())],
         };
         CsMatBase {
             storage: CSC,
@@ -1042,30 +1042,32 @@ where
     }
 }
 
-impl<'a, 'b, N, I, IS1, DS1, IpS2, IS2, DS2>
-    Mul<&'b CsMatBase<N, I, IpS2, IS2, DS2>> for &'a CsVecBase<IS1, DS1>
+impl<'a, 'b, N, I, Iptr, IS1, DS1, IpS2, IS2, DS2>
+    Mul<&'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>> for &'a CsVecBase<IS1, DS1>
 where
     N: 'a + Copy + Num + Default,
     I: 'a + SpIndex,
+    Iptr: 'a + SpIndex,
     IS1: 'a + Deref<Target = [I]>,
     DS1: 'a + Deref<Target = [N]>,
-    IpS2: 'b + Deref<Target = [I]>,
+    IpS2: 'b + Deref<Target = [Iptr]>,
     IS2: 'b + Deref<Target = [I]>,
     DS2: 'b + Deref<Target = [N]>,
 {
     type Output = CsVecI<N, I>;
 
-    fn mul(self, rhs: &CsMatBase<N, I, IpS2, IS2, DS2>) -> CsVecI<N, I> {
+    fn mul(self, rhs: &CsMatBase<N, I, IpS2, IS2, DS2, Iptr>) -> CsVecI<N, I> {
         (&self.row_view() * rhs).outer_view(0).unwrap().to_owned()
     }
 }
 
-impl<'a, 'b, N, I, IpS1, IS1, DS1, IS2, DS2> Mul<&'b CsVecBase<IS2, DS2>>
-    for &'a CsMatBase<N, I, IpS1, IS1, DS1>
+impl<'a, 'b, N, I, Iptr, IpS1, IS1, DS1, IS2, DS2> Mul<&'b CsVecBase<IS2, DS2>>
+    for &'a CsMatBase<N, I, IpS1, IS1, DS1, Iptr>
 where
     N: Copy + Num + Default + Sum,
     I: SpIndex,
-    IpS1: Deref<Target = [I]>,
+    Iptr: SpIndex,
+    IpS1: Deref<Target = [Iptr]>,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [N]>,
     IS2: Deref<Target = [I]>,


### PR DESCRIPTION
(Not pushing directly to main branch given it's a rather large diff.)

This diff adds support to set different types for `indptr` & `indices` in `CsMatBase`, which are currently assumed to have the same type. This can be overly restrictive in some cases: even if the indices are small enough to fit into small integer type, the total number of non-zero entries can still cause overflow.

For example, one might want to use `u32` instead of `usize` for indexing to save space. Say each row has 1000 non-zero elements on average, the total number of elements would overflow `u32` with less than 5MM rows.

Since this diff sets the type for `indptr` to be the same as `indices` by default, this shouldn't break most 3rd party dependent code.