### PR TITLE
Make casting from & to SpIndex panic if it overflows

### DIFF
--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -71,6 +71,7 @@ macro_rules! sp_index_impl {
 
             #[inline(always)]
             fn index_unchecked(self) -> usize {
+                debug_assert!(num_traits::cast::<Self, usize>(self).is_some());
                 self as usize
             }
 
@@ -83,6 +84,7 @@ macro_rules! sp_index_impl {
 
             #[inline(always)]
             fn from_usize_unchecked(ind: usize) -> Self {
+                debug_assert!(num_traits::cast::<usize, Self>(ind).is_some());
                 ind as $int
             }
         }

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -164,7 +164,7 @@ where
                 Both((ind, lval, rval)) => (ind, binop(lval, rval)),
             };
             if binop_val != N::zero() {
-                out_indices[nnz] = I::from_usize(ind);
+                out_indices[nnz] = I::from_usize_unchecked(ind);
                 out_data[nnz] = binop_val;
                 nnz += 1;
             }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -615,7 +615,9 @@ impl<N, I: SpIndex, Iptr: SpIndex>
             CSR => self.nrows += 1,
             CSC => self.ncols += 1,
         }
-        let nnz = Iptr::from_usize(self.indptr.last().unwrap().index_unchecked() + vec.nnz());
+        let nnz = Iptr::from_usize(
+            self.indptr.last().unwrap().index_unchecked() + vec.nnz(),
+        );
         self.indptr.push(nnz);
         self
     }

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -158,7 +158,7 @@ where
         assert!(index < self.dim);
         match self.storage {
             Identity => index,
-            FinitePerm { perm: ref p, .. } => p[index].index(),
+            FinitePerm { perm: ref p, .. } => p[index].index_unchecked(),
         }
     }
 
@@ -168,7 +168,7 @@ where
             Identity => index,
             FinitePerm {
                 perm_inv: ref p_, ..
-            } => p_[index].index(),
+            } => p_[index].index_unchecked(),
         }
     }
 
