### PR TITLE
Sparse product benches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       env: RUN_RUSTFMT=true
     - rust: beta
     - rust: nightly
+      env: WITH_NIGHTLY=true
 
 script:
     - rustc --version
@@ -18,6 +19,7 @@ script:
     - cargo test --release --all --verbose
     - cargo run --example heat
     - ./.travis_rustfmt
+    - ./.travis_nightly
 
 notifications:
   email:

--- a/.travis_nightly
+++ b/.travis_nightly
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ev
+
+if [ -z ${WITH_NIGHTLY+x} ]; then
+    echo "Not on nightly channel: skipping nightly only parts."
+else
+    cd sprs-benches
+    cargo build --features nightly
+fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,5 @@ members = [
     "suitesparse_bindings/suitesparse_ldl_sys",
     "suitesparse_bindings/sprs_suitesparse_ldl",
     "sprs-rand",
+    "sprs-benches",
 ]

--- a/sprs-benches/.cargo/config
+++ b/sprs-benches/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+
+rustflags = "-C force-frame-pointers=yes"

--- a/sprs-benches/.gitignore
+++ b/sprs-benches/.gitignore
@@ -1,0 +1,4 @@
+target/
+*.png
+perf.data.old
+perf.data

--- a/sprs-benches/Cargo.toml
+++ b/sprs-benches/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sprs-benches"
+version = "0.1.0"
+authors = ["Vincent Barrielle <vincent.barrielle@m4x.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies.sprs]
+version = "0.7.1"
+path = ".."
+
+[dependencies.sprs-rand]
+version = "0.1.0"
+path = "../sprs-rand"
+
+[dependencies.plotters]
+version = "0.2.12"
+

--- a/sprs-benches/Cargo.toml
+++ b/sprs-benches/Cargo.toml
@@ -22,8 +22,12 @@ pyo3 = { version="0.9.2", optional=true }
 
 [build-dependencies]
 cc = "1.0.52"
+reqwest = { version="0.10.4", features=["blocking"], optional=true }
+tar = { version="0.4.26", optional=true }
+libflate = {version="1.0.0", optional=true }
 
 [features]
 
 default = []
 nightly = ["pyo3"]
+dl_eigen = ["reqwest", "tar", "libflate"]

--- a/sprs-benches/Cargo.toml
+++ b/sprs-benches/Cargo.toml
@@ -18,5 +18,9 @@ path = "../sprs-rand"
 version = "0.2.12"
 
 [dependencies]
-pyo3 = "0.9.2"
+pyo3 = { version="0.9.2", optional=true }
 
+[features]
+
+default = []
+nightly = ["pyo3"]

--- a/sprs-benches/Cargo.toml
+++ b/sprs-benches/Cargo.toml
@@ -31,3 +31,4 @@ libflate = {version="1.0.0", optional=true }
 default = []
 nightly = ["pyo3"]
 dl_eigen = ["reqwest", "tar", "libflate"]
+eigen = []

--- a/sprs-benches/Cargo.toml
+++ b/sprs-benches/Cargo.toml
@@ -17,3 +17,6 @@ path = "../sprs-rand"
 [dependencies.plotters]
 version = "0.2.12"
 
+[dependencies]
+pyo3 = "0.9.2"
+

--- a/sprs-benches/Cargo.toml
+++ b/sprs-benches/Cargo.toml
@@ -20,6 +20,9 @@ version = "0.2.12"
 [dependencies]
 pyo3 = { version="0.9.2", optional=true }
 
+[build-dependencies]
+cc = "1.0.52"
+
 [features]
 
 default = []

--- a/sprs-benches/README.md
+++ b/sprs-benches/README.md
@@ -1,0 +1,12 @@
+# sprs benches
+
+This crate is there to benchmark algorithms in sprs, both against old versions
+and versus other implementations. Currently it only benchmarks the sparse matrix
+product.
+
+The benchmark can be run against scipy, but this requires a nightly compiler,
+and running the benchmarks as follows:
+
+```
+cargo +nightly run --release --features nightly
+```

--- a/sprs-benches/build.rs
+++ b/sprs-benches/build.rs
@@ -1,7 +1,52 @@
-fn main() {
+#[cfg(feature = "dl_eigen")]
+use std::fs::File;
+#[cfg(feature = "dl_eigen")]
+use std::path::Path;
+
+#[cfg(feature = "dl_eigen")]
+fn collect_lib<P>(
+    save_dir: P,
+    lib_url: &str,
+    extracted_path: &str,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    P: AsRef<Path>,
+{
+    let save_dir = save_dir.as_ref();
+    let extracted_path = save_dir.join(extracted_path);
+    let probe = save_dir.join(&extracted_path).join("dl_done");
+    if !probe.exists() {
+        println!(
+            "probe {} does not exist, downloading {}",
+            probe.to_string_lossy(),
+            lib_url,
+        );
+        tar::Archive::new(libflate::gzip::Decoder::new(
+            reqwest::blocking::get(lib_url)?,
+        )?)
+        .unpack(save_dir)?;
+        let _ = File::create(probe)?;
+    } else {
+        println!("Using cached archive {}", extracted_path.to_string_lossy());
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "dl_eigen")]
+    collect_lib(
+        ".",
+        "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz",
+        "eigen-3.3.7",
+    )?;
+    #[cfg(not(feature = "dl_eigen"))]
+    let eigen_include_path = "/usr/include/eigen3";
+    #[cfg(feature = "dl_eigen")]
+    let eigen_include_path = "eigen-3.3.7";
     cc::Build::new()
         .cpp(true)
-        .include("/usr/include/eigen3")
+        .include(eigen_include_path)
         .file("src/eigen.cpp")
         .compile("eigen");
+    Ok(())
 }

--- a/sprs-benches/build.rs
+++ b/sprs-benches/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    cc::Build::new()
+        .cpp(true)
+        .include("/usr/include/eigen3")
+        .file("src/eigen.cpp")
+        .compile("eigen");
+}

--- a/sprs-benches/build.rs
+++ b/sprs-benches/build.rs
@@ -43,10 +43,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eigen_include_path = "/usr/include/eigen3";
     #[cfg(feature = "dl_eigen")]
     let eigen_include_path = "eigen-3.3.7";
-    cc::Build::new()
+    let res = cc::Build::new()
         .cpp(true)
         .include(eigen_include_path)
         .file("src/eigen.cpp")
-        .compile("eigen");
+        .try_compile("eigen");
+    if res.is_ok() {
+        println!("cargo:rustc-cfg=feature=\"eigen\"");
+    } else {
+        println!(
+            "cargo:warning=Could not find and compile eigen, it will not \
+             be benchmarked against. You can enable it by activating the \
+            'dl_eigen' feature which will download and compile it."
+        );
+    }
     Ok(())
 }

