### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,107 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches:
+    - master
+  schedule:
+  - cron: '0 0 15 * *'
+jobs:
+  test:
+    name: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build:
+        - stable
+        - beta
+        - nightly
+        include:
+        - build: stable
+          os: ubuntu-18.04
+          rust: stable
+        - build: beta
+          os: ubuntu-18.04
+          rust: beta
+        - build: nightly
+          os: ubuntu-18.04
+          rust: nightly
+        - build: macos
+          os: macos-latest
+          rust: stable
+        - build: win-msvc
+          os: windows-2019
+          rust: stable
+        - build: win-gnu
+          os: windows-2019
+          rust: stable
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install suitesparse
+      if: matrix.os == 'ubuntu-18.04'
+      run: |
+          sudo apt-get install libsuitesparse-dev
+
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        profile: minimal
+        override: true
+
+    - name: Build (exclude suitesparse)
+      run: cargo build --verbose --workspace --exclude suitesparse_ldl_sys --exclude sprs_suitesparse_ldl
+      if: matrix.os != 'ubuntu-18.04'
+
+    - name: Build (all)
+      run: cargo build --verbose --workspace
+      if: matrix.os == 'ubuntu-18.04'
+
+    - name: Test (exclude suitesparse)
+      run: cargo test --verbose --workspace --exclude suitesparse_ldl_sys --exclude sprs_suitesparse_ldl
+      if: matrix.os != 'ubuntu-18.04'
+
+    - name: Test (all)
+      run: cargo test --verbose --workspace
+      if: matrix.os == 'ubuntu-18.04'
+
+  rustfmt:
+    name: rustfmt
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+        components: rustfmt
+    - name: Check formatting
+      run: |
+        cargo fmt -- --check
+    - name: Documentation
+      run: cargo doc
+
+  benches:
+    name: benchmarks
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+          sudo apt-get install libeigen3-dev libsuitesparse-dev
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+    - name: Run benchmarks
+      run: |
+          cargo bench --workspace


### PR DESCRIPTION
This adds github actions, which are run on every PR and push to master/main, and every month.

The time it takes for CI is reduced significantly, a rustfmt seems to take less than 30 seconds, with the full suite taking about 5 minutes. The crates are now tested on `ubuntu`, `mac`, and `windows`, but the `suitesparse_bindings` are only built on ubuntu.

Some differences between travis and github actions (these can be added if wanted):
- No longer running the heat example
- Tests are not run with release
- Nightly feature is not enabled for `sprs-benches`

If this PR is merged, the actions will automatically be run, without any futher setup.

The workflow is inspired mostly by the implementation in `ripgrep` (license: unlicense)