### PR TITLE
Parallel smmp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ num-complex = "0.2.1"
 serde = { version = "1.0.0", optional = true, features = ["derive"] }
 smallvec = "1.4.0"
 rayon = "1.3.0"
+num_cpus = "1.13.0"
 
 [dev-dependencies]
 bencher = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ alga = { version = "0.9.0", optional = true }
 num-complex = "0.2.1"
 serde = { version = "1.0.0", optional = true, features = ["derive"] }
 smallvec = "1.4.0"
+rayon = "1.3.0"
 
 [dev-dependencies]
 bencher = "0.1.0"

--- a/sprs-benches/.cargo/config
+++ b/sprs-benches/.cargo/config
@@ -1,3 +1,7 @@
 [build]
 
 rustflags = "-C force-frame-pointers=yes"
+
+[profile.release]
+
+debug = true

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -4,6 +4,7 @@ use pyo3::{
     types::{IntoPyDict, PyModule},
 };
 use sprs_rand::rand_csr_std;
+use sprs::smmp;
 
 #[cfg(feature = "nightly")]
 fn scipy_mat<'a>(
@@ -101,7 +102,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         BenchSpec {
             shape: (15000, 25000),
             densities: vec![
-                1e-5, 2e-5, 5e-5, 1e-4, 2e-4, 5e-4, 1e-3, 2e-3, 3e-3, 5e-3,
+                1e-5, 2e-5, 5e-5, 1e-4, 2e-4, 5e-4,//1e-3, 2e-3, 3e-3, 5e-3,
             ],
             ..Default::default()
         },
@@ -147,6 +148,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 (2500000, 2500000),
             ],
             forbid_old: true,
+            forbid_eigen: true,
             nnz_over_rows: 4,
             bench_filename: "sparse_mult_perf_by_shape_no_old.png".to_string(),
             ..Default::default()
@@ -185,6 +187,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         let mut times = Vec::with_capacity(densities.len());
+        let mut times_boolvec = Vec::with_capacity(densities.len());
         let mut times_old = Vec::with_capacity(densities.len());
         #[cfg(feature = "nightly")]
         let mut times_py = Vec::with_capacity(densities.len());
@@ -203,6 +206,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             let elapsed = now.elapsed().as_millis();
             println!("Generating matrices took {}ms", elapsed);
 
+            smmp::set_thread_symbolic_method(smmp::SymbMethod::LinkedList);
             let now = std::time::Instant::now();
             let prod = &m1 * &m2;
             let elapsed = now.elapsed().as_millis();
@@ -211,6 +215,17 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 shape.0, shape.1, density, elapsed,
             );
             times.push(elapsed);
+
+            smmp::set_thread_symbolic_method(smmp::SymbMethod::BoolVecAndSort);
+            let now = std::time::Instant::now();
+            let prod_b = &m1 * &m2;
+            let elapsed = now.elapsed().as_millis();
+            println!(
+                "New product (boolvec) of shape ({}, {}) and density {} done in {}ms",
+                shape.0, shape.1, density, elapsed,
+            );
+            assert_eq!(prod, prod_b);
+            times_boolvec.push(elapsed);
 
             if !spec.forbid_old {
                 let now = std::time::Instant::now();
@@ -271,6 +286,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         println!("Product nnzs: {:?}", nnzs);
         println!("Product densities: {:?}", res_densities);
         println!("Product times: {:?}", times);
+        println!("Product times (boolvec): {:?}", times_boolvec);
         println!("Product times (old): {:?}", times_old);
         #[cfg(feature = "nightly")]
         println!("Product times (scipy): {:?}", times_py);
@@ -304,6 +320,10 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             let max_time =
                 *std::cmp::max(times.iter().max(), times_old.iter().max())
                     .unwrap_or(&1);
+            let max_time = std::cmp::max(
+                max_time,
+                *times_boolvec.iter().max().unwrap_or(&1),
+            );
             #[cfg(feature = "eigen")]
             let max_time = std::cmp::max(
                 max_time,
@@ -339,6 +359,19 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 .label("sprs (new)")
                 .legend(|(x, y)| {
                     PathElement::new(vec![(x, y), (x + 20, y)], &RED)
+                });
+
+            chart
+                .draw_series(LineSeries::new(
+                    abscisses
+                        .iter()
+                        .map(|d| *d as f32)
+                        .zip(times_boolvec.iter().map(|t| *t as f32)),
+                    &MAGENTA,
+                ))?
+                .label("sprs (new)")
+                .legend(|(x, y)| {
+                    PathElement::new(vec![(x, y), (x + 20, y)], &MAGENTA)
                 });
 
             if !spec.forbid_old {

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -105,18 +105,21 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 1e-5, 2e-5, 5e-5, 1e-4, 2e-4,
                 5e-4, //1e-3, 2e-3, 3e-3, 5e-3,
             ],
+            forbid_old: true,
             ..Default::default()
         },
         BenchSpec {
             shape: (150000, 25000),
             densities: vec![1e-7, 1e-6, 1e-5, 1e-4],
             forbid_old: true,
+            forbid_eigen: true,
             ..Default::default()
         },
         BenchSpec {
             shape: (150000, 250000),
             densities: vec![1e-7, 1e-6, 1e-5, 1e-4],
             forbid_old: true,
+            forbid_eigen: true,
             ..Default::default()
         },
         BenchSpec {
@@ -131,6 +134,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 (55000, 55000),
             ],
             nnz_over_rows: 4,
+            forbid_old: true,
             bench_filename: "sparse_mult_perf_by_shape.png".to_string(),
             ..Default::default()
         },

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -3,8 +3,8 @@ use pyo3::{
     prelude::*,
     types::{IntoPyDict, PyModule},
 };
