### PR TITLE
Implementation reverse Cuthill-McKee

### DIFF
--- a/examples/fill_in_reduction.rs
+++ b/examples/fill_in_reduction.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         small_lap_mat()
     };
 
-    let ordering = sprs::linalg::cuthill_mckee(lap_mat.view());
+    let ordering = sprs::linalg::reverse_cuthill_mckee(lap_mat.view());
     let perm_lap =
         sprs::transform_mat_papt(lap_mat.view(), ordering.perm.view());
 

--- a/src/sparse/linalg/mod.rs
+++ b/src/sparse/linalg/mod.rs
@@ -6,11 +6,10 @@ use num_traits::Num;
 use std::iter::IntoIterator;
 
 pub mod etree;
-mod ordering;
+pub mod ordering;
 pub mod trisolve;
 
 pub use self::ordering::reverse_cuthill_mckee;
-pub use self::ordering::cuthill_mckee_custom;
 
 /// Diagonal solve
 pub fn diag_solve<'a, N, I1, I2>(diag: I1, x: I2)

--- a/src/sparse/linalg/mod.rs
+++ b/src/sparse/linalg/mod.rs
@@ -10,6 +10,7 @@ mod ordering;
 pub mod trisolve;
 
 pub use self::ordering::reverse_cuthill_mckee;
+pub use self::ordering::cuthill_mckee_custom;
 
 /// Diagonal solve
 pub fn diag_solve<'a, N, I1, I2>(diag: I1, x: I2)

--- a/src/sparse/linalg/mod.rs
+++ b/src/sparse/linalg/mod.rs
@@ -9,7 +9,7 @@ pub mod etree;
 mod ordering;
 pub mod trisolve;
 
-pub use self::ordering::cuthill_mckee;
+pub use self::ordering::reverse_cuthill_mckee;
 
 /// Diagonal solve
 pub fn diag_solve<'a, N, I1, I2>(diag: I1, x: I2)

--- a/src/sparse/linalg/ordering.rs
+++ b/src/sparse/linalg/ordering.rs
@@ -13,7 +13,9 @@ pub struct Ordering<I> {
     pub connected_parts: Vec<usize>,
 }
 
-pub fn cuthill_mckee<N, I, Iptr>(mat: CsMatViewI<N, I, Iptr>) -> Ordering<I>
+pub fn reverse_cuthill_mckee<N, I, Iptr>(
+    mat: CsMatViewI<N, I, Iptr>,
+) -> Ordering<I>
 where
     N: PartialEq,
     I: SpIndex,
