### PR TITLE
Add `try_` constructors for owning vector & matrix

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,7 @@ pub enum SprsError {
     NonSortedIndices,
     UnsortedIndptr,
     SingularMatrix,
+    IllegalArguments(&'static str),
 }
 
 use self::SprsError::*;
@@ -18,6 +19,7 @@ impl SprsError {
             NonSortedIndices => "a vector's indices are not sorted",
             UnsortedIndptr => "indptr is not sorted",
             SingularMatrix => "matrix is singular",
+            IllegalArguments(s) => s,
         }
     }
 }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -484,7 +484,19 @@ impl<N, I: SpIndex> CsVecBase<Vec<I>, Vec<N>> {
     ///
     /// - if `indices` and `data` lengths differ
     /// - if the vector contains out of bounds indices
-    pub fn new(n: usize, mut indices: Vec<I>, mut data: Vec<N>) -> CsVecI<N, I>
+    pub fn new(n: usize, indices: Vec<I>, data: Vec<N>) -> CsVecI<N, I>
+    where
+        N: Copy,
+    {
+        Self::try_new(n, indices, data).unwrap()
+    }
+
+    /// Try create an owning CsVec from vector data.
+    pub fn try_new(
+        n: usize,
+        mut indices: Vec<I>,
+        mut data: Vec<N>,
+    ) -> Result<CsVecI<N, I>, SprsError>
     where
         N: Copy,
     {
@@ -499,7 +511,7 @@ impl<N, I: SpIndex> CsVecBase<Vec<I>, Vec<N>> {
             indices,
             data,
         };
-        v.check_structure().and(Ok(v)).unwrap()
+        v.check_structure().and(Ok(v))
     }
 
     /// Create an empty CsVec, which can be used for incremental construction
@@ -652,7 +664,7 @@ where
             .unwrap_or(&I::zero())
             .index_unchecked();
         if max_ind >= self.dim {
-            panic!("Out of bounds index");
+            return Err(SprsError::IllegalArguments("Out of bounds index"));
         }
 
         Ok(())


### PR DESCRIPTION
It seems to have been decided previously that the program should simply panic when invalid arguments are given during vector / matrix construction, since it's the caller's responsibility to ensure correctness. However, the direct caller might not have constructed the input themselves, and could also have received the input from elsewhere (e.g. user input, untrusted file, etc.). To prevent panics, the caller must manually validate the input, which is not completely trivial, especially for matrix construction. By providing the `try_` constructors, the caller can choose to reuse the validation logic in the sprs library, and gracefully recover from invalid inputs.

Let me know what you think :)