### PR TITLE
Remove old product implementation

### DIFF
--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -185,7 +185,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             std::iter::repeat(shape).take(densities.len()).collect()
         };
 
-        let mut times_boolvec = Vec::with_capacity(densities.len());
+        let mut times = Vec::with_capacity(densities.len());
         let mut times_autothread = Vec::with_capacity(densities.len());
         let mut times_2threads = Vec::with_capacity(densities.len());
         let mut times_4threads = Vec::with_capacity(densities.len());
@@ -212,10 +212,10 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             let prod = &m1 * &m2;
             let elapsed = now.elapsed().as_millis();
             println!(
-                "New product (boolvec) of shape ({}, {}) and density {} done in {}ms",
+                "sprs product of shape ({}, {}) and density {} done in {}ms",
                 shape.0, shape.1, density, elapsed,
             );
-            times_boolvec.push(elapsed);
+            times.push(elapsed);
 
             smmp::set_thread_threading_strategy(
                 smmp::ThreadingStrategy::Fixed(2),
@@ -224,7 +224,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             let prod_ = &m1 * &m2;
             let elapsed = now.elapsed().as_millis();
             println!(
-                "New product (boolvec, 2 threads) of shape ({}, {}) and density {} done in {}ms",
+                "sprs product (2 threads) of shape ({}, {}) and density {} done in {}ms",
                 shape.0, shape.1, density, elapsed,
             );
             assert_eq!(prod, prod_);
@@ -237,7 +237,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             let prod_ = &m1 * &m2;
             let elapsed = now.elapsed().as_millis();
             println!(
-                "New product (boolvec, 4 threads) of shape ({}, {}) and density {} done in {}ms",
+                "sprs product (4 threads) of shape ({}, {}) and density {} done in {}ms",
                 shape.0, shape.1, density, elapsed,
             );
             assert_eq!(prod, prod_);
@@ -250,7 +250,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             let prod_ = &m1 * &m2;
             let elapsed = now.elapsed().as_millis();
             println!(
-                "New product (boolvec, auto thread) of shape ({}, {}) and density {} done in {}ms",
+                "sprs product (auto thread) of shape ({}, {}) and density {} done in {}ms",
                 shape.0, shape.1, density, elapsed,
             );
             assert_eq!(prod, prod_);
@@ -302,13 +302,10 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         println!("Results for shape: ({}, {})", shape.0, shape.1);
         println!("Product nnzs: {:?}", nnzs);
         println!("Product densities: {:?}", res_densities);
-        println!("Product times (boolvec): {:?}", times_boolvec);
-        println!("Product times (boolvec, 2 threads): {:?}", times_2threads);
-        println!("Product times (boolvec, 4 threads): {:?}", times_4threads);
-        println!(
-            "Product times (boolvec, auto threads): {:?}",
-            times_autothread
-        );
+        println!("Product times (sprs): {:?}", times);
+        println!("Product times (sprs, 2 threads): {:?}", times_2threads);
+        println!("Product times (sprs, 4 threads): {:?}", times_4threads);
+        println!("Product times (sprs, auto threads): {:?}", times_autothread);
         #[cfg(feature = "nightly")]
         println!("Product times (scipy): {:?}", times_py);
         #[cfg(feature = "eigen")]
@@ -339,10 +336,8 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 "Time vs density"
             };
             let max_time =
-                *std::cmp::max(
-                    times_boolvec.iter().max(),
-                    times_2threads.iter().max(),
-                ).unwrap_or(&1);
+                *std::cmp::max(times.iter().max(), times_2threads.iter().max())
+                    .unwrap_or(&1);
             let max_time = std::cmp::max(
                 max_time,
                 *times_4threads.iter().max().unwrap_or(&1),
@@ -380,10 +375,10 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                     abscisses
                         .iter()
                         .map(|d| *d as f32)
-                        .zip(times_boolvec.iter().map(|t| *t as f32)),
+                        .zip(times.iter().map(|t| *t as f32)),
                     &MAGENTA,
                 ))?
