### PR TITLE
Better performance for sparse matrix product

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ pub use sparse::CompressedStorage::{self, CSC, CSR};
 pub use sparse::binop;
 pub use sparse::linalg;
 pub use sparse::prod;
+pub use sparse::smmp;
 pub use sparse::special_mats;
 pub use sparse::visu;
 

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -520,6 +520,23 @@ impl<N, I: SpIndex, Iptr: SpIndex>
         CsMatI::try_new_csc(shape, indptr, indices, data).unwrap()
     }
 
+    pub(crate) fn new_trusted(
+        storage: CompressedStorage,
+        shape: Shape,
+        indptr: Vec<Iptr>,
+        indices: Vec<I>,
+        data: Vec<N>,
+    ) -> CsMatI<N, I, Iptr> {
+        CsMatI {
+            storage,
+            nrows: shape.0,
+            ncols: shape.1,
+            indptr,
+            indices,
+            data,
+        }
+    }
+
     fn new_(
         storage: CompressedStorage,
         shape: Shape,
@@ -1822,9 +1839,7 @@ where
         rhs: &'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>,
     ) -> CsMatI<N, I, Iptr> {
         match (self.storage(), rhs.storage()) {
-            (CSR, CSR) => {
-                smmp::mul_csr_csr(self.view(), rhs.view())
-            }
+            (CSR, CSR) => smmp::mul_csr_csr(self.view(), rhs.view()),
             (CSR, CSC) => {
                 let rhs_csr = rhs.to_other_storage();
                 smmp::mul_csr_csr(self.view(), rhs_csr.view())

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -275,7 +275,7 @@ mod utils {
             buf.push((indices[i], data[i]));
         }
 
-        buf.sort_by_key(|x| x.0);
+        buf.sort_unstable_by_key(|x| x.0);
 
         for (i, &(ind, x)) in buf.iter().enumerate() {
             indices[i] = ind;

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -291,6 +291,7 @@ pub mod csmat;
 pub mod linalg;
 pub mod permutation;
 pub mod prod;
+pub mod smmp;
 pub mod special_mats;
 pub mod symmetric;
 pub mod to_dense;

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -3,14 +3,27 @@
 
 use indexing::SpIndex;
 
-/// Compute the symbolic structure of the
-/// matrix product C = A * B
+/// Compute the symbolic structure of the matrix product C = A * B, with
+/// A, B and C stored in the CSR matrix format.
+///
+/// This algorithm has a complexity of O(n * k * log(k)), where k is the
+/// average number of nonzeros in the rows of the result.
+///
+/// # Panics
 ///
 /// `index.len()` should be equal to the maximum dimension among the input
 /// matrices.
 ///
-/// This algorithm has a complexity of O(n * k * log(k)), where k is the
-/// average number of nonzeros in the rows of the result.
+/// The matrices should be in proper CSR structure, and their dimensions
+/// should be compatible. Failures to do so may result in out of bounds errors
+/// (though some cases might go unnoticed).
+///
+/// # Minimizing allocations
+///
+/// This function will reserve
+/// `a_indptr.last().unwrap() + b_indptr.last.unwrap()` in `c_indices`.
+/// Therefore, to prevent this function from allocating, it is required
+/// to have reserved at least this amount of memory.
 pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
     a_indptr: &[Iptr],
     a_indices: &[I],
@@ -27,6 +40,7 @@ pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
     let b_rows = b_indptr.len() - 1;
     let a_nnz = a_indptr[a_rows].index();
     let b_nnz = b_indptr[b_rows].index();
+    c_indices.clear();
     c_indices.reserve_exact(a_nnz + b_nnz);
 
     // `index` is used as a set to remember which columns of a row of C are

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -1,0 +1,125 @@
+//! Implementation of the paper
+//! Bank and Douglas, 2001, Sparse Matrix Multiplication Package (SMPP)
+
+use indexing::SpIndex;
+
+/// Compute the symbolic structure of the
+/// matrix product C = A * B
+///
+/// `index.len()` should be equal to the maximum dimension among the input
+/// matrices.
+///
+/// This algorithm has a complexity of O(n * k * log(k)), where k is the
+/// average number of nonzeros in the rows of the result.
+pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
+    a_indptr: &[Iptr],
+    a_indices: &[I],
+    b_cols: usize,
+    b_indptr: &[Iptr],
+    b_indices: &[I],
+    c_indptr: &mut [Iptr],
+    // TODO look for litterature on the nnz of C to be able to have a slice here
+    c_indices: &mut Vec<I>,
+    index: &mut [usize],
+) {
+    assert!(a_indptr.len() == c_indptr.len());
+    let a_rows = a_indptr.len() - 1;
+    let b_rows = b_indptr.len() - 1;
+    let a_nnz = a_indptr[a_rows].index();
+    let b_nnz = b_indptr[b_rows].index();
+    c_indices.reserve_exact(a_nnz + b_nnz);
+
+    // `index` is used as a set to remember which columns of a row of C are
+    // nonzero. At any point in the algorithm, if `index[col] == sentinel0`,
+    // then we know there is no nonzero value in the column. As the algorithm
+    // progresses, we discover nonzero elements. When a nonzero at `col` is
+    // discovered, we store in `index[col]` the column of the preceding
+    // nonzero (storing `sentinel1` for the first nonzero). Therefore,
+    // when we want to collect nonzeros and clear the set, we can simply
+    // follow the trail of column indices, putting back `sentinel0` along
+    // the way. This way, collecting the nonzero indices for a column
+    // has a complexity O(col_nnz).
+    let ind_len = a_rows.max(b_rows.max(b_cols));
+    let sentinel0 = usize::max_value();
+    let sentinel1 = usize::max_value() - 1;
+    assert!(index.len() == ind_len);
+    assert!(ind_len < sentinel1);
+    for elt in index.iter_mut() {
+        *elt = sentinel0;
+    }
+
+    c_indptr[0] = Iptr::from_usize(0);
+    for a_row in 0..a_rows {
+        let mut istart = sentinel1;
+        let mut length = 0;
+        let a_start = a_indptr[a_row].index();
+        let a_stop = a_indptr[a_row + 1].index();
+        for &a_col in &a_indices[a_start..a_stop] {
+            let b_row = a_col.index();
+            let b_start = b_indptr[b_row].index();
+            let b_stop = b_indptr[b_row + 1].index();
+            for b_col in &b_indices[b_start..b_stop] {
+                let b_col = b_col.index();
+                if index[b_col] == sentinel0 {
+                    index[b_col] = istart;
+                    istart = b_col;
+                    length += 1;
+                }
+            }
+        }
+        c_indptr[a_row + 1] = c_indptr[a_row] + Iptr::from_usize(length);
+        for _ in 0..length {
+            debug_assert!(istart < sentinel1);
+            c_indices.push(I::from_usize(istart));
+            let new_start = index[istart];
+            index[istart] = sentinel0;
+            istart = new_start;
+        }
+        let c_start = c_indptr[a_row].index();
+        let c_end = c_indptr[a_row + 1].index();
+        c_indices[c_start..c_end].sort();
+        index[a_row] = sentinel0;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use test_data;
+
+    #[test]
+    fn symbolic() {
+        let a = test_data::mat1();
+        let b = test_data::mat2();
+        // a * b 's structure:
+        //                | x x x   x |
+        //                | x     x   |
+        //                |           |
+        //                |     x x   |
+        //                |   x x     |
+        //
+        // |     x x   |  |     x x   |
+        // |       x x |  |   x x x   |
+        // |     x     |  |           |
+        // |   x       |  | x     x   |
+        // |       x   |  |     x x   |
+        let exp = test_data::mat1_matprod_mat2();
+
+        let mut c_indptr = [0; 6];
+        let mut c_indices = Vec::new();
+        let mut index = [0; 5];
+
+        super::symbolic(
+            a.indptr(),
+            a.indices(),
+            b.cols(),
+            b.indptr(),
+            b.indices(),
+            &mut c_indptr,
+            &mut c_indices,
+            &mut index,
+        );
+
+        assert_eq!(exp.indptr(), c_indptr);
+        assert_eq!(exp.indices(), &c_indices[..]);
+    }
+}

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -115,7 +115,7 @@ pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
             }
             let c_start = c_indptr[a_row].index();
             let c_end = c_indptr[a_row + 1].index();
-            c_indices[c_start..c_end].sort();
+            c_indices[c_start..c_end].sort_unstable();
         }
         index[a_row] = sentinel0;
     }

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -133,8 +133,8 @@ pub fn numeric<
     assert!(a_data.len() == a_indptr[a_rows].index());
     assert!(b_indices.len() == b_indptr[b_rows].index());
     assert!(b_data.len() == b_indptr[b_rows].index());
-    assert!(c_indices.len() == c_indptr[b_rows].index());
-    assert!(c_data.len() == c_indptr[b_rows].index());
+    assert!(c_indices.len() == c_indptr[a_rows].index());
+    assert!(c_data.len() == c_indptr[a_rows].index());
 
     for elt in tmp.iter_mut() {
         *elt = N::zero();

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -1,9 +1,10 @@
 //! Implementation of the paper
 //! Bank and Douglas, 2001, Sparse Matrix Multiplication Package (SMPP)
 
-use sparse::prelude::*;
 use indexing::SpIndex;
 use num_traits::Num;
+use sparse::prelude::*;
+use sparse::CompressedStorage::CSR;
 
 /// Compute the symbolic structure of the matrix product C = A * B, with
 /// A, B and C stored in the CSR matrix format.
@@ -244,7 +245,16 @@ where
         &mut res_data,
         tmp,
     );
-    CsMatI::new((l_rows, r_cols), res_indptr, res_indices, res_data)
+    // Correctness: The invariants of the output come from the invariants of
+    // the inputs when in-bounds indices are concerned, and we are sorting
+    // indices.
+    CsMatI::new_trusted(
+        CSR,
+        (l_rows, r_cols),
+        res_indptr,
+        res_indices,
+        res_data,
+    )
 }
 
 #[cfg(test)]

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -139,10 +139,10 @@ where
 
         match storage {
             CompressedStorage::CSR => {
-                rc.sort_by_key(|i| (i.0, i.1));
+                rc.sort_unstable_by_key(|i| (i.0, i.1));
             }
             CompressedStorage::CSC => {
-                rc.sort_by_key(|i| (i.1, i.0));
+                rc.sort_unstable_by_key(|i| (i.1, i.0));
             }
         }
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1079,7 +1079,7 @@ where
 impl<'a, 'b, N, I, Iptr, IS1, DS1, IpS2, IS2, DS2>
     Mul<&'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>> for &'a CsVecBase<IS1, DS1>
 where
-    N: 'a + Copy + Num + Default,
+    N: 'a + Copy + Num + Default + std::ops::AddAssign,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IS1: 'a + Deref<Target = [I]>,
@@ -1098,7 +1098,7 @@ where
 impl<'a, 'b, N, I, Iptr, IpS1, IS1, DS1, IS2, DS2> Mul<&'b CsVecBase<IS2, DS2>>
     for &'a CsMatBase<N, I, IpS1, IS1, DS1, Iptr>
 where
-    N: Copy + Num + Default + Sum,
+    N: Copy + Num + Default + Sum + std::ops::AddAssign,
     I: SpIndex,
     Iptr: SpIndex,
     IpS1: Deref<Target = [Iptr]>,


### PR DESCRIPTION
As shown in #184, the current implementation of sparse matrix product had quadratic behavior. As suggested, this branch implements the paper [Sparse Matrix Multiplication Package](https://www.i2m.univ-amu.fr/perso/abdallah.bradji/multp_sparse.pdf) to get better performance.

Benchmarks are given in #184.