### PR TITLE
Optional rayon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,19 @@ jobs:
     - name: Run benchmarks
       run: |
           cargo bench --workspace
+
+  optional_features:
+    name: Optional features
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+    - name: Run test
+      run: |
+          cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ exclude = [
 ]
 
 [features]
-default = ["alga"]
+default = ["alga", "multi_thread"]
+multi_thread = ["rayon", "num_cpus"]
 
 [dependencies]
 num-traits = "0.2.0"
@@ -26,8 +27,8 @@ alga = { version = "0.9.0", optional = true }
 num-complex = "0.2.1"
 serde = { version = "1.0.0", optional = true, features = ["derive"] }
 smallvec = "1.4.0"
-rayon = "1.3.0"
-num_cpus = "1.13.0"
+rayon = { version = "1.3.0", optional = true }
+num_cpus = { version = "1.13.0", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.0"


### PR DESCRIPTION
As mentioned in #208 rayon will panic when creating a threadpool on targets which do not have threads. This PR puts `rayon` and `num_cpus` behind the feature flag `multi_thread` (suggestions for name?), but otherwise follows exactly the same code path as the `Fixed(1)` case.

Fixes #208