@@ -21,66 +23,213 @@ where
 {
     debug_assert!(is_symmetric(&mat));
     assert_eq!(mat.cols(), mat.rows());
+
     let nb_vertices = mat.cols();
-    let mut deque = VecDeque::with_capacity(nb_vertices);
-    let max_neighbors = mat
-        .indptr()
-        .windows(2)
-        .map(|w| w[1] - w[0])
-        .max()
-        .unwrap_or(Iptr::zero());
-    let mut neighbors = Vec::with_capacity(max_neighbors.index());
-    let mut perm = Vec::with_capacity(nb_vertices);
-    let mut visited = vec![false; nb_vertices];
-    let mut connected_parts = Vec::with_capacity(4);
-    connected_parts.push(0);
-
     let degrees = mat.degrees();
+    let max_neighbors = degrees.iter().max().cloned().unwrap_or(0);
 
-    while perm.len() < nb_vertices {
-        // find the non-visited vertex with the lowest degree
-        let mut min_deg = nb_vertices;
-        let mut min_deg_vert = 0;
-        for (vert, vis) in visited.iter().enumerate() {
-            let vert_deg = degrees[vert];
-            if !vis && vert_deg <= min_deg {
-                min_deg = vert_deg;
-                min_deg_vert = vert;
+    // This is the 'working data', into which new neighboring, sorted vertices are inserted,
+    // the next vertex to process is popped from here.
+    let mut deque = VecDeque::with_capacity(nb_vertices);
+
+    // This are all new neighbors of the currently processed vertex, they are collected here
+    // to be sorted prior to being appended to 'deque'.
+    let mut neighbors = Vec::with_capacity(max_neighbors);
+
+    // Storing which vertices have already been visited.
+    let mut visited = vec![false; nb_vertices];
+
+    // Delimeting connected components inside the permutation.
+    let mut connected_parts = Vec::with_capacity(nb_vertices / 16 + 1);
+
+    // The final permutation reducing the bandwidth of the given sparse matrix.
+    // Missed optimization: Work with MaybeUninit here.
+    let mut perm = vec![I::default(); nb_vertices];
+
+    for perm_index in 0..nb_vertices {
+        // Find the next index to process, choosing a new starting vertex if necessary.
+        let current_vertex = deque.pop_front().unwrap_or_else(|| {
+            // We found a new connected component. This number will be reverse-inverted later.
+            connected_parts.push(perm_index);
+            // Employ the George-Liu pseudoperipheral vertex finder to find a new starting vertex.
+            find_pseudoperipheral_vertex(&visited, &degrees, &mat).unwrap()
+        });
+
+        // Write the next permutation in reverse order.
+        perm[nb_vertices - perm_index - 1] = I::from_usize(current_vertex);
+        visited[current_vertex.index()] = true;
+
+        // Find, sort, and push all new neighbors of the current vertex.
+        let outer = mat.outer_view(current_vertex.index()).unwrap();
+        neighbors.clear();
+        for &neighbor in outer.indices() {
+            if !visited[neighbor.index()] {
+                neighbors.push((degrees[neighbor.index()], neighbor));
+                visited[neighbor.index()] = true;
             }
         }
-        deque.clear();
-        deque.push_back(min_deg_vert);
 
-        while let Some(cur_vert) = deque.pop_front() {
-            if visited[cur_vert] {
-                continue;
-            }
-            perm.push(I::from_usize(cur_vert));
-            visited[cur_vert.index()] = true;
-            let outer = mat.outer_view(cur_vert.index()).unwrap();
-            neighbors.clear();
-            for &neighbor in outer.indices() {
-                if !visited[neighbor.index()] {
-                    neighbors.push((degrees[neighbor.index()], neighbor));
-                }
-            }
-            neighbors.sort_by_key(|&(deg, _)| deg);
-            for (_deg, neighbor) in &neighbors {
-                deque.push_back(neighbor.index());
-            }
+        // Missed optimization: match small sizes explicitly, sort using sorting networks.
+        // This especially makes sense if swaps are predictably compiled into cmov instructions,
+        // which they aren't currently, see https://github.com/rust-lang/rust/issues/53823.
+        // For more information on how to do sorting networks efficiently see https://arxiv.org/pdf/1505.01962.pdf.
+        neighbors.sort_unstable_by_key(|&(deg, _)| deg);
+
+        for (_deg, neighbor) in &neighbors {
+            deque.push_back(neighbor.index());
         }
-        connected_parts.push(perm.len());
     }
+
+    connected_parts.push(nb_vertices);
 
     Ordering {
         perm: PermOwnedI::new(perm),
-        connected_parts,
+        connected_parts: connected_parts
+            .into_iter()
+            .map(|i| nb_vertices - i)
+            .rev()
+            .collect(),
     }
+}
+
+fn find_pseudoperipheral_vertex<N, I, Iptr>(
+    visited: &[bool],
+    degrees: &[usize],
+    mat: &CsMatViewI<N, I, Iptr>,
+) -> Option<usize>
+where
+    N: PartialEq,
+    I: SpIndex,
+    Iptr: SpIndex,
+{
+    // Choose the next available vertex as currrent starting vertex.
+    let mut current = visited
+        .iter()
+        .enumerate()
+        .find(|(_i, &a)| !a)
+        .map(|(i, _a)| i)?;
+
+    // Isolated vertices are by definition pseudoperipheral.
+    if degrees[current] == 0 {
+        return Some(current);
+    }
+
+    let (mut contender, mut current_height) =
+        rls_contender_and_height(current, degrees, mat);
+
+    loop {
+        let (contender_contender, contender_height) =
+            rls_contender_and_height(contender, degrees, mat);
+
+        if contender_height > current_height {
+            current_height = contender_height;
+            current = contender;
+            contender = contender_contender;
+        } else {
+            return Some(current);
+        }
+    }
+}
+
+/// Computes the rooted level structure rooted at `root`,
+/// returning the index of vertex of the last level with minimum degree, called "contender", and the height of the rls.
+fn rls_contender_and_height<N, I, Iptr>(
+    root: usize,
+    degrees: &[usize],
+    mat: &CsMatViewI<N, I, Iptr>,
+) -> (usize, usize)
+where
+    N: PartialEq,
+    I: SpIndex,
+    Iptr: SpIndex,
+{
+    // One might wonder: "Why are we not reusing the rooted level structure (rls) we build here,
+    // isn't it basically the same thing we build in the rcm again, afterwards?""
+    // The answer: Yes, but, No.
+    //
+    // The rooted level structure here differs from the one built afterwards by its order.
+    // The required order is very nasty indeed: the position of a vertex in its level depends primarily on the position of
+    // its neighboring vertex in the previous level, and secondarily on its degree.
+    //
+    // Still, one may think: "Well, then just keep the rls around, and sort it if its root is choosen as starting vertex".
+    // This is easier said than done, let's consider some strategies to do that:
+    // 1. Sort it without any additionally stored information. That would require going through the entire vec again, one by one.
+    //    This would erase the overhead of allocating and then deallocating the rls, but making this pass performant
+    //    requires non-trivial, error-prone code. Overall, this strategies perfomance gains can at most be minimal.
+    // 2. Store additional information, like the delimeters of levels, neighbouring vertex delimeters, etc.
+    //    That would require doing additional work (computing and storing the information) while building the rls,
+    //    and does not speed up sorting afterwards significantly, as the levels still need to be sorted serially.
+    //    Overall, this strategy comes at a significant cost in memory, and it's performance improvements are debatable at best.
+    // 3. Maybe just build any rls in a way that makes it a valid rcm odering?
+    //    That would be optimal if we always find a pseudoperipheral vertex on first try. Unfortunately, we rarely do,
+    //    typical are a few swaps, meaning this strategy, overall, comes with a loss of performance.
+    //
+    // So, thats why we discard the rls. One may feel free to try on his own.
+
+    let nb_vertices = degrees.len();
+
+    // This is ok, if we are given a valid root we can never reach an invalid vertex.
+    let mut visited = vec![false; nb_vertices];
+
+    let mut rls = Vec::with_capacity(nb_vertices);
+
+    // Start out by pushing the root.
+    visited[root] = true;
+    rls.push(root);
+
+    let mut rls_index = 0;
+
+    // For calculating the height.
+    let mut height = 0;
+    let mut current_level_countdown = 1;
+    let mut next_level_countup = 0;
+
+    // The last levels len is used to compute the contender in the end.
+    let mut last_level_len = 1;
+
+    while rls_index < rls.len() {
+        let parent = rls[rls_index];
+        current_level_countdown -= 1;
+
+        let outer = mat.outer_view(parent.index()).unwrap();
+        for &neighbor in outer.indices() {
+            if !visited[neighbor.index()] {
+                visited[neighbor.index()] = true;
+                next_level_countup += 1;
+                rls.push(neighbor.index());
+            }
+        }
+
+        if current_level_countdown == 0 {
+            if next_level_countup > 0 {
+                last_level_len = next_level_countup;
+            }
+
+            current_level_countdown = next_level_countup;
+            next_level_countup = 0;
+            height += 1;
+        }
+
+        rls_index += 1;
+    }
+
+    // Choose the contender.
+    let rls_len = rls.len();
+    let last_level_start_index = rls_len - last_level_len;
+    let contender = rls[last_level_start_index..rls_len]
+        .iter()
+        .min_by_key(|i| degrees[i.index()])
+        .cloned()
+        .unwrap();
+
+    // Return the node of the last level with minimal degree along with the rls's height.
+    (contender, height)
 }
 
 #[cfg(test)]
 mod test {
-    use super::cuthill_mckee;
+    use super::reverse_cuthill_mckee;
+    use sparse::permutation::Permutation;
     use sparse::CsMat;
 
     fn unconnected_graph_lap() -> CsMat<f64> {
@@ -141,9 +290,27 @@ mod test {
     }
 
     #[test]
-    fn cuthill_mckee_unconnected_graph_lap() {
+    fn reverse_cuthill_mckee_unconnected_graph_lap_components() {
         let lap_mat = unconnected_graph_lap();
-        let ordering = cuthill_mckee(lap_mat.view());
+        let ordering = reverse_cuthill_mckee(lap_mat.view());
         assert_eq!(&ordering.connected_parts, &[0, 3, 12],);
+    }
+
+    #[test]
+    fn reverse_cuthill_mckee_unconnected_graph_lap_perm() {
+        let lap_mat = unconnected_graph_lap();
+        let ordering = reverse_cuthill_mckee(lap_mat.view());
+        // This is just one posible permutation. Might be silently broken, e. g. through changes in unstable sorting.
+        let correct_perm =
+            Permutation::new(vec![7, 9, 6, 11, 10, 3, 1, 2, 5, 8, 4, 0]);
+        assert_eq!(&ordering.perm.vec(), &correct_perm.vec());
+    }
+
+    #[test]
+    fn reverse_cuthill_mckee_eye() {
+        let mat = CsMat::<f64>::eye(3);
+        let ordering = reverse_cuthill_mckee(mat.view());
+        let correct_perm = Permutation::new(vec![2, 1, 0]);
+        assert_eq!(&ordering.perm.vec(), &correct_perm.vec());
     }
 }

--- a/src/sparse/linalg/ordering.rs
+++ b/src/sparse/linalg/ordering.rs
@@ -17,6 +17,12 @@ pub mod start {
 
     /// This trait abstracts over possible strategies to choose a starting vertex for the Cutihll-McKee algorithm.
     /// Common strategies are provided.
+    /// 
+    /// You can implement this trait yourself to enable custom strategies,
+    /// e.g. for predetermined starting vertices.
+    /// If you do that, please let us now by filing an issue in the repo, 
+    /// since we would like to know which strategies are common in the wild,
+    /// so we can consider implementing them in the library.
     pub trait Strategy<N, I, Iptr>
     where
         N: PartialEq,
@@ -30,28 +36,6 @@ pub mod start {
             degrees: &[usize],
             mat: &CsMatViewI<N, I, Iptr>,
         ) -> usize;
-    }
-
-    /// This strategy chooses predetermined starting vertices.
-    pub struct Predetermined<I: Iterator<Item = usize>>(I);
-
-    impl<Iter, N, I, Iptr> Strategy<N, I, Iptr> for Predetermined<Iter>
-    where
-        Iter: Iterator<Item = usize>,
-        N: PartialEq,
-        I: SpIndex,
-        Iptr: SpIndex,
-    {
-        fn find_start_vertex(
-            &mut self,
-            visited: &[bool],
-            degrees: &[usize],
-            _mat: &CsMatViewI<N, I, Iptr>,
-        ) -> usize {
-            self.0
-                .next()
-                .expect("Not enough predetermined starting vertices supplied")
-        }
     }
 
     /// This strategy chooses some next available vertex as starting vertex.
@@ -457,7 +441,7 @@ where
             new_start_vertex
         });
 
-        // Write the next permutation in reverse order.
+        // Add the next transposition to the ordering.
         directed_ordering.add_transposition(current_vertex);
         visited[current_vertex.index()] = true;
 

--- a/src/sparse/linalg/ordering.rs
+++ b/src/sparse/linalg/ordering.rs
@@ -52,6 +52,7 @@ where
             // We found a new connected component. This number will be reverse-inverted later.
             connected_parts.push(perm_index);
             // Employ the George-Liu pseudoperipheral vertex finder to find a new starting vertex.
+            // This will only fail if no unvisited nodes are left, which can not be the case at this point.
             find_pseudoperipheral_vertex(&visited, &degrees, &mat).unwrap()
         });
 
@@ -80,15 +81,14 @@ where
         }
     }
 
