### PR TITLE
Fix triplet to csr conversion for input ending with empty lines

### DIFF
--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -564,7 +564,7 @@ mod test {
     }
 
     #[test]
-    fn triplet_empy_lines() {
+    fn triplet_empty_lines() {
         // regression test for https://github.com/vbarrielle/sprs/issues/170
         let tri_mat = TriMatI::new((2, 4));
         let m: CsMat<u64> = tri_mat.to_csr();
@@ -619,5 +619,20 @@ mod test {
 
         let csr = triplet_mat.to_csr();
         assert_eq!(csr, expected.to_csr());
+
+        // Matrix ending with several empty lines/columns
+        // |. . . 2 . . |
+        // |. 1 . . . . |
+        // |. . . . . . |
+        // |. . . . . . |
+        let mut triplet_mat = TriMat::with_capacity((4, 6), 2);
+
+        triplet_mat.add_triplet(1, 1, 1);
+        triplet_mat.add_triplet(0, 3, 2);
+
+        let m = triplet_mat.to_csc();
+        assert_eq!(m.indptr(), &[0, 0, 1, 1, 2, 2, 2]);
+        assert_eq!(m.indices(), &[1, 3]);
+        assert_eq!(m.data(), &[1, 2]);
     }
 }

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -632,7 +632,7 @@ mod test {
 
         let m = triplet_mat.to_csc();
         assert_eq!(m.indptr(), &[0, 0, 1, 1, 2, 2, 2]);
-        assert_eq!(m.indices(), &[1, 3]);
+        assert_eq!(m.indices(), &[1, 0]);
         assert_eq!(m.data(), &[1, 2]);
     }
 }

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -172,12 +172,7 @@ where
                 }
             }
 
-            let new_outer = if rec < nnz_max {
-                outer_idx(&rc[rec])
-            } else {
-                // on last iteration: fill indptr to the end
-                I::from_usize(outer_dims)
-            };
+            let new_outer = outer_idx(&rc[rec]);
 
             while new_outer > cur_outer {
                 indptr[cur_outer.index() + 1] = I::from_usize(slot);
@@ -188,6 +183,11 @@ where
         // Ensure that slot == nnz
         if nnz_max > 0 {
             slot += 1;
+        }
+        // fill indptr up to the end
+        while I::from_usize(outer_dims) > cur_outer {
+            indptr[cur_outer.index() + 1] = I::from_usize(slot);
+            cur_outer += I::one();
         }
 
         rc.truncate(slot);

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -172,7 +172,13 @@ where
                 }
             }
 
-            let new_outer = outer_idx(&rc[rec]);
+            let new_outer = if rec < nnz_max {
+                outer_idx(&rc[rec])
+            } else {
+                // on last iteration: fill indptr to the end
+                I::from_usize(outer_dims)
+            };
+
             while new_outer > cur_outer {
                 indptr[cur_outer.index() + 1] = I::from_usize(slot);
                 cur_outer += I::one();
@@ -183,7 +189,7 @@ where
         if nnz_max > 0 {
             slot += 1;
         }
-        indptr[outer_dims] = I::from_usize(slot);
+
         rc.truncate(slot);
 
         let mut data: Vec<N> = vec![N::zero(); slot];


### PR DESCRIPTION
The previous fix was not working for matrice ending with empty lines/columns.
This commit fixes this issue and adds a related test.