### PR TITLE
DOC Add crates.io badge to the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ sprs, sparse matrices for Rust
 .. image:: https://travis-ci.org/vbarrielle/sprs.svg?branch=master
     :target: https://travis-ci.org/vbarrielle/sprs
 
+.. |crates| image:: https://img.shields.io/crates/v/sprs.svg
+.. _crates: https://crates.io/crates/sprs
+
 sprs implements some sparse matrix data structures and linear algebra
 algorithms in pure Rust.
 

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,8 @@ sprs, sparse matrices for Rust
 
 .. image:: https://travis-ci.org/vbarrielle/sprs.svg?branch=master
     :target: https://travis-ci.org/vbarrielle/sprs
-
-.. |crates| image:: https://img.shields.io/crates/v/sprs.svg
-.. _crates: https://crates.io/crates/sprs
+.. image:: https://img.shields.io/crates/v/sprs.svg
+    :target: https://crates.io/crates/sprs
 
 sprs implements some sparse matrix data structures and linear algebra
 algorithms in pure Rust.

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -507,5 +507,4 @@ mod test {
 
         assert_eq!(c, expected_output);
     }
-
 }


### PR DESCRIPTION
Makes it a bit easier to know which is currently the latest version.

Edit: the rendered version is [here](https://github.com/rth/sprs/blob/crates.io-badge/README.rst).