@@ -200,10 +200,14 @@ where
                 perm: ref p,
                 perm_inv: ref p_,
             } => {
-                let perm =
-                    p.iter().map(|i| I2::from_usize(i.index())).collect();
-                let perm_inv =
-                    p_.iter().map(|i| I2::from_usize(i.index())).collect();
+                let perm = p
+                    .iter()
+                    .map(|i| I2::from_usize(i.index_unchecked()))
+                    .collect();
+                let perm_inv = p_
+                    .iter()
+                    .map(|i| I2::from_usize(i.index_unchecked()))
+                    .collect();
                 PermOwnedI {
                     dim: self.dim,
                     storage: FinitePerm { perm, perm_inv },
@@ -227,7 +231,7 @@ where
             Identity => res,
             FinitePerm { perm: ref p, .. } => {
                 for (pi, r) in p.iter().zip(res.iter_mut()) {
-                    *r = rhs[pi.index()];
+                    *r = rhs[pi.index_unchecked()];
                 }
                 res
             }

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -136,11 +136,11 @@ impl<N, I: SpIndex> TriMatBase<Vec<I>, Vec<N>> {
             "all inputs should have the same length"
         );
         assert!(
-            row_inds.iter().all(|&i| i.index() < shape.0),
+            row_inds.iter().all(|&i| i.index_unchecked() < shape.0),
             "row indices should be within shape"
         );
         assert!(
-            col_inds.iter().all(|&j| j.index() < shape.1),
+            col_inds.iter().all(|&j| j.index_unchecked() < shape.1),
             "col indices should be within shape"
         );
         TriMatI {
@@ -223,7 +223,9 @@ where
             .iter()
             .zip(self.col_inds.iter())
             .enumerate()
-            .filter(|&(_, (&i, &j))| i.index() == row && j.index() == col)
+            .filter(|&(_, (&i, &j))| {
+                i.index_unchecked() == row && j.index_unchecked() == col
+            })
             .map(|(ind, _)| TripletIndex(ind))
             .collect()
     }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -686,7 +686,10 @@ where
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = Array2 {
-            data: [Iptr::zero(), Iptr::from_usize_unchecked(self.indices.len())],
+            data: [
+                Iptr::zero(),
+                Iptr::from_usize_unchecked(self.indices.len()),
+            ],
         };
         CsMatBase {
             storage: CSR,
@@ -703,7 +706,10 @@ where
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = Array2 {
-            data: [Iptr::zero(), Iptr::from_usize_unchecked(self.indices.len())],
+            data: [
+                Iptr::zero(),
+                Iptr::from_usize_unchecked(self.indices.len()),
+            ],
         };
         CsMatBase {
             storage: CSC,

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -87,7 +87,9 @@ impl<'a, N: 'a, I: 'a + SpIndex> Iterator for VectorIterator<'a, N, I> {
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         match self.ind_data.next() {
             None => None,
-            Some((inner_ind, data)) => Some((inner_ind.index(), data)),
+            Some((inner_ind, data)) => {
+                Some((inner_ind.index_unchecked(), data))
+            }
         }
     }
 
@@ -103,7 +105,7 @@ impl<'a, N: 'a, I: 'a + SpIndex> Iterator for VectorIteratorPerm<'a, N, I> {
         match self.ind_data.next() {
             None => None,
             Some((inner_ind, data)) => {
-                Some((self.perm.at(inner_ind.index()), data))
+                Some((self.perm.at(inner_ind.index_unchecked()), data))
             }
         }
     }
@@ -119,7 +121,9 @@ impl<'a, N: 'a, I: 'a + SpIndex> Iterator for VectorIteratorMut<'a, N, I> {
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         match self.ind_data.next() {
             None => None,
-            Some((inner_ind, data)) => Some((inner_ind.index(), data)),
+            Some((inner_ind, data)) => {
+                Some((inner_ind.index_unchecked(), data))
+            }
         }
     }
 
@@ -519,7 +523,7 @@ impl<N, I: SpIndex> CsVecBase<Vec<I>, Vec<N>> {
         match self.indices.last() {
             None => (),
             Some(&last_ind) => {
-                assert!(ind > last_ind.index(), "unsorted append")
+                assert!(ind > last_ind.index_unchecked(), "unsorted append")
             }
         }
         assert!(ind <= self.dim, "out of bounds index");
@@ -667,7 +671,7 @@ where
         let indices = self
             .indices
             .iter()
-            .map(|i| I2::from_usize(i.index()))
+            .map(|i| I2::from_usize(i.index_unchecked()))
             .collect();
         let data = self.data.iter().cloned().collect();
         CsVecI {
@@ -682,7 +686,7 @@ where
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = Array2 {
-            data: [I::zero(), I::from_usize(self.indices.len())],
+            data: [I::zero(), I::from_usize_unchecked(self.indices.len())],
         };
         CsMatBase {
             storage: CSR,
@@ -699,7 +703,7 @@ where
         // Safe because we're taking a view into a vector that has
         // necessarily been checked
         let indptr = Array2 {
-            data: [I::zero(), I::from_usize(self.indices.len())],
+            data: [I::zero(), I::from_usize_unchecked(self.indices.len())],
         };
         CsMatBase {
             storage: CSC,
@@ -728,7 +732,7 @@ where
     pub fn nnz_index(&self, index: usize) -> Option<NnzIndex> {
         self.indices
             .binary_search(&I::from_usize(index))
-            .map(|i| NnzIndex(i.index()))
+            .map(|i| NnzIndex(i.index_unchecked()))
             .ok()
     }
 
@@ -764,7 +768,7 @@ where
         assert_eq!(self.dim(), rhs.dim());
         if rhs.is_dense() {
             self.iter()
-                .map(|(idx, val)| *val * *rhs.index(idx.index()))
+                .map(|(idx, val)| *val * *rhs.index(idx.index_unchecked()))
                 .sum()
         } else {
             let mut lhs_iter = self.iter();
@@ -807,7 +811,7 @@ where
     {
         assert_eq!(self.dim(), rhs.dim());
         self.iter()
-            .map(|(idx, val)| *val * *rhs.index(idx.index()))
+            .map(|(idx, val)| *val * *rhs.index(idx.index_unchecked()))
             .sum()
     }
 
@@ -880,7 +884,7 @@ where
     {
         self.indices()
             .iter()
-            .map(|i| i.index())
+            .map(|i| i.index_unchecked())
             .zip(self.data.iter().cloned())
             .collect()
     }


### PR DESCRIPTION
(Not pushing directly to master branch since this diff has performance implications.)

Got bitten by this issue recently (see https://github.com/tomtung/parabel-rs/commit/597a9f2c87a9ac10c33ca31689d60e26d11d6d15), so I think maybe it better to panic even in release mode if arithmatic overflow happens, while providing the option of unchecked casting explicitly.

I think we can look at existing usage in the code base, and figure out where it's safe to do unchecked casts for better performance?