+    // Revert-Invert the connected parts, to fit with the reverted order.
     connected_parts.push(nb_vertices);
+    connected_parts.iter_mut().for_each(|i| *i = nb_vertices - *i);
+    connected_parts.reverse();
 
     Ordering {
         perm: PermOwnedI::new(perm),
-        connected_parts: connected_parts
-            .into_iter()
-            .map(|i| nb_vertices - i)
-            .rev()
-            .collect(),
+        connected_parts
     }
 }
 
@@ -117,6 +117,9 @@ where
     let (mut contender, mut current_height) =
         rls_contender_and_height(current, degrees, mat);
 
+    // This loop always terminates, typically within very few iterations.
+    // This essentially comes from the fact that no same vertex can be choosen as `current` twice,
+    // as the height of the rls of `current` must always strictly increase for the loop to continue.
     loop {
         let (contender_contender, contender_height) =
             rls_contender_and_height(contender, degrees, mat);

--- a/src/sparse/linalg/ordering.rs
+++ b/src/sparse/linalg/ordering.rs
@@ -1,7 +1,6 @@
 use std::collections::vec_deque::VecDeque;
-
 use indexing::SpIndex;
-
+use sparse::linalg::ordering::order::DirectedOrdering;
 use sparse::permutation::PermOwnedI;
 use sparse::symmetric::is_symmetric;
 use sparse::CsMatViewI;
@@ -13,13 +12,297 @@ pub struct Ordering<I> {
     pub connected_parts: Vec<usize>,
 }
 
-pub fn reverse_cuthill_mckee<N, I, Iptr>(
+pub mod start {
+    use indexing::SpIndex;
+    use sparse::CsMatViewI;
+
+    /// This trait abstracts over possible strategies to choose a starting vertex for the Cutihll-McKee algorithm.
+    /// Common strategies are provided.
+    pub trait Strategy<N, I, Iptr>
+    where
+        N: PartialEq,
+        I: SpIndex,
+        Iptr: SpIndex,
+    {
+        /// Contract: This function must always be called with at least one unvisited vertex left.
+        fn find_start_vertex(
+            &mut self,
+            visited: &[bool],
+            degrees: &[usize],
+            mat: &CsMatViewI<N, I, Iptr>,
+        ) -> usize;
+    }
+
+    /// This strategy employs an pseudoperipheral vertex finder as described by George and Liu.
+    /// It is the most expensive strategy to compute, but typically results in the narrowest bandwidth.
+    pub struct PseudoPeripheral();
+
+    impl PseudoPeripheral {
+        #[inline]
+        pub fn new() -> Self {
+            PseudoPeripheral {}
+        }
+
+        /// Computes the rooted level structure rooted at `root`,
+        /// returning the index of vertex of the last level with minimum degree, called "contender", and the height of the rls.
+        fn rls_contender_and_height<N, I, Iptr>(
+            &mut self,
+            root: usize,
+            degrees: &[usize],
+            mat: &CsMatViewI<N, I, Iptr>,
+        ) -> (usize, usize)
+        where
+            N: PartialEq,
+            I: SpIndex,
+            Iptr: SpIndex,
+        {
+            // One might wonder: "Why are we not reusing the rooted level structure (rls) we build here,
+            // isn't it basically the same thing we build in the rcm again, afterwards?""
+            // The answer: Yes, but, No.
+            //
+            // The rooted level structure here differs from the one built afterwards by its order.
+            // The required order is very nasty indeed: the position of a vertex in its level depends primarily on the position of
+            // its neighboring vertex in the previous level, and secondarily on its degree.
+            //
+            // Still, one may think: "Well, then just keep the rls around, and sort it if its root is choosen as starting vertex".
+            // This is easier said than done, let's consider some strategies to do that:
+            // 1. Sort it without any additionally stored information. That would require going through the entire vec again, one by one.
+            //    This would erase the overhead of allocating and then deallocating the rls, but making this pass performant
+            //    requires non-trivial, error-prone code. Overall, this strategies perfomance gains can at most be minimal.
+            // 2. Store additional information, like the delimeters of levels, neighbouring vertex delimeters, etc.
+            //    That would require doing additional work (computing and storing the information) while building the rls,
+            //    and does not speed up sorting afterwards significantly, as the levels still need to be sorted serially.
+            //    Overall, this strategy comes at a significant cost in memory, and it's performance improvements are debatable at best.
+            // 3. Maybe just build any rls in a way that makes it a valid rcm odering?
+            //    That would be optimal if we always find a pseudoperipheral vertex on first try. Unfortunately, we rarely do,
+            //    typical are a few swaps, meaning this strategy, overall, comes with a loss of performance.
+            //
+            // So, thats why we discard the rls. One may feel free to try on his own.
+
+            let nb_vertices = degrees.len();
+
+            // This is ok, if we are given a valid root we can never reach an invalid vertex.
+            let mut visited = vec![false; nb_vertices];
+
+            let mut rls = Vec::with_capacity(nb_vertices);
+
+            // Start out by pushing the root.
+            visited[root] = true;
+            rls.push(root);
+
+            let mut rls_index = 0;
+
+            // For calculating the height.
+            let mut height = 0;
+            let mut current_level_countdown = 1;
+            let mut next_level_countup = 0;
+
+            // The last levels len is used to compute the contender in the end.
+            let mut last_level_len = 1;
+
+            while rls_index < rls.len() {
+                let parent = rls[rls_index];
+                current_level_countdown -= 1;
+
+                let outer = mat.outer_view(parent.index()).unwrap();
+                for &neighbor in outer.indices() {
+                    if !visited[neighbor.index()] {
+                        visited[neighbor.index()] = true;
+                        next_level_countup += 1;
+                        rls.push(neighbor.index());
+                    }
+                }
+
+                if current_level_countdown == 0 {
+                    if next_level_countup > 0 {
+                        last_level_len = next_level_countup;
+                    }
+
+                    current_level_countdown = next_level_countup;
+                    next_level_countup = 0;
+                    height += 1;
+                }
+
+                rls_index += 1;
+            }
+
+            // Choose the contender.
+            let rls_len = rls.len();
+            let last_level_start_index = rls_len - last_level_len;
+            let contender = rls[last_level_start_index..rls_len]
+                .iter()
+                .min_by_key(|i| degrees[i.index()])
+                .cloned()
+                .unwrap();
+
+            // Return the node of the last level with minimal degree along with the rls's height.
+            (contender, height)
+        }
+    }
+
+    impl<N, I, Iptr> Strategy<N, I, Iptr> for PseudoPeripheral
+    where
+        N: PartialEq,
+        I: SpIndex,
+        Iptr: SpIndex,
+    {
+        fn find_start_vertex(
+            &mut self,
+            visited: &[bool],
+            degrees: &[usize],
+            mat: &CsMatViewI<N, I, Iptr>,
+        ) -> usize {
+            // Choose the next available vertex as currrent starting vertex.
+            let mut current = visited
+                .iter()
+                .enumerate()
+                .find(|(_i, &a)| !a)
+                .map(|(i, _a)| i)
+                .expect(
+                    "There should always be a unvisited vertex left to choose",
+                );
+
+            // Isolated vertices are by definition pseudoperipheral.
+            if degrees[current] == 0 {
+                return current;
+            }
+
+            let (mut contender, mut current_height) =
+                self.rls_contender_and_height(current, degrees, mat);
+
+            // This loop always terminates, typically within very few iterations.
+            // This essentially comes from the fact that no same vertex can be choosen as `current` twice,
+            // as the height of the rls of `current` must always strictly increase for the loop to continue.
+            loop {
+                let (contender_contender, contender_height) =
+                    self.rls_contender_and_height(contender, degrees, mat);
+
+                if contender_height > current_height {
+                    current_height = contender_height;
+                    current = contender;
+                    contender = contender_contender;
+                } else {
+                    return current;
+                }
+            }
+        }
+    }
+}
+
+pub mod order {
+
+    use super::Ordering;
+    use indexing::SpIndex;
+    use sparse::permutation::PermOwnedI;
+
+    /// This trait is very deeply integrated with the inner workings of the Cuthill-McKee algorithm implemented here.
+    /// It is conceptually only an enum, specifying if the Cuthill-McKee ordering should be built in reverse order.
+    ///
+    /// No method on this trait shuld ever be called by the consumer.
+    //
+    // This is a trait, not an enum, because monomorphization is absolutely critical for performance.
+    // Also having the directions manage their state themselves enables some optimizations.
+    pub trait DirectedOrdering<I: SpIndex> {
+
+        /// Prepares this directed ordering for working with the specified number of vertices.
+        // Seperated from `fn new, as it requires `nb_vertices` as parameter,
+        // which the consumer would have to supply otherwise, which he can't be trusted to do corretly.
+        fn prepare(&mut self, nb_vertices: usize);
+
+        /// Adds a new vertex_index as computed in the algorithms main loop.
+        fn add_transposition(&mut self, vertex_index: usize);
+
+        /// Adds an index indicating the start of a new connected component.
+        fn add_component_delimeter(&mut self, index: usize);
+
+        /// Transforms this directed ordering into an ordering to return from the algorithm.
+        // Actually implementing `From` or `Into` results in coherence errors.
+        fn into_ordering(self) -> Ordering<I>;
+    }
+
+    pub struct Reversed<I: SpIndex> {
+        perm: Vec<I>,
+        connected_parts: Vec<usize>,
+        nb_vertices: usize,
+        count: usize,
+    }
+
+    impl<I : SpIndex> Reversed<I>{
+        // This is not optimal, as it leads to close-to-invalid states if not used correctly.
+        // A solution using some kind of "uninitialized" wrapper type however seems to be overkill,
+        // especially since all the uglieness is under the hood and not triggerable unless explicitly asked for.
+        #[inline]
+        pub fn new() -> Self {
+            Self {
+                perm: Vec::with_capacity(0),
+                connected_parts: Vec::with_capacity(0),
+                nb_vertices: 0,
+                count: 0,
+            }
+        }
+    }
+
+    impl<I: SpIndex> DirectedOrdering<I> for Reversed<I> {
+
+        #[inline]
+        fn prepare(&mut self, nb_vertices: usize) {
+            // Missed optimization: Work with MaybeUninit here.
+            self.perm = vec![I::default(); nb_vertices];
+            self.connected_parts = Vec::with_capacity(nb_vertices / 16 + 1);
+            self.nb_vertices = nb_vertices;
+        }
+
+        #[inline]
+        fn add_transposition(&mut self, vertex_index: usize) {
+            self.perm[self.nb_vertices - self.count - 1] =
+                I::from_usize(vertex_index);
+            self.count += 1;
+        }
+
+        #[inline]
+        fn add_component_delimeter(&mut self, index: usize) {
+            self.connected_parts.push(index);
+        }
+
+        #[inline]
+        fn into_ordering(self) -> Ordering<I> {
+            let nb_vertices = self.nb_vertices;
+            let mut connected_parts = self.connected_parts;
+
+            // Reverse-Inverse the connected parts, to fit with the reversed order.
+            connected_parts
+                .iter_mut()
+                .for_each(|i| *i = nb_vertices - *i);
+            connected_parts.reverse();
+
+            Ordering {
+                perm: PermOwnedI::new(self.perm),
+                connected_parts,
+            }
+        }
+    }
+}
+
+/// Runs a customized Cuthill-McKee algorithm on the given matrix, returning a permutation to reduce its bandwidth.
+///
+/// Use this function to customize the parameters of the algorithm.
+///
+///  specifically you can decide,
+/// if you want the usual order, or that of the reverse Cuthill-McKee algorithm,
+/// as well as what strategy to use to find a starting vertex.
+///
+/// When calling this function, all generic parameters need to specified.
+pub fn cuthill_mckee_custom<N, I, Iptr, S, D>(
     mat: CsMatViewI<N, I, Iptr>,
+    mut starting_strategy: S,
+    mut directed_ordering: D,
 ) -> Ordering<I>
 where
     N: PartialEq,
     I: SpIndex,
     Iptr: SpIndex,
+    S: start::Strategy<N, I, Iptr>,
+    D: order::DirectedOrdering<I>,
 {
     debug_assert!(is_symmetric(&mat));
     assert_eq!(mat.cols(), mat.rows());
@@ -28,36 +311,38 @@ where
     let degrees = mat.degrees();
     let max_neighbors = degrees.iter().max().cloned().unwrap_or(0);
 
+    // This will be transformed into the actual `Ordering` in the end,
+    // contains the permuntation and component delimeters.
+    directed_ordering.prepare(nb_vertices);
+
     // This is the 'working data', into which new neighboring, sorted vertices are inserted,
     // the next vertex to process is popped from here.
     let mut deque = VecDeque::with_capacity(nb_vertices);
 
     // This are all new neighbors of the currently processed vertex, they are collected here
     // to be sorted prior to being appended to 'deque'.
+    // The alternative of immediately pushing to deque and sorting there surprisingly performs worse.
     let mut neighbors = Vec::with_capacity(max_neighbors);
 
     // Storing which vertices have already been visited.
     let mut visited = vec![false; nb_vertices];
 
-    // Delimeting connected components inside the permutation.
-    let mut connected_parts = Vec::with_capacity(nb_vertices / 16 + 1);
-
-    // The final permutation reducing the bandwidth of the given sparse matrix.
-    // Missed optimization: Work with MaybeUninit here.
-    let mut perm = vec![I::default(); nb_vertices];
-
     for perm_index in 0..nb_vertices {
         // Find the next index to process, choosing a new starting vertex if necessary.
         let current_vertex = deque.pop_front().unwrap_or_else(|| {
-            // We found a new connected component. This number will be reverse-inverted later.
-            connected_parts.push(perm_index);
-            // Employ the George-Liu pseudoperipheral vertex finder to find a new starting vertex.
-            // This will only fail if no unvisited nodes are left, which can not be the case at this point.
-            find_pseudoperipheral_vertex(&visited, &degrees, &mat).unwrap()
+
+            // We found a new connected component, starting at this iteration.
+            directed_ordering.add_component_delimeter(perm_index);
+
+            // Find a new starting vertex, using the given strategy.
+            let new_start_vertex = starting_strategy.find_start_vertex(&visited, &degrees, &mat);
+            assert!(!visited[new_start_vertex], "Vertex returned by starting strategy should always be unvisited");
+
+            new_start_vertex
         });
 
         // Write the next permutation in reverse order.
-        perm[nb_vertices - perm_index - 1] = I::from_usize(current_vertex);
+        directed_ordering.add_transposition(current_vertex);
         visited[current_vertex.index()] = true;
 
         // Find, sort, and push all new neighbors of the current vertex.
@@ -81,152 +366,35 @@ where
         }
     }
 
-    // Revert-Invert the connected parts, to fit with the reverted order.
-    connected_parts.push(nb_vertices);
-    connected_parts.iter_mut().for_each(|i| *i = nb_vertices - *i);
-    connected_parts.reverse();
+    directed_ordering.add_component_delimeter(nb_vertices);
 
-    Ordering {
-        perm: PermOwnedI::new(perm),
-        connected_parts
-    }
+    directed_ordering.into_ordering()
 }
 
-fn find_pseudoperipheral_vertex<N, I, Iptr>(
-    visited: &[bool],
-    degrees: &[usize],
-    mat: &CsMatViewI<N, I, Iptr>,
-) -> Option<usize>
+/// Runs the reverse Cuthill-McKee algorithm on the given matrix, returning a permutation to reduce its bandwidth.
+///
+/// This version of the algorithm chooses pseudoperipheral vertices as starting vertices,
+/// and builds the reversed ordering. This is the most common configuration of the algorithm.
+///
+/// This library also exposes a costomizable version of the algorithm, [cuthill_mckee_custom](fn.cuthill_mckee_custom.html).
+///
+/// Implemented as:
+/// ```text
+/// cuthill_mckee_custom(mat, start::PseudoPeripheral::new(), order::Reversed::new())
+/// ```
+pub fn reverse_cuthill_mckee<N, I, Iptr>(
+    mat: CsMatViewI<N, I, Iptr>,
+) -> Ordering<I>
 where
     N: PartialEq,
     I: SpIndex,
     Iptr: SpIndex,
 {
-    // Choose the next available vertex as currrent starting vertex.
-    let mut current = visited
-        .iter()
-        .enumerate()
-        .find(|(_i, &a)| !a)
-        .map(|(i, _a)| i)?;
-
-    // Isolated vertices are by definition pseudoperipheral.
-    if degrees[current] == 0 {
-        return Some(current);
-    }
-
-    let (mut contender, mut current_height) =
-        rls_contender_and_height(current, degrees, mat);
-
-    // This loop always terminates, typically within very few iterations.
-    // This essentially comes from the fact that no same vertex can be choosen as `current` twice,
-    // as the height of the rls of `current` must always strictly increase for the loop to continue.
-    loop {
-        let (contender_contender, contender_height) =
-            rls_contender_and_height(contender, degrees, mat);
-
-        if contender_height > current_height {
-            current_height = contender_height;
-            current = contender;
-            contender = contender_contender;
-        } else {
-            return Some(current);
-        }
-    }
-}
-
-/// Computes the rooted level structure rooted at `root`,
-/// returning the index of vertex of the last level with minimum degree, called "contender", and the height of the rls.
-fn rls_contender_and_height<N, I, Iptr>(
-    root: usize,
-    degrees: &[usize],
-    mat: &CsMatViewI<N, I, Iptr>,
-) -> (usize, usize)
-where
-    N: PartialEq,
-    I: SpIndex,
-    Iptr: SpIndex,
-{
-    // One might wonder: "Why are we not reusing the rooted level structure (rls) we build here,
-    // isn't it basically the same thing we build in the rcm again, afterwards?""
-    // The answer: Yes, but, No.
-    //
-    // The rooted level structure here differs from the one built afterwards by its order.
-    // The required order is very nasty indeed: the position of a vertex in its level depends primarily on the position of
-    // its neighboring vertex in the previous level, and secondarily on its degree.
-    //
-    // Still, one may think: "Well, then just keep the rls around, and sort it if its root is choosen as starting vertex".
-    // This is easier said than done, let's consider some strategies to do that:
-    // 1. Sort it without any additionally stored information. That would require going through the entire vec again, one by one.
-    //    This would erase the overhead of allocating and then deallocating the rls, but making this pass performant
-    //    requires non-trivial, error-prone code. Overall, this strategies perfomance gains can at most be minimal.
-    // 2. Store additional information, like the delimeters of levels, neighbouring vertex delimeters, etc.
-    //    That would require doing additional work (computing and storing the information) while building the rls,
-    //    and does not speed up sorting afterwards significantly, as the levels still need to be sorted serially.
-    //    Overall, this strategy comes at a significant cost in memory, and it's performance improvements are debatable at best.
-    // 3. Maybe just build any rls in a way that makes it a valid rcm odering?
-    //    That would be optimal if we always find a pseudoperipheral vertex on first try. Unfortunately, we rarely do,
-    //    typical are a few swaps, meaning this strategy, overall, comes with a loss of performance.
-    //
-    // So, thats why we discard the rls. One may feel free to try on his own.
-
-    let nb_vertices = degrees.len();
-
-    // This is ok, if we are given a valid root we can never reach an invalid vertex.
-    let mut visited = vec![false; nb_vertices];
-
-    let mut rls = Vec::with_capacity(nb_vertices);
-
-    // Start out by pushing the root.
-    visited[root] = true;
-    rls.push(root);
-
-    let mut rls_index = 0;
-
-    // For calculating the height.
-    let mut height = 0;
-    let mut current_level_countdown = 1;
-    let mut next_level_countup = 0;
-
-    // The last levels len is used to compute the contender in the end.
-    let mut last_level_len = 1;
-
-    while rls_index < rls.len() {
-        let parent = rls[rls_index];
-        current_level_countdown -= 1;
-
-        let outer = mat.outer_view(parent.index()).unwrap();
-        for &neighbor in outer.indices() {
-            if !visited[neighbor.index()] {
-                visited[neighbor.index()] = true;
-                next_level_countup += 1;
-                rls.push(neighbor.index());
-            }
-        }
-
-        if current_level_countdown == 0 {
-            if next_level_countup > 0 {
-                last_level_len = next_level_countup;
-            }
-
-            current_level_countdown = next_level_countup;
-            next_level_countup = 0;
-            height += 1;
-        }
-
-        rls_index += 1;
-    }
-
-    // Choose the contender.
-    let rls_len = rls.len();
-    let last_level_start_index = rls_len - last_level_len;
-    let contender = rls[last_level_start_index..rls_len]
-        .iter()
-        .min_by_key(|i| degrees[i.index()])
-        .cloned()
-        .unwrap();
-
-    // Return the node of the last level with minimal degree along with the rls's height.
-    (contender, height)
+    cuthill_mckee_custom(
+        mat,
+        start::PseudoPeripheral::new(),
+        order::Reversed::new(),
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
See also #185 .
This changes the Cuthill-McKee algorithm implemented here to the reverse Cuthill-McKee algorithm. Starting vertices are choosen by a George-Liu pseudoperipheral vertex finder.
I have added two more test cases and verified the correctness of the exisiting one w.r.t. the new algorithm.

I did try to write in the style of the library, however I might not always have got it right when to use `.index()`, when to call `.unwrap()` vs `.expect()`, and so on. Feel free to change these details, as well as remove unneccesary comments or line breaks. I just can't get enough of those.

As benchmark possibilities are scarce, I did not optimize anything to aggressively. I really believe this crate should come with some sparse matrix collection as well as random matrices to benchmark against, automatically. That would make tweaking the details worthwile. That's an issue for another time though.

Concerning the minimum degree ordering: As it is significantly more complex, It will take some more time to implement it, as in a few days to weeks. I will do it eventually, but I don't want to block somebody else on it, if there is interest.