### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub mod array_backend;
 pub mod errors;
 pub mod indexing;
 pub mod io;
-mod num_kinds;
+pub mod num_kinds;
 mod sparse;
 pub mod stack;
 


### PR DESCRIPTION
A PR to expose the `num_traits` as public, it is also the fix for https://github.com/vbarrielle/sprs/issues/205.