-                .label("sprs (boolvec 1T)")
+                .label("sprs (1T)")
                 .legend(|(x, y)| {
                     PathElement::new(vec![(x, y), (x + 20, y)], &MAGENTA)
                 });
@@ -396,7 +391,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                         .zip(times_2threads.iter().map(|t| *t as f32)),
                     &BLACK,
                 ))?
-                .label("sprs (boolvec 2T)")
+                .label("sprs (2T)")
                 .legend(|(x, y)| {
                     PathElement::new(vec![(x, y), (x + 20, y)], &BLACK)
                 });
@@ -409,7 +404,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                         .zip(times_4threads.iter().map(|t| *t as f32)),
                     &YELLOW,
                 ))?
-                .label("sprs (boolvec 4T)")
+                .label("sprs (4T)")
                 .legend(|(x, y)| {
                     PathElement::new(vec![(x, y), (x + 20, y)], &YELLOW)
                 });
@@ -422,7 +417,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                         .zip(times_autothread.iter().map(|t| *t as f32)),
                     &BLUE,
                 ))?
-                .label("sprs (boolvec auto)")
+                .label("sprs (auto thread)")
                 .legend(|(x, y)| {
                     PathElement::new(vec![(x, y), (x + 20, y)], &BLUE)
                 });

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -83,7 +83,6 @@ fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
 struct BenchSpec {
     shape: (usize, usize),
     densities: Vec<f64>,
-    forbid_old: bool,
     forbid_eigen: bool,
     shapes: Vec<(usize, usize)>, // will trigger shape benchmark
     nnz_over_rows: usize,        // used to compute density in shape benchmark
@@ -105,20 +104,17 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 1e-5, 2e-5, 5e-5, 1e-4, 2e-4,
                 5e-4, //1e-3, 2e-3, 3e-3, 5e-3,
             ],
-            forbid_old: true,
             ..Default::default()
         },
         BenchSpec {
             shape: (150000, 25000),
             densities: vec![1e-7, 1e-6, 1e-5, 1e-4],
-            forbid_old: true,
             forbid_eigen: true,
             ..Default::default()
         },
         BenchSpec {
             shape: (150000, 250000),
             densities: vec![1e-7, 1e-6, 1e-5, 1e-4],
-            forbid_old: true,
             forbid_eigen: true,
             ..Default::default()
         },
@@ -134,7 +130,6 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 (55000, 55000),
             ],
             nnz_over_rows: 4,
-            forbid_old: true,
             bench_filename: "sparse_mult_perf_by_shape.png".to_string(),
             ..Default::default()
         },
@@ -152,7 +147,6 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 (1500000, 1500000),
                 (2500000, 2500000),
             ],
-            forbid_old: true,
             forbid_eigen: true,
             nnz_over_rows: 4,
             bench_filename: "sparse_mult_perf_by_shape_no_old.png".to_string(),
@@ -196,7 +190,6 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         let mut times_autothread = Vec::with_capacity(densities.len());
         let mut times_2threads = Vec::with_capacity(densities.len());
         let mut times_4threads = Vec::with_capacity(densities.len());
-        let mut times_old = Vec::with_capacity(densities.len());
         #[cfg(feature = "nightly")]
         let mut times_py = Vec::with_capacity(densities.len());
         #[cfg(feature = "eigen")]
@@ -204,7 +197,6 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
         let mut nnzs = Vec::with_capacity(densities.len());
         let mut res_densities = Vec::with_capacity(densities.len());
         for (density, shape) in densities.iter().zip(shapes.iter()) {
-            let mut workspace = vec![0.; shape.0];
             let density = *density;
             let shape = *shape;
             println!("Generating matrices");
@@ -280,18 +272,6 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             assert_eq!(prod, prod_b);
             times_autothread.push(elapsed);
 
-            if !spec.forbid_old {
-                let now = std::time::Instant::now();
-                let old_res = sprs::prod::csr_mul_csr(&m1, &m2, &mut workspace);
-                let elapsed = now.elapsed().as_millis();
-                println!(
-                    "Old product of shape ({}, {}) and density {} done in {}ms",
-                    shape.0, shape.1, density, elapsed,
-                );
-                times_old.push(elapsed);
-                assert_eq!(prod, old_res);
-            }
-
             nnzs.push(prod.nnz());
             res_densities.push(prod.density());
 
@@ -346,7 +326,6 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             "Product times (boolvec, auto threads): {:?}",
             times_autothread
         );
