### PR TITLE
Exercise overflow checks in all build configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
     - rustc --version
     - cargo --version
     - cargo test --all --verbose
+    - cargo test --release --all --verbose
     - cargo run --example heat
     - ./.travis_rustfmt
 

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -130,14 +130,14 @@ mod test {
     use super::SpIndex;
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic)]
+    #[should_panic]
     fn overflow_u16() {
         let b: u16 = u16::from_usize(131072); // 2^17
         println!("{}", b);
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic)]
+    #[should_panic]
     fn negative_i16() {
         let b: i16 = -1;
         let a = b.index();


### PR DESCRIPTION
Running `cargo test --release` on my local machine, I realized some tests failed because the overflow checks are now panicking in the release build as well. This was not caught by the CI because it runs only in debug mode.

Therefore I'm adding the tests in the release mode to the CI, and fixing the overflow tests to also expect panic in release builds.