### PR TITLE
Add #[inline] to indexing

### DIFF
--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -361,6 +361,7 @@ impl<'a, N: 'a> DenseVector<N> for &'a [N] {
         self.len()
     }
 
+    #[inline]
     fn index(&self, idx: usize) -> &N {
         &self[idx]
     }
@@ -371,6 +372,7 @@ impl<N> DenseVector<N> for Vec<N> {
         self.len()
     }
 
+    #[inline]
     fn index(&self, idx: usize) -> &N {
         &self[idx]
     }
@@ -381,6 +383,7 @@ impl<'a, N: 'a> DenseVector<N> for &'a Vec<N> {
         self.len()
     }
 
+    #[inline]
     fn index(&self, idx: usize) -> &N {
         &self[idx]
     }
@@ -394,6 +397,7 @@ where
         self.shape()[0]
     }
 
+    #[inline]
     fn index(&self, idx: usize) -> &N {
         &self[[idx]]
     }


### PR DESCRIPTION
Adding the `#[inline]` attribute to the indexing operators got a speedup of 15-30% on `mul_acc_mat_vec_csr` for some matrices. The benchmarks in this library does not gain or lose anything from this change.

Further observations: Changing to unsafe access in `mul_acc_mat_vec_csr` does not modify the performance characteristics compared to the safe version.