--- a/sprs-benches/src/eigen.cpp
+++ b/sprs-benches/src/eigen.cpp
@@ -1,0 +1,32 @@
+
+#include <Eigen/SparseCore>
+
+extern "C" {
+
+size_t
+prod_nnz(
+        size_t          a_rows,
+        size_t          a_cols,
+        size_t          b_cols,
+        const int64_t * a_indptr,
+        const int64_t * a_indices,
+        const double *  a_data,
+        const int64_t * b_indptr,
+        const int64_t * b_indices,
+        const double *  b_data
+    )
+{
+    typedef Eigen::SparseMatrix<double, Eigen::RowMajor, int64_t> SpMat;
+    int64_t a_nnz = a_indptr[a_rows];
+    int64_t b_nnz = b_indptr[a_cols];
+    Eigen::Map<const SpMat> a(
+        a_rows, a_cols, a_nnz, a_indptr, a_indices, a_data
+    );
+    Eigen::Map<const SpMat> b(
+        a_cols, b_cols, b_nnz, b_indptr, b_indices, b_data
+    );
+    SpMat c = a * b;
+    return c.nonZeros();
+}
+
+} // extern C

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -1,0 +1,113 @@
+use sprs_rand::rand_csr_std;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let shapes_and_densities = [
+        ((15, 25), vec![0.1]),
+        (
+            (1500, 2500),
+            vec![1e-4, 5e-4, 1e-3, 2e-3, 5e-3, 8e-3, 1e-2, 2e-2, 5e-2],
+        ),
+        (
+            (15000, 25000),
+            vec![1e-5, 2e-5, 5e-5, 1e-4, 2e-4, 5e-4, 1e-3, 2e-3, 3e-3, 5e-3],
+        ),
+        ((150000, 25000), vec![1e-7, 1e-6, 1e-5, 1e-4]),
+        ((150000, 250000), vec![1e-7, 1e-6, 1e-5, 1e-4]),
+    ];
+
+    for (shape, densities) in &shapes_and_densities {
+        let mut times = Vec::with_capacity(densities.len());
+        let mut times_old = Vec::with_capacity(densities.len());
+        let mut nnzs = Vec::with_capacity(densities.len());
+        let mut res_densities = Vec::with_capacity(densities.len());
+        let mut workspace = vec![0.; shape.0];
+        for &density in densities {
+            println!("Generating matrices");
+            let now = std::time::Instant::now();
+            let m1 = rand_csr_std(*shape, density);
+            let m2 = rand_csr_std((shape.1, shape.0), density);
+            let elapsed = now.elapsed().as_millis();
+            println!("Generating matrices took {}ms", elapsed);
+
+            let now = std::time::Instant::now();
+            let prod = &m1 * &m2;
+            let elapsed = now.elapsed().as_millis();
+            println!(
+                "New product of shape ({}, {}) and density {} done in {}ms",
+                shape.0, shape.1, density, elapsed,
+            );
+            times.push(elapsed);
+            let now = std::time::Instant::now();
+            let old_res = sprs::prod::csr_mul_csr(&m1, &m2, &mut workspace);
+            let elapsed = now.elapsed().as_millis();
+            println!(
+                "Old product of shape ({}, {}) and density {} done in {}ms",
+                shape.0, shape.1, density, elapsed,
+            );
+            times_old.push(elapsed);
+            assert_eq!(prod, old_res);
+            nnzs.push(prod.nnz());
+            res_densities.push(prod.density());
+        }
+        println!("Results for shape: ({}, {})", shape.0, shape.1);
+        println!("Product nnzs: {:?}", nnzs);
+        println!("Product densities: {:?}", res_densities);
+        println!("Product times: {:?}", times);
+        println!("Product times (old): {:?}", times_old);
+
+        // plot
+        {
+            use plotters::prelude::*;
+            let title = format!("sparse_mult_perf_{}_{}.png", shape.0, shape.1);
+            let res = (640, 480);
+            let root = BitMapBackend::new(&title, res).into_drawing_area();
+            root.fill(&WHITE)?;
+            let max_density = *res_densities.last().unwrap_or(&1.) as f32;
+            let max_time =
+                *std::cmp::max(times.iter().max(), times_old.iter().max())
+                    .unwrap_or(&1) as f32;
+            let mut chart = ChartBuilder::on(&root)
+                .caption("Time vs density", ("sans-serif", 50).into_font())
+                .margin(5)
+                .x_label_area_size(30)
+                .y_label_area_size(50)
+                .build_ranged(0f32..max_density, 0f32..max_time)?;
+
+            chart.configure_mesh().draw()?;
+
+            chart
+                .draw_series(LineSeries::new(
+                    res_densities
+                        .iter()
+                        .map(|d| *d as f32)
+                        .zip(times.iter().map(|t| *t as f32)),
+                    &RED,
+                ))?
+                .label("SMMP")
+                .legend(|(x, y)| {
+                    PathElement::new(vec![(x, y), (x + 20, y)], &RED)
+                });
+
+            chart
+                .draw_series(LineSeries::new(
+                    res_densities
+                        .iter()
+                        .map(|d| *d as f32)
+                        .zip(times_old.iter().map(|t| *t as f32)),
+                    &BLUE,
+                ))?
+                .label("Old prod")
+                .legend(|(x, y)| {
+                    PathElement::new(vec![(x, y), (x + 20, y)], &BLUE)
+                });
+
+            chart
+                .configure_series_labels()
+                .background_style(&WHITE.mix(0.8))
+                .border_style(&BLACK)
+                .draw()?;
+        }
+    }
+
+    Ok(())
+}

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -254,15 +254,17 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
 
             // bench eigen
             #[cfg(feature = "eigen")]