-        println!("Product times (old): {:?}", times_old);
         #[cfg(feature = "nightly")]
         println!("Product times (scipy): {:?}", times_py);
         #[cfg(feature = "eigen")]

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -9,32 +9,6 @@ use rayon::prelude::*;
 
 use std::cell::RefCell;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum SymbMethod {
-    LinkedList,
-    BoolVecAndSort,
-}
-
-thread_local!(static SYMBOLIC_METHOD: RefCell<SymbMethod> =
-    RefCell::new(SymbMethod::BoolVecAndSort)
-);
-
-/// Set the method used to compute the symbolic part of sparse matrix
-/// product, for the current thread. This will affect all subsequent calls
-/// to the `*` operator between sparse matrices for the current thread until
-/// it is changed again.
-pub fn set_thread_symbolic_method(method: SymbMethod) {
-    SYMBOLIC_METHOD.with(|m| {
-        *m.borrow_mut() = method;
-    });
-}
-
-/// Get the current method for computing the symbolic part of sparse matrix
-/// product.
-pub fn thread_symbolic_method() -> SymbMethod {
-    SYMBOLIC_METHOD.with(|m| *m.borrow())
-}
-
 /// Control the strategy used to parallelize the matrix product workload.
 ///
 /// The `Automatic` strategy will try to pick a good number of threads based
@@ -98,100 +72,6 @@ pub fn thread_threading_strategy() -> ThreadingStrategy {
 /// `a_indptr.last().unwrap() + b_indptr.last.unwrap()` in `c_indices`.
 /// Therefore, to prevent this function from allocating, it is required
 /// to have reserved at least this amount of memory.
-pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
-    a_indptr: &[Iptr],
-    a_indices: &[I],
-    b_cols: usize,
-    b_indptr: &[Iptr],
-    b_indices: &[I],
-    c_indptr: &mut [Iptr],
-    // TODO look for litterature on the nnz of C to be able to have a slice here
-    c_indices: &mut Vec<I>,
-    index: &mut [usize],
-) {
-    assert!(a_indptr.len() == c_indptr.len());
-    let a_rows = a_indptr.len() - 1;
-    let b_rows = b_indptr.len() - 1;
-    let a_nnz = a_indptr[a_rows].index();
-    let b_nnz = b_indptr[b_rows].index();
-    c_indices.clear();
-    c_indices.reserve_exact(a_nnz + b_nnz);
-
-    // `index` is used as a set to remember which columns of a row of C are
-    // nonzero. At any point in the algorithm, if `index[col] == sentinel0`,
-    // then we know there is no nonzero value in the column. As the algorithm
-    // progresses, we discover nonzero elements. When a nonzero at `col` is
-    // discovered, we store in `index[col]` the column of the preceding
-    // nonzero (storing `sentinel1` for the first nonzero). Therefore,
-    // when we want to collect nonzeros and clear the set, we can simply
-    // follow the trail of column indices, putting back `sentinel0` along
-    // the way. This way, collecting the nonzero indices for a column
-    // has a complexity O(col_nnz).
-    let ind_len = a_rows.max(b_rows.max(b_cols));
-    let sentinel0 = usize::max_value();
-    let sentinel1 = usize::max_value() - 1;
-    assert!(index.len() == ind_len);
-    assert!(ind_len < sentinel1);
-    for elt in index.iter_mut() {
-        *elt = sentinel0;
-    }
-
-    c_indptr[0] = Iptr::from_usize(0);
-    for a_row in 0..a_rows {
-        let mut istart = sentinel1;
-        let mut length = 0;
-        let mut max_bcol = 0;
-        let mut min_bcol = index.len();
-
-        let a_start = a_indptr[a_row].index();
-        let a_stop = a_indptr[a_row + 1].index();
-        for &a_col in &a_indices[a_start..a_stop] {
-            let b_row = a_col.index();
-            let b_start = b_indptr[b_row].index();
-            let b_stop = b_indptr[b_row + 1].index();
-            for b_col in &b_indices[b_start..b_stop] {
-                let b_col = b_col.index();
-                if index[b_col] == sentinel0 {
-                    index[b_col] = istart;
-                    istart = b_col;
-                    length += 1;
-                    max_bcol = max_bcol.max(b_col);
-                    min_bcol = min_bcol.min(b_col);
-                }
-            }
-        }
-        c_indptr[a_row + 1] = c_indptr[a_row] + Iptr::from_usize(length);
-        // We dynamically change our strategy to recover the nonzero indices
-        // sorted. We try and determine if it's cheaper to scan
-        // `index[min_col..=max_col]` or to use the linked list embedded in
-        // the array and sort the indices afterwards. In essence, we're
-        // choosing between `max_col - min_col` comparisons vs
-        // `length * log(length)` comparisons.
-        // TODO: the linear scan could be implemented faster using SIMD
-        if max_bcol > min_bcol && max_bcol - min_bcol < length * log2(length) {
-            for b_col in min_bcol..=max_bcol {
-                if index[b_col] != sentinel0 {
-                    c_indices.push(I::from_usize(b_col));
-                    index[b_col] = sentinel0;
-                }
-            }
-            debug_assert_eq!(c_indices.len(), c_indptr[a_row + 1].index());
-        } else {
-            for _ in 0..length {
-                debug_assert!(istart < sentinel1);
-                c_indices.push(I::from_usize(istart));
-                let new_start = index[istart];
-                index[istart] = sentinel0;
-                istart = new_start;
-            }
-            let c_start = c_indptr[a_row].index();
-            let c_end = c_indptr[a_row + 1].index();
-            c_indices[c_start..c_end].sort_unstable();
-        }
-        index[a_row] = sentinel0;
-    }
-}
-
 pub fn symbolic_boolvec<Iptr: SpIndex, I: SpIndex>(
     a_indptr: &[Iptr],
     a_indices: &[I],
@@ -246,14 +126,6 @@ pub fn symbolic_boolvec<Iptr: SpIndex, I: SpIndex>(
             seen[c_col.index()] = false;
         }
     }
