### PR TITLE
Fix triplet to CSR conversion with empty input.

### DIFF
--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -562,4 +562,14 @@ mod test {
         let csr = triplet_mat.to_csr();
         assert_eq!(csr, expected.to_csr());
     }
+
+    #[test]
+    fn triplet_empy_lines() {
+        // regression test for https://github.com/vbarrielle/sprs/issues/170
+        let tri_mat = TriMatI::new((2, 4));
+        let m: CsMat<u64> = tri_mat.to_csr();
+        assert_eq!(m.indptr(), &[0, 0]);
+        assert_eq!(m.indices(), &[]);
+        assert_eq!(m.data(), &[]);
+    }
 }

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -174,7 +174,10 @@ where
             }
         }
 
-        slot += 1;
+        // Ensure that slot == nnz
+        if nnz_max > 0 {
+            slot += 1;
+        }
         indptr.push(I::from_usize(slot));
         rc.truncate(slot);
 


### PR DESCRIPTION
The invariant that, after suppressing duplicates, `slot` should be equal to the number of nonzeros
was not respected with an empty input.

Fixes #170