-            if !spec.forbid_eigen {
-                let now = std::time::Instant::now();
-                let _nnz = eigen_prod(m1.view(), m2.view());
-                let elapsed = now.elapsed().as_millis();
-                println!(
-                    "Eigen product of shape ({}, {}) and density {} done in {}ms",
-                    shape.0, shape.1, density, elapsed,
-                );
-                times_eigen.push(elapsed);
+            {
+                if !spec.forbid_eigen {
+                    let now = std::time::Instant::now();
+                    let _nnz = eigen_prod(m1.view(), m2.view());
+                    let elapsed = now.elapsed().as_millis();
+                    println!(
+                        "Eigen product of shape ({}, {}) and density {} done in {}ms",
+                        shape.0, shape.1, density, elapsed,
+                    );
+                    times_eigen.push(elapsed);
+                }
             }
         }
         println!("Results for shape: ({}, {})", shape.0, shape.1);
@@ -369,19 +371,21 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 });
 
             #[cfg(feature = "eigen")]
-            if !spec.forbid_eigen {
-                chart
-                    .draw_series(LineSeries::new(
-                        abscisses
-                            .iter()
-                            .map(|d| *d as f32)
-                            .zip(times_eigen.iter().map(|t| *t as f32)),
-                        &CYAN,
-                    ))?
-                    .label("Eigen")
-                    .legend(|(x, y)| {
-                        PathElement::new(vec![(x, y), (x + 20, y)], &CYAN)
-                    });
+            {
+                if !spec.forbid_eigen {
+                    chart
+                        .draw_series(LineSeries::new(
+                            abscisses
+                                .iter()
+                                .map(|d| *d as f32)
+                                .zip(times_eigen.iter().map(|t| *t as f32)),
+                            &CYAN,
+                        ))?
+                        .label("Eigen")
+                        .legend(|(x, y)| {
+                            PathElement::new(vec![(x, y), (x + 20, y)], &CYAN)
+                        });
+                }
             }
 
             chart

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -28,6 +28,47 @@ fn scipy_mat<'a>(
         })
 }
 
