### PR TITLE
Make serde and serde_derive dependencies optional 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
     - rustc --version
     - cargo --version
     - cargo test --all --verbose
+    - cargo test --features=serde,serde_derive --all --verbose
     - cargo test --release --all --verbose
     - cargo run --example heat
     - ./.travis_rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [features]
-default = ["alga", "serde", "serde_derive"]
+default = ["alga"]
 
 [dependencies]
 num-traits = "0.1.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ exclude = [
 ]
 
 [features]
-default = ["alga"]
+default = ["alga", "serde", "serde_derive"]
 
 [dependencies]
 num-traits = "0.1.32"
 ndarray = ">=0.11, <0.13"
 alga = { version = "0.5", optional = true }
 num-complex = "0.1.36"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", optional = true }
+serde_derive = {version = "1.0", optional = true}
 
 [dev-dependencies]
 bencher = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,9 @@ extern crate alga;
 extern crate ndarray;
 extern crate num_complex;
 extern crate num_traits;
+#[cfg(feature = "serde")]
 extern crate serde;
+#[cfg(feature = "serde_derive")]
 #[macro_use]
 extern crate serde_derive;
 #[cfg(test)]

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -507,5 +507,4 @@ mod test {
 
         assert_eq!(c, expected_output);
     }
-
 }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -46,7 +46,8 @@ where
 }
 
 /// Describe the storage of a CsMat
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(all(feature = "serde", feature = "serde_derive"), derive(Serialize, Deserialize))]
 pub enum CompressedStorage {
     /// Compressed row storage
     CSR,

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -47,7 +47,10 @@ where
 
 /// Describe the storage of a CsMat
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(all(feature = "serde", feature = "serde_derive"), derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "serde_derive"),
+    derive(Serialize, Deserialize)
+)]
 pub enum CompressedStorage {
     /// Compressed row storage
     CSR,

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -75,7 +75,8 @@ pub use self::csmat::CompressedStorage;
 /// [`vstack`]: fn.vstack.html
 /// [`hstack`]: fn.hstack.html
 /// [`bmat`]: fn.bmat.html
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone)]
+#[cfg_attr(all(feature = "serde", feature = "serde_derive"), derive(Serialize, Deserialize))]
 pub struct CsMatBase<N, I, IptrStorage, IndStorage, DataStorage, Iptr = I>
 where
     I: SpIndex,
@@ -134,7 +135,8 @@ pub type CsMatVecView<'a, N> = CsMatVecView_<'a, N, usize>;
 /// [`CsVecI`]: type.CsVecI.html
 /// [`CsVecViewI`]: type.CsVecViewI.html
 /// [`CsVecViewMutI`]: type.CsVecViewMutI.html
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
+#[cfg_attr(all(feature = "serde", feature = "serde_derive"), derive(Serialize, Deserialize))]
 pub struct CsVecBase<IStorage, DStorage> {
     dim: usize,
     indices: IStorage,

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -76,7 +76,10 @@ pub use self::csmat::CompressedStorage;
 /// [`hstack`]: fn.hstack.html
 /// [`bmat`]: fn.bmat.html
 #[derive(Eq, PartialEq, Debug, Clone)]
-#[cfg_attr(all(feature = "serde", feature = "serde_derive"), derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "serde_derive"),
+    derive(Serialize, Deserialize)
+)]
 pub struct CsMatBase<N, I, IptrStorage, IndStorage, DataStorage, Iptr = I>
 where
     I: SpIndex,
@@ -136,7 +139,10 @@ pub type CsMatVecView<'a, N> = CsMatVecView_<'a, N, usize>;
 /// [`CsVecViewI`]: type.CsVecViewI.html
 /// [`CsVecViewMutI`]: type.CsVecViewMutI.html
 #[derive(PartialEq, Debug, Clone)]
-#[cfg_attr(all(feature = "serde", feature = "serde_derive"), derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "serde_derive"),
+    derive(Serialize, Deserialize)
+)]
 pub struct CsVecBase<IStorage, DStorage> {
     dim: usize,
     indices: IStorage,

--- a/tests/bincode_ser.rs
+++ b/tests/bincode_ser.rs
@@ -1,9 +1,11 @@
 extern crate bincode;
 extern crate sprs;
 
-use sprs::CsMat;
 
+#[cfg(all(feature = "serde", feature = "serde_derive"))]
 fn main() {
+    use sprs::CsMat;
+
     let m: CsMat<f32> = CsMat::<f32>::eye(3);
     let serialized = bincode::serialize(&m.view()).unwrap();
     let deserialized = bincode::deserialize::<CsMat<f32>>(&serialized).unwrap();

--- a/tests/bincode_ser.rs
+++ b/tests/bincode_ser.rs
@@ -1,7 +1,6 @@
 extern crate bincode;
 extern crate sprs;
 
-
 #[cfg(all(feature = "serde", feature = "serde_derive"))]
 fn main() {
     use sprs::CsMat;


### PR DESCRIPTION
Currently serde (and serde_derive) are mandatory dependencies, while some users may not need serialization capability. They pull in additional 11 dependencies (e.g. while building sprs), which is non negligible particularly for downstream projects.

I think it would be better to make them optional, as for instance ndarray is doing.

Currently enabling serialization for sprs could be done with,
```
cargo build --features=serde,serde_derive
```

Alternatively those could be put behind a single feature flag (e.g. `serialization` or `serde-1`). 

It is also possible to add them to the list of default features, though I think consistency with `ndarray` on this would be preferable (i.e. not having them enabled by default).