-use sprs_rand::rand_csr_std;
 use sprs::smmp;
+use sprs_rand::rand_csr_std;
 
 #[cfg(feature = "nightly")]
 fn scipy_mat<'a>(
@@ -102,7 +102,8 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         BenchSpec {
             shape: (15000, 25000),
             densities: vec![
-                1e-5, 2e-5, 5e-5, 1e-4, 2e-4, 5e-4,//1e-3, 2e-3, 3e-3, 5e-3,
+                1e-5, 2e-5, 5e-5, 1e-4, 2e-4,
+                5e-4, //1e-3, 2e-3, 3e-3, 5e-3,
             ],
             ..Default::default()
         },

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -193,6 +193,9 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
 
         let mut times = Vec::with_capacity(densities.len());
         let mut times_boolvec = Vec::with_capacity(densities.len());
+        let mut times_autothread = Vec::with_capacity(densities.len());
+        let mut times_2threads = Vec::with_capacity(densities.len());
+        let mut times_4threads = Vec::with_capacity(densities.len());
         let mut times_old = Vec::with_capacity(densities.len());
         #[cfg(feature = "nightly")]
         let mut times_py = Vec::with_capacity(densities.len());
@@ -222,6 +225,9 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             times.push(elapsed);
 
             smmp::set_thread_symbolic_method(smmp::SymbMethod::BoolVecAndSort);
+            smmp::set_thread_threading_strategy(
+                smmp::ThreadingStrategy::Fixed(1),
+            );
             let now = std::time::Instant::now();
             let prod_b = &m1 * &m2;
             let elapsed = now.elapsed().as_millis();
@@ -231,6 +237,48 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             );
             assert_eq!(prod, prod_b);
             times_boolvec.push(elapsed);
+
+            smmp::set_thread_symbolic_method(smmp::SymbMethod::BoolVecAndSort);
+            smmp::set_thread_threading_strategy(
+                smmp::ThreadingStrategy::Fixed(2),
+            );
+            let now = std::time::Instant::now();
+            let prod_b = &m1 * &m2;
+            let elapsed = now.elapsed().as_millis();
+            println!(
+                "New product (boolvec, 2 threads) of shape ({}, {}) and density {} done in {}ms",
+                shape.0, shape.1, density, elapsed,
+            );
+            assert_eq!(prod, prod_b);
+            times_2threads.push(elapsed);
+
+            smmp::set_thread_symbolic_method(smmp::SymbMethod::BoolVecAndSort);
+            smmp::set_thread_threading_strategy(
+                smmp::ThreadingStrategy::Fixed(4),
+            );
+            let now = std::time::Instant::now();
+            let prod_b = &m1 * &m2;
+            let elapsed = now.elapsed().as_millis();
+            println!(
+                "New product (boolvec, 4 threads) of shape ({}, {}) and density {} done in {}ms",
+                shape.0, shape.1, density, elapsed,
+            );
+            assert_eq!(prod, prod_b);
+            times_4threads.push(elapsed);
+
+            smmp::set_thread_symbolic_method(smmp::SymbMethod::BoolVecAndSort);
+            smmp::set_thread_threading_strategy(
+                smmp::ThreadingStrategy::Automatic,
+            );
+            let now = std::time::Instant::now();
+            let prod_b = &m1 * &m2;
+            let elapsed = now.elapsed().as_millis();
+            println!(
+                "New product (boolvec, auto thread) of shape ({}, {}) and density {} done in {}ms",
+                shape.0, shape.1, density, elapsed,
+            );
+            assert_eq!(prod, prod_b);
+            times_autothread.push(elapsed);
 
             if !spec.forbid_old {
                 let now = std::time::Instant::now();
@@ -292,6 +340,12 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         println!("Product densities: {:?}", res_densities);
         println!("Product times: {:?}", times);
         println!("Product times (boolvec): {:?}", times_boolvec);
+        println!("Product times (boolvec, 2 threads): {:?}", times_2threads);
+        println!("Product times (boolvec, 4 threads): {:?}", times_4threads);
+        println!(
+            "Product times (boolvec, auto threads): {:?}",
+            times_autothread
+        );
         println!("Product times (old): {:?}", times_old);
         #[cfg(feature = "nightly")]
         println!("Product times (scipy): {:?}", times_py);
@@ -323,11 +377,19 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 "Time vs density"
             };
             let max_time =