-}
-
-/// Compute the approximate base 2 logarithm of an integer, using its
-/// number of "used" bits.
-fn log2(num: usize) -> usize {
-    let num_bits = std::mem::size_of::<usize>() * 8;
-    assert!(num > 0);
-    num_bits - (num.leading_zeros() as usize) - 1
 }
 
 /// Numeric part of the matrix product C = A * B with A, B and C stored in the
@@ -347,7 +219,6 @@ where
     let r_rows = rhs.rows();
     let r_cols = rhs.cols();
     assert_eq!(l_cols, r_rows);
-    let method = thread_symbolic_method();
     let workspace_len = l_rows.max(l_cols).max(r_cols);
     use self::ThreadingStrategy::{Automatic, AutomaticPhysical};
     let nb_threads = match thread_threading_strategy() {
@@ -367,88 +238,30 @@ where
     for _ in 0..nb_threads {
         tmps.push(vec![N::zero(); workspace_len].into_boxed_slice())
     }
-    match method {
-        SymbMethod::LinkedList => {
-            let mut index = vec![0; workspace_len];
-            mul_csr_csr_with_workspace(lhs, rhs, &mut index, &mut tmps[0])
-        }
-        SymbMethod::BoolVecAndSort => {
-            let mut seens = Vec::with_capacity(nb_threads);
-            for _ in 0..nb_threads {
-                seens.push(vec![false; workspace_len].into_boxed_slice());
-            }
-            mul_csr_csr_with_workspace_boolvec(lhs, rhs, &mut seens, &mut tmps)
-        }
+    let mut seens = Vec::with_capacity(nb_threads);
+    for _ in 0..nb_threads {
+        seens.push(vec![false; workspace_len].into_boxed_slice());
     }
+    mul_csr_csr_with_workspace_boolvec(lhs, rhs, &mut seens, &mut tmps)
 }
 
 /// Compute a sparse matrix product using the SMMP routines, using temporary
 /// storage that was already allocated
 ///
-/// `index` and `tmp` are temporary storage vectors used to accumulate non
+/// `seens` and `tmps` are temporary storage vectors used to accumulate non
 /// zero locations and values. Their values need not be specified on input.
-/// They will be zero on output.
+/// They will be zero on output. They are slices of boxed slices, where the
+/// outer slice is there to give mutliple workspaces for multi-threading.
+/// Therefore, `seens.len()` controls the number of threads used for symbolic
+/// computation, and `tmps.len()` the number of threads for numeric computation.
 ///
 /// # Panics
 ///
 /// - if `lhs.cols() != rhs.rows()`.
-/// - if `index.len() != lhs.cols().max(lhs.rows()).max(rhs.cols())`
-/// - if `tmp.len() != lhs.cols().max(lhs.rows()).max(rhs.cols())`
-pub fn mul_csr_csr_with_workspace<N, I, Iptr>(
-    lhs: CsMatViewI<N, I, Iptr>,
-    rhs: CsMatViewI<N, I, Iptr>,
-    index: &mut [usize],
-    tmp: &mut [N],
-) -> CsMatI<N, I, Iptr>
-where
-    N: Num + Copy + std::ops::AddAssign,
-    I: SpIndex,
-    Iptr: SpIndex,
-{
-    let l_rows = lhs.rows();
-    let l_cols = lhs.cols();
-    let r_rows = rhs.rows();
-    let r_cols = rhs.cols();
-    assert_eq!(l_cols, r_rows);
-    assert_eq!(index.len(), l_rows.max(l_cols).max(r_cols));
-    assert_eq!(tmp.len(), l_rows.max(l_cols).max(r_cols));
-    let mut res_indptr = vec![Iptr::zero(); l_rows + 1];
-    let mut res_indices = Vec::new();
-    symbolic(
-        lhs.indptr(),
-        lhs.indices(),
-        r_cols,
-        rhs.indptr(),
-        rhs.indices(),
-        &mut res_indptr,
-        &mut res_indices,
-        index,
-    );
-    let mut res_data = vec![N::zero(); res_indices.len()];
-    numeric(
-        lhs.indptr(),
-        lhs.indices(),
-        lhs.data(),
-        rhs.indptr(),
-        rhs.indices(),
-        rhs.data(),
-        &res_indptr,
-        &res_indices,
-        &mut res_data,
-        tmp,
-    );
-    // Correctness: The invariants of the output come from the invariants of
-    // the inputs when in-bounds indices are concerned, and we are sorting
-    // indices.
-    CsMatI::new_trusted(
-        CSR,
-        (l_rows, r_cols),
-        res_indptr,
-        res_indices,
-        res_data,
-    )
-}
-
+/// - if `seens.len() == 0`
+/// - if `tmps.len() == 0`
+/// - if `seens[i].len() != lhs.cols().max(lhs.rows()).max(rhs.cols())`
+/// - if `tmps[i].len() != lhs.cols().max(lhs.rows()).max(rhs.cols())`
 pub fn mul_csr_csr_with_workspace_boolvec<N, I, Iptr>(
     lhs: CsMatViewI<N, I, Iptr>,
     rhs: CsMatViewI<N, I, Iptr>,
@@ -631,9 +444,9 @@ mod test {
 
         let mut c_indptr = [0; 6];
         let mut c_indices = Vec::new();
-        let mut index = [0; 5];
+        let mut seen = [false; 5];
 
-        super::symbolic(
+        super::symbolic_boolvec(
             a.indptr(),
             a.indices(),
             b.cols(),
@@ -641,7 +454,7 @@ mod test {
             b.indices(),
             &mut c_indptr,
             &mut c_indices,
-            &mut index,
+            &mut seen,
         );
 
         let mut c_data = vec![0.; c_indices.len()];


### PR DESCRIPTION
Recent PRs have introduced a more efficient matrix-matrix product. There is no benefit to keeping the old implementation around. Since the old product was a public API, this is a breaking change and will require bumping `sprs` version to 0.8.