### PR TITLE
Faster ldl decomposition

### DIFF
--- a/sprs-ldl/src/lib.rs
+++ b/sprs-ldl/src/lib.rs
@@ -502,7 +502,7 @@ where
             y_workspace[inner_ind] = y_workspace[inner_ind] + val;
             let mut i = inner_ind;
             pattern_workspace.clear_left();
-            while flag_workspace[i].index() != k {
+            while flag_workspace[i].index_unchecked() != k {
                 pattern_workspace.push_left(I::from_usize(i));
                 flag_workspace[i] = I::from_usize(k);
                 i = parents.get_parent(i).expect("enforced by ldl_symbolic");
@@ -515,7 +515,7 @@ where
         diag[k] = y_workspace[k];
         y_workspace[k] = N::zero();
         'pattern: for &i in pattern_workspace.iter_right() {
-            let i = i.index();
+            let i = i.index_unchecked();
             let yi = y_workspace[i];
             y_workspace[i] = N::zero();
             let p2 = (l_colptr[i] + l_nz[i]).index();


### PR DESCRIPTION
I've investigated performance differences between `sprs-ldl` and `sprs-suitesparse-ldl`. As it turns out, the bindings over the C library were faster, mostly because bounds checking had a high impact in a tight loop.

Fortunately, using an iterator could remove one of the offending bound checks, and I've been able to prove the other bounds check unnecessary regardless of the inputs, which means some unsafe indexing can be used.

This should help #199.