+extern "C" {
+
+    fn prod_nnz(
+        a_rows: usize,
+        a_cols: usize,
+        b_cols: usize,
+        a_indptr: *const isize,
+        a_indices: *const isize,
+        a_data: *const f64,
+        b_indptr: *const isize,
+        b_indices: *const isize,
+        b_data: *const f64,
+    ) -> usize;
+
+}
+
+fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
+    let (a_rows, a_cols) = a.shape();
+    let (b_rows, b_cols) = b.shape();
+    assert_eq!(a_cols, b_rows);
+    let a_indptr = a.indptr().as_ptr() as *const isize;
+    let a_indices = a.indices().as_ptr() as *const isize;
+    let a_data = a.data().as_ptr();
+    let b_indptr = b.indptr().as_ptr() as *const isize;
+    let b_indices = b.indices().as_ptr() as *const isize;
+    let b_data = b.data().as_ptr();
+    unsafe {
+        prod_nnz(
+            a_rows,
+            a_cols,
+            b_cols,
+            a_indptr,
+            a_indices,
+            a_data,
+            b_indptr,
+            b_indices,
+            b_data,
+        )
+    }
+}
+
 fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
     let shapes_and_densities = [
         ((15, 25), vec![0.1]),
@@ -59,6 +100,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         let mut times_old = Vec::with_capacity(densities.len());
         #[cfg(feature = "nightly")]
         let mut times_py = Vec::with_capacity(densities.len());
+        let mut times_eigen = Vec::with_capacity(densities.len());
         let mut nnzs = Vec::with_capacity(densities.len());
         let mut res_densities = Vec::with_capacity(densities.len());
         let mut workspace = vec![0.; shape.0];
@@ -114,6 +156,16 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 );
                 times_py.push(elapsed);
             }
+
+            // bench eigen
+            let now = std::time::Instant::now();
+            let _nnz = eigen_prod(m1.view(), m2.view());
+            let elapsed = now.elapsed().as_millis();
+            println!(
+                "Eigen product of shape ({}, {}) and density {} done in {}ms",
+                shape.0, shape.1, density, elapsed,
+            );
+            times_eigen.push(elapsed);
         }
         println!("Results for shape: ({}, {})", shape.0, shape.1);
         println!("Product nnzs: {:?}", nnzs);
@@ -122,6 +174,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         println!("Product times (old): {:?}", times_old);
         #[cfg(feature = "nightly")]
         println!("Product times (scipy): {:?}", times_py);
+        println!("Product times (eigen): {:?}", times_eigen);
 
         // plot
         {
@@ -181,6 +234,19 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 .label("Scipy")
                 .legend(|(x, y)| {
                     PathElement::new(vec![(x, y), (x + 20, y)], &GREEN)
+                });
+
+            chart
+                .draw_series(LineSeries::new(
+                    res_densities
+                        .iter()
+                        .map(|d| *d as f32)
+                        .zip(times_eigen.iter().map(|t| *t as f32)),
+                    &CYAN,
+                ))?
+                .label("Eigen")
+                .legend(|(x, y)| {
+                    PathElement::new(vec![(x, y), (x + 20, y)], &CYAN)
                 });
 
             chart

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -28,6 +28,7 @@ fn scipy_mat<'a>(
         })
 }
 
