### PR TITLE
export iterators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub type Ix2 = ndarray::Ix2;
 pub use indexing::SpIndex;
 
 pub use sparse::{
+    csmat::OuterIterator, csmat::OuterIteratorMut, csmat::OuterIteratorPerm,
     CsMat, CsMatBase, CsMatI, CsMatVecView, CsMatView, CsMatViewI,
     CsMatViewMut, CsMatViewMutI, CsVec, CsVecBase, CsVecI, CsVecView,
     CsVecViewI, CsVecViewMut, CsVecViewMutI, SparseMat, TriMat, TriMatBase,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,12 +106,12 @@ pub type Ix2 = ndarray::Ix2;
 pub use indexing::SpIndex;
 
 pub use sparse::{
-    csmat::OuterIterator, csmat::OuterIteratorMut, csmat::OuterIteratorPerm,
-    CsMat, CsMatBase, CsMatI, CsMatVecView, CsMatView, CsMatViewI,
-    CsMatViewMut, CsMatViewMutI, CsVec, CsVecBase, CsVecI, CsVecView,
-    CsVecViewI, CsVecViewMut, CsVecViewMutI, SparseMat, TriMat, TriMatBase,
-    TriMatI, TriMatIter, TriMatView, TriMatViewI, TriMatViewMut,
-    TriMatViewMutI,
+    csmat::CsIter, csmat::OuterIterator, csmat::OuterIteratorMut,
+    csmat::OuterIteratorPerm, CsMat, CsMatBase, CsMatI, CsMatVecView,
+    CsMatView, CsMatViewI, CsMatViewMut, CsMatViewMutI, CsVec, CsVecBase,
+    CsVecI, CsVecView, CsVecViewI, CsVecViewMut, CsVecViewMutI, SparseMat,
+    TriMat, TriMatBase, TriMatI, TriMatIter, TriMatView, TriMatViewI,
+    TriMatViewMut, TriMatViewMutI,
 };
 
 pub use sparse::symmetric::is_symmetric;


### PR DESCRIPTION
It seems some structures are not exported in the docs, which makes it hard to understand how they work, and which traits they implement.

It would be nice if such items were exported automatically, which they are if `pub mod sparse` is added to the topleve. But adding `pub mod sparse` will add `Re-exports` to all the type definitions on the toppage, which makes it difficult getting an overview. Is there a better way of handling this?