### PR TITLE
Fix handling of empty lines in triplet to CSR/CSC

### DIFF
--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -564,7 +564,7 @@ mod test {
     }
 
     #[test]
-    fn triplet_empy_lines() {
+    fn triplet_empty_lines() {
         // regression test for https://github.com/vbarrielle/sprs/issues/170
         let tri_mat = TriMatI::new((2, 4));
         let m: CsMat<u64> = tri_mat.to_csr();
@@ -619,5 +619,20 @@ mod test {
 
         let csr = triplet_mat.to_csr();
         assert_eq!(csr, expected.to_csr());
+
+        // Matrix ending with several empty lines/columns
+        // |. . . 2 . . |
+        // |. 1 . . . . |
+        // |. . . . . . |
+        // |. . . . . . |
+        let mut triplet_mat = TriMat::with_capacity((4, 6), 2);
+
+        triplet_mat.add_triplet(1, 1, 1);
+        triplet_mat.add_triplet(0, 3, 2);
+
+        let m = triplet_mat.to_csc();
+        assert_eq!(m.indptr(), &[0, 0, 1, 1, 2, 2, 2]);
+        assert_eq!(m.indices(), &[1, 3]);
+        assert_eq!(m.data(), &[1, 2]);
     }
 }

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -632,7 +632,7 @@ mod test {
 
         let m = triplet_mat.to_csc();
         assert_eq!(m.indptr(), &[0, 0, 1, 1, 2, 2, 2]);
-        assert_eq!(m.indices(), &[1, 3]);
+        assert_eq!(m.indices(), &[1, 0]);
         assert_eq!(m.data(), &[1, 2]);
     }
 }

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -568,8 +568,56 @@ mod test {
         // regression test for https://github.com/vbarrielle/sprs/issues/170
         let tri_mat = TriMatI::new((2, 4));
         let m: CsMat<u64> = tri_mat.to_csr();
-        assert_eq!(m.indptr(), &[0, 0]);
+        assert_eq!(m.indptr(), &[0, 0, 0]);
         assert_eq!(m.indices(), &[]);
         assert_eq!(m.data(), &[]);
+
+        let m: CsMat<u64> = tri_mat.to_csc();
+        assert_eq!(m.indptr(), &[0, 0, 0, 0, 0]);
+        assert_eq!(m.indices(), &[]);
+        assert_eq!(m.data(), &[]);
+
+        // More complex matrix with empty lines/cols inside
+        // |1 . . . 6 . . . 2|
+        // |. . . . . . . . .|
+        // |1 2 . 3 . . . . 2|
+        // |1 . . . . 4 . . 2|
+        // |1 . . 5 . . . . 2|
+        // |1 . . . . 7 . . 2|
+        let mut triplet_mat = TriMat::with_capacity((6, 9), 22);
+
+        triplet_mat.add_triplet(5, 8, 1); // (a) push 1 later
+        triplet_mat.add_triplet(0, 0, 1);
+        triplet_mat.add_triplet(0, 8, 2);
+        triplet_mat.add_triplet(0, 4, 2); // (b) push 4 later
+        triplet_mat.add_triplet(2, 0, 1);
+        triplet_mat.add_triplet(2, 1, 2);
+        triplet_mat.add_triplet(2, 3, 2); // (c) push 1 later
+        triplet_mat.add_triplet(2, 8, 2);
+        triplet_mat.add_triplet(0, 4, 4); // push the missing 4 (b)
+        triplet_mat.add_triplet(3, 8, 2);
+        triplet_mat.add_triplet(3, 5, 4);
+        triplet_mat.add_triplet(5, 8, 1); // push the missing 1 (a)
+        triplet_mat.add_triplet(3, 0, 1);
+        triplet_mat.add_triplet(4, 0, 1);
+        triplet_mat.add_triplet(4, 8, 2);
+        triplet_mat.add_triplet(4, 3, 5);
+        triplet_mat.add_triplet(5, 0, 1);
+        triplet_mat.add_triplet(5, 5, 7);
+        triplet_mat.add_triplet(2, 3, 1); // push the missing 1 (c)
+
+        let csc = triplet_mat.to_csc();
+
+        let expected = CsMat::new_csc(
+            (6, 9),
+            vec![0, 5, 6, 6, 8, 9, 11, 11, 11, 16],
+            vec![0, 2, 3, 4, 5, 2, 2, 4, 0, 3, 5, 0, 2, 3, 4, 5],
+            vec![1, 1, 1, 1, 1, 2, 3, 5, 6, 4, 7, 2, 2, 2, 2, 2],
+        );
+
+        assert_eq!(csc, expected);
+
+        let csr = triplet_mat.to_csr();
+        assert_eq!(csr, expected.to_csr());
     }
 }

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -172,12 +172,7 @@ where
                 }
             }
 
-            let new_outer = if rec < nnz_max {
-                outer_idx(&rc[rec])
-            } else {
-                // on last iteration: fill indptr to the end
-                I::from_usize(outer_dims)
-            };
+            let new_outer = outer_idx(&rc[rec]);
 
             while new_outer > cur_outer {
                 indptr[cur_outer.index() + 1] = I::from_usize(slot);
@@ -188,6 +183,11 @@ where
         // Ensure that slot == nnz
         if nnz_max > 0 {
             slot += 1;
+        }
+        // fill indptr up to the end
+        while I::from_usize(outer_dims) > cur_outer {
+            indptr[cur_outer.index() + 1] = I::from_usize(slot);
+            cur_outer += I::one();
         }
 
         rc.truncate(slot);

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -172,7 +172,13 @@ where
                 }
             }
 
-            let new_outer = outer_idx(&rc[rec]);
+            let new_outer = if rec < nnz_max {
+                outer_idx(&rc[rec])
+            } else {
+                // on last iteration: fill indptr to the end
+                I::from_usize(outer_dims)
+            };
+
             while new_outer > cur_outer {
                 indptr[cur_outer.index() + 1] = I::from_usize(slot);
                 cur_outer += I::one();
@@ -183,7 +189,7 @@ where
         if nnz_max > 0 {
             slot += 1;
         }
-        indptr[outer_dims] = I::from_usize(slot);
+
         rc.truncate(slot);
 
         let mut data: Vec<N> = vec![N::zero(); slot];

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -151,8 +151,13 @@ where
             CompressedStorage::CSC => idx.1,
         };
 
+        let outer_dims = match storage {
+            CompressedStorage::CSR => self.rows(),
+            CompressedStorage::CSC => self.cols(),
+        };
+
         let mut slot = 0;
-        let mut indptr = vec![I::zero()];
+        let mut indptr = vec![I::zero(); outer_dims + 1];
         let mut cur_outer = I::zero();
 
         for rec in 0..nnz_max {
@@ -169,7 +174,7 @@ where
 
             let new_outer = outer_idx(&rc[rec]);
             while new_outer > cur_outer {
-                indptr.push(I::from_usize(slot));
+                indptr[cur_outer.index() + 1] = I::from_usize(slot);
                 cur_outer += I::one();
             }
         }
@@ -178,7 +183,7 @@ where
         if nnz_max > 0 {
             slot += 1;
         }
-        indptr.push(I::from_usize(slot));
+        indptr[outer_dims] = I::from_usize(slot);
         rc.truncate(slot);
 
         let mut data: Vec<N> = vec![N::zero(); slot];


### PR DESCRIPTION
The previous fix was incomplete due to a bogus test. This commit adds a
more comprehensive test that should cover all edge cases.

Fixes #170 (again...).