-                *std::cmp::max(times.iter().max(), times_old.iter().max())
+                *std::cmp::max(times.iter().max(), times_boolvec.iter().max())
                     .unwrap_or(&1);
             let max_time = std::cmp::max(
                 max_time,
-                *times_boolvec.iter().max().unwrap_or(&1),
+                *times_2threads.iter().max().unwrap_or(&1),
+            );
+            let max_time = std::cmp::max(
+                max_time,
+                *times_4threads.iter().max().unwrap_or(&1),
+            );
+            let max_time = std::cmp::max(
+                max_time,
+                *times_autothread.iter().max().unwrap_or(&1),
             );
             #[cfg(feature = "eigen")]
             let max_time = std::cmp::max(
@@ -374,25 +436,49 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                         .zip(times_boolvec.iter().map(|t| *t as f32)),
                     &MAGENTA,
                 ))?
-                .label("sprs (new)")
+                .label("sprs (boolvec 1T)")
                 .legend(|(x, y)| {
                     PathElement::new(vec![(x, y), (x + 20, y)], &MAGENTA)
                 });
 
-            if !spec.forbid_old {
-                chart
-                    .draw_series(LineSeries::new(
-                        abscisses
-                            .iter()
-                            .map(|d| *d as f32)
-                            .zip(times_old.iter().map(|t| *t as f32)),
-                        &BLUE,
-                    ))?
-                    .label("sprs (old)")
-                    .legend(|(x, y)| {
-                        PathElement::new(vec![(x, y), (x + 20, y)], &BLUE)
-                    });
-            }
+            chart
+                .draw_series(LineSeries::new(
+                    abscisses
+                        .iter()
+                        .map(|d| *d as f32)
+                        .zip(times_2threads.iter().map(|t| *t as f32)),
+                    &BLACK,
+                ))?
+                .label("sprs (boolvec 2T)")
+                .legend(|(x, y)| {
+                    PathElement::new(vec![(x, y), (x + 20, y)], &BLACK)
+                });
+
+            chart
+                .draw_series(LineSeries::new(
+                    abscisses
+                        .iter()
+                        .map(|d| *d as f32)
+                        .zip(times_4threads.iter().map(|t| *t as f32)),
+                    &YELLOW,
+                ))?
+                .label("sprs (boolvec 4T)")
+                .legend(|(x, y)| {
+                    PathElement::new(vec![(x, y), (x + 20, y)], &YELLOW)
+                });
+
+            chart
+                .draw_series(LineSeries::new(
+                    abscisses
+                        .iter()
+                        .map(|d| *d as f32)
+                        .zip(times_autothread.iter().map(|t| *t as f32)),
+                    &BLUE,
+                ))?
+                .label("sprs (boolvec auto)")
+                .legend(|(x, y)| {
+                    PathElement::new(vec![(x, y), (x + 20, y)], &BLUE)
+                });
 
             #[cfg(feature = "nightly")]
             chart

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -15,7 +15,7 @@ use num_traits::int::PrimInt;
 ///
 /// This is a convenience trait to enable using various integer sizes for sparse
 /// matrix indices.
