### PR TITLE
Extend supported ndarray version to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["alga"]
 
 [dependencies]
 num-traits = "0.1.32"
-ndarray = ">=0.11, <0.13"
+ndarray = ">=0.11, <0.14"
 alga = { version = "0.5", optional = true }
 num-complex = "0.1.36"
 serde = "1.0"

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -507,5 +507,4 @@ mod test {
 
         assert_eq!(c, expected_output);
     }
-
 }


### PR DESCRIPTION
As far as I can tell, sprs builds fine and tests pass with ndarray 0.13. 

So I imagine the supported range of versions could be extended (otherwise I can't use it alongside ndarray 0.13).

Not sure if it's necessary to test it in CI (or how to do that). 