+#[cfg(feature = "eigen")]
 extern "C" {
 
     fn prod_nnz(
@@ -44,6 +45,7 @@ extern "C" {
 
 }
 
+#[cfg(feature = "eigen")]
 fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
     let (a_rows, a_cols) = a.shape();
     let (b_rows, b_cols) = b.shape();
@@ -107,6 +109,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         let mut times_old = Vec::with_capacity(densities.len());
         #[cfg(feature = "nightly")]
         let mut times_py = Vec::with_capacity(densities.len());
+        #[cfg(feature = "eigen")]
         let mut times_eigen = Vec::with_capacity(densities.len());
         let mut nnzs = Vec::with_capacity(densities.len());
         let mut res_densities = Vec::with_capacity(densities.len());
@@ -165,14 +168,17 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // bench eigen
-            let now = std::time::Instant::now();
-            let _nnz = eigen_prod(m1.view(), m2.view());
-            let elapsed = now.elapsed().as_millis();
-            println!(
-                "Eigen product of shape ({}, {}) and density {} done in {}ms",
-                shape.0, shape.1, density, elapsed,
-            );
-            times_eigen.push(elapsed);
+            #[cfg(feature = "eigen")]
+            {
+                let now = std::time::Instant::now();
+                let _nnz = eigen_prod(m1.view(), m2.view());
+                let elapsed = now.elapsed().as_millis();
+                println!(
+                    "Eigen product of shape ({}, {}) and density {} done in {}ms",
+                    shape.0, shape.1, density, elapsed,
+                );
+                times_eigen.push(elapsed);
+            }
         }
         println!("Results for shape: ({}, {})", shape.0, shape.1);
         println!("Product nnzs: {:?}", nnzs);
@@ -181,6 +187,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         println!("Product times (old): {:?}", times_old);
         #[cfg(feature = "nightly")]
         println!("Product times (scipy): {:?}", times_py);
+        #[cfg(feature = "eigen")]
         println!("Product times (eigen): {:?}", times_eigen);
 
         // plot
@@ -243,6 +250,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                     PathElement::new(vec![(x, y), (x + 20, y)], &GREEN)
                 });
 
+            #[cfg(feature = "eigen")]
             chart
                 .draw_series(LineSeries::new(
                     res_densities


### PR DESCRIPTION
As noted in #188, benchamrks were needed to be able to monitor the performance of sparse matrix products.

In this PR, I implemented benchmarks of the old and new (SMMP) implementation of product in sprs, scipy's matrix product, and also the product for the C++ library eigen.

There are benchmarks inspecting the influence of the matrices shape on the performance, with the number of non zeros growing as the number of rows:


![sparse_mult_perf_by_shape](https://user-images.githubusercontent.com/1874105/81745064-65b30580-94a4-11ea-951c-54a8e25716d7.png)
![sparse_mult_perf_by_shape_no_old](https://user-images.githubusercontent.com/1874105/81745065-664b9c00-94a4-11ea-9f8a-e8a4a343242d.png)

The quadratic performance of the old product implementation can clearly be seen. It's also possible to observe that eigen has a lower performance than scipy and sprs, and I suspect this is because their sparse matrix format is an extension of CSR that reserves some space to be able to more efficiently insert new elements in the matrix. Maintaining this possibility must have a runtime cost.

Scipy looks a bit faster than sprs most of the time, but it does not guarantee that the indices are sorted in the resulting matrix, so most of the overhead in sprs comes from sorting. There are also some huge variations for scipy when dealing with big matrices, and I can't find a good explanation for this. Maybe sometimes the python runtime kicks in and impacts my benchmarks?

Here are benchmarks with the density increasing. This is probably less representative of real workloads, but it helps monitoring the different performance caracteristics.

Shape (1500, 2500):
![sparse_mult_perf_1500_2500](https://user-images.githubusercontent.com/1874105/81745595-66986700-94a5-11ea-9199-6addd38078b8.png)

Shape (15000, 25000):
![sparse_mult_perf_15000_25000](https://user-images.githubusercontent.com/1874105/81745639-70ba6580-94a5-11ea-8c8e-baec15d3921b.png)

Shape (150000, 25000):
![sparse_mult_perf_150000_25000](https://user-images.githubusercontent.com/1874105/81745668-7e6feb00-94a5-11ea-8999-f8345c9719ec.png)

Shape (150000, 250000):
![sparse_mult_perf_150000_250000](https://user-images.githubusercontent.com/1874105/81745694-892a8000-94a5-11ea-9fd8-e185c1e2d254.png)

The same trends appear, but we can see the old sprs implementation was actually good for small shapes and high densities. However this is probably not a very realistic workload. With these quite dense matrices, there are more elements per row in the result, so the sorting overhead for sprs augments, meaning scipy gets a larger edge.