-pub trait SpIndex: Debug + PrimInt + AddAssign<Self> + Default {
+pub trait SpIndex: Debug + PrimInt + AddAssign<Self> + Default + Send + Sync {
     /// Convert to usize.
     ///
     /// # Panics

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -15,7 +15,9 @@ use num_traits::int::PrimInt;
 ///
 /// This is a convenience trait to enable using various integer sizes for sparse
 /// matrix indices.
-pub trait SpIndex: Debug + PrimInt + AddAssign<Self> + Default + Send + Sync {
+pub trait SpIndex:
+    Debug + PrimInt + AddAssign<Self> + Default + Send + Sync
+{
     /// Convert to usize.
     ///
     /// # Panics

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1914,7 +1914,7 @@ impl<'a, 'b, N, I, Iptr, IpS1, IS1, DS1, IpS2, IS2, DS2>
     Mul<&'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>>
     for &'a CsMatBase<N, I, IpS1, IS1, DS1, Iptr>
 where
-    N: 'a + Copy + Num + Default + std::ops::AddAssign,
+    N: 'a + Copy + Num + Default + std::ops::AddAssign + Send + Sync,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IpS1: 'a + Deref<Target = [Iptr]>,

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -171,16 +171,6 @@ pub fn symbolic_boolvec<Iptr: SpIndex, I: SpIndex>(
     c_indices.clear();
     c_indices.reserve_exact(a_nnz + b_nnz);
 
-    // `index` is used as a set to remember which columns of a row of C are
-    // nonzero. At any point in the algorithm, if `index[col] == sentinel0`,
-    // then we know there is no nonzero value in the column. As the algorithm
-    // progresses, we discover nonzero elements. When a nonzero at `col` is
-    // discovered, we store in `index[col]` the column of the preceding
-    // nonzero (storing `sentinel1` for the first nonzero). Therefore,
-    // when we want to collect nonzeros and clear the set, we can simply
-    // follow the trail of column indices, putting back `sentinel0` along
-    // the way. This way, collecting the nonzero indices for a column
-    // has a complexity O(col_nnz).
     let ind_len = a_rows.max(b_rows.max(b_cols));
     assert!(seen.len() == ind_len);
     for elt in seen.iter_mut() {

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -32,9 +32,7 @@ pub fn set_thread_symbolic_method(method: SymbMethod) {
 /// Get the current method for computing the symbolic part of sparse matrix
 /// product.
 pub fn thread_symbolic_method() -> SymbMethod {
-    SYMBOLIC_METHOD.with(|m| {
-        *m.borrow()
-    })
+    SYMBOLIC_METHOD.with(|m| *m.borrow())
 }
 
 /// Control the strategy used to parallelize the matrix product workload.
@@ -70,11 +68,8 @@ pub fn set_thread_threading_strategy(strategy: ThreadingStrategy) {
 }
 
 pub fn thread_threading_strategy() -> ThreadingStrategy {
-    THREADING_STRAT.with(|s| {
-        *s.borrow()
-    })
+    THREADING_STRAT.with(|s| *s.borrow())
 }
-
 
 /// Compute the symbolic structure of the matrix product C = A * B, with
 /// A, B and C stored in the CSR matrix format.
@@ -509,26 +504,34 @@ where
     res_indptr_chunks.push(res_indptr_rem);
     res_indices_chunks.push(res_indices_rem);
     res_data_chunks.push(res_data_rem);
-    lhs_indptr_chunks.par_iter()
+    lhs_indptr_chunks
+        .par_iter()
         .zip(res_indptr_chunks.par_iter())
         .zip(res_indices_chunks.par_iter())
         .zip(res_data_chunks.par_iter_mut())
         .zip(tmps.par_iter_mut())
-        .for_each(|((((lhs_indptr_chunk, res_indptr_chunk),
-                       res_indices_chunk), res_data_chunk), tmp)| {
-            numeric(
-                lhs_indptr_chunk,
-                lhs.indices(),
-                lhs.data(),
-                rhs.indptr(),
-                rhs.indices(),
-                rhs.data(),
-                res_indptr_chunk,
-                res_indices_chunk,
-                res_data_chunk,
+        .for_each(
+            |(
+                (
+                    ((lhs_indptr_chunk, res_indptr_chunk), res_indices_chunk),
+                    res_data_chunk,
+                ),
                 tmp,
-            );
-        });
+            )| {
+                numeric(
+                    lhs_indptr_chunk,
+                    lhs.indices(),
+                    lhs.data(),
+                    rhs.indptr(),
+                    rhs.indices(),
+                    rhs.data(),
+                    res_indptr_chunk,
+                    res_indices_chunk,
+                    res_data_chunk,
+                    tmp,
+                );
+            },
+        );
 
     // Correctness: The invariants of the output come from the invariants of
     // the inputs when in-bounds indices are concerned, and we are sorting

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -15,15 +15,21 @@ pub enum SymbMethod {
 }
 
 thread_local!(static SYMBOLIC_METHOD: RefCell<SymbMethod> =
-    RefCell::new(SymbMethod::LinkedList)
+    RefCell::new(SymbMethod::BoolVecAndSort)
 );
 
+/// Set the method used to compute the symbolic part of sparse matrix
+/// product, for the current thread. This will affect all subsequent calls
+/// to the `*` operator between sparse matrices for the current thread until
+/// it is changed again.
 pub fn set_thread_symbolic_method(method: SymbMethod) {
     SYMBOLIC_METHOD.with(|m| {
         *m.borrow_mut() = method;
     });
 }
 
+/// Get the current method for computing the symbolic part of sparse matrix
+/// product.
 pub fn thread_symbolic_method() -> SymbMethod {
     SYMBOLIC_METHOD.with(|m| {
         *m.borrow()

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1085,7 +1085,7 @@ where
 impl<'a, 'b, N, I, Iptr, IS1, DS1, IpS2, IS2, DS2>
     Mul<&'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>> for &'a CsVecBase<IS1, DS1>
 where
-    N: 'a + Copy + Num + Default + std::ops::AddAssign,
+    N: 'a + Copy + Num + Default + std::ops::AddAssign + Send + Sync,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IS1: 'a + Deref<Target = [I]>,
@@ -1104,7 +1104,7 @@ where
 impl<'a, 'b, N, I, Iptr, IpS1, IS1, DS1, IS2, DS2> Mul<&'b CsVecBase<IS2, DS2>>
     for &'a CsMatBase<N, I, IpS1, IS1, DS1, Iptr>
 where
-    N: Copy + Num + Default + Sum + std::ops::AddAssign,
+    N: Copy + Num + Default + Sum + std::ops::AddAssign + Send + Sync,
     I: SpIndex,
     Iptr: SpIndex,
     IpS1: Deref<Target = [Iptr]>,


### PR DESCRIPTION
This pull request improves the performance of the sparse matrix product by taking advantage of multiple cores, thanks to rayon. Here are benchmark results demonstrating the improvements (benchmarked on a AMD Ryzen 7 3700X 8-Core Processor this time):

![sparse_mult_perf_by_shape_no_old](https://user-images.githubusercontent.com/1874105/86404635-45d3dd00-bcb0-11ea-9ed3-f99092513637.png)

Here's a description of the entries:

- the red line corresponds to the SMMP algorithm as implemented in #187.
- the pink line (boolvec 1T) is a micro-optimization of the SMMP algorithm, using a `Vec<bool>` in the symbolic part of the algorithm to check if a column has been seen, which is more cache friendly than the index based "linked list" in the original SMMP algorithm
- boolvec 2T and 4T are the same as boolvec 1T, but with the workloads for the symbolic and numeric parts divided on respectively 2 and 4 threads.
- boolvec auto dynamically chooses the number of threads, to avoid the threading overhead for small nonzero counts, and to be able to use all CPU cores if needed. This is the most efficient strategy and thus the default, though it can be configured. There may be some tuning to do in the thresholds to pick the number of threads.

As before, with no multithreading, it takes a very large matrix to beat scipy's implementation (mostly because we need to sort the indices whereas scipy does not guarantee sorted indices). However, as far as I know scipy's matrix product is not parallelized, so taking advantage of multiple cores gives sprs an advantage.

On smaller shapes it takes a lot of threads to beat scipy (here the shape is 15000 x 25000):

![sparse_mult_perf_150000_25000](https://user-images.githubusercontent.com/1874105/86404718-6439d880-bcb0-11ea-8bc8-5510481ea0a4.png)

I'm not entirely satisfied with the current multithreading implementation, dividing the work into independent chunks has been a bit clunky, but I'm sure it could be done in a cleaner way. That can wait though, the current state is correct and is a nice milestone.

It's quite possible some performance can be gained in the future, as currently the heuristic to divide the workload for the symbolic part has not been extensively tested, so some threads could be starving. A simple improvement could be to delay the sorting of indices, to know the actual number of nonzeros of the result and be able to divide the sorting workload evenly.

