### PR TITLE
Permutation validity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,8 @@ pub use crate::sparse::{
 pub use crate::sparse::symmetric::is_symmetric;
 
 pub use crate::sparse::permutation::{
-    transform_mat_papt, PermOwned, PermOwnedI, PermView, PermViewI, Permutation,
+    perm_is_valid, transform_mat_papt, PermOwned, PermOwnedI, PermView,
+    PermViewI, Permutation,
 };
 
 pub use crate::sparse::CompressedStorage::{self, CSC, CSR};

--- a/src/sparse/linalg/ordering.rs
+++ b/src/sparse/linalg/ordering.rs
@@ -340,8 +340,9 @@ pub mod order {
 
         #[inline]
         fn into_ordering(self) -> Ordering<I> {
+            debug_assert!(crate::perm_is_valid(&self.perm));
             Ordering {
-                perm: PermOwnedI::new(self.perm),
+                perm: PermOwnedI::new_trusted(self.perm),
                 connected_parts: self.connected_parts,
             }
         }
@@ -409,8 +410,9 @@ pub mod order {
                 .for_each(|i| *i = nb_vertices - *i);
             connected_parts.reverse();
 
+            debug_assert!(crate::perm_is_valid(&self.perm));
             Ordering {
-                perm: PermOwnedI::new(self.perm),
+                perm: PermOwnedI::new_trusted(self.perm),
                 connected_parts,
             }
         }

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -49,6 +49,11 @@ pub fn perm_is_valid<I: SpIndex>(perm: &[I]) -> bool {
 
 impl<I: SpIndex> Permutation<I, Vec<I>> {
     pub fn new(perm: Vec<I>) -> PermOwnedI<I> {
+        assert!(perm_is_valid(&perm));
+        Permutation::new_trusted(perm)
+    }
+
+    pub(crate) fn new_trusted(perm: Vec<I>) -> PermOwnedI<I> {
         let mut perm_inv = perm.clone();
         for (ind, val) in perm.iter().enumerate() {
             perm_inv[val.index()] = I::from_usize(ind);

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -35,6 +35,18 @@ pub type PermOwnedI<I> = Permutation<I, Vec<I>>;
 pub type PermView<'a> = Permutation<usize, &'a [usize]>;
 pub type PermViewI<'a, I> = Permutation<I, &'a [I]>;
 
+pub fn perm_is_valid<I: SpIndex>(perm: &[I]) -> bool {
+    let n = perm.len();
+    let mut seen = vec![false; n];
+    for i in perm {
+        if *i < I::zero() || *i >= I::from_usize(n) || seen[i.index()] {
+            return false;
+        }
+        seen[i.index()] = true;
+    }
+    return true;
+}
+
 impl<I: SpIndex> Permutation<I, Vec<I>> {
     pub fn new(perm: Vec<I>) -> PermOwnedI<I> {
         let mut perm_inv = perm.clone();
@@ -366,5 +378,14 @@ mod test {
         );
         let papt = super::transform_mat_papt(mat.view(), perm.view());
         assert_eq!(expected_papt, papt);
+    }
+
+    #[test]
+    fn perm_validity() {
+        use super::perm_is_valid;
+        assert!(perm_is_valid(&[0, 1, 2, 3, 4]));
+        assert!(perm_is_valid(&[1, 0, 3, 4, 2]));
+        assert!(!perm_is_valid(&[0, 1, 2, 3, 5]));
+        assert!(!perm_is_valid(&[0, 1, 2, 3, 3]));
     }
 }


### PR DESCRIPTION
Add functions to check permutation validity, and check the validity of permutations when they are created from vectors of indices.