### PR TITLE
make some small improvements in the utils:sort_indices_data_slices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ smallvec = "1.4.0"
 rayon = { version = "1.3.0", optional = true }
 num_cpus = { version = "1.13.0", optional = true }
 approx = { version = "0.3.2", optional = true }
+itertools = "0.9"
 
 [dev-dependencies]
 bencher = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ smallvec = "1.4.0"
 rayon = { version = "1.3.0", optional = true }
 num_cpus = { version = "1.13.0", optional = true }
 approx = { version = "0.3.2", optional = true }
-itertools = "0.9"
 
 [dev-dependencies]
 bencher = "0.1.0"

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -256,7 +256,6 @@ pub trait SparseMat {
 
 mod utils {
     use crate::indexing::SpIndex;
-    use itertools::izip;
 
     pub fn sort_indices_data_slices<N: Copy, I: SpIndex>(
         indices: &mut [I],
@@ -275,8 +274,10 @@ mod utils {
 
         buf.sort_unstable_by_key(|x| x.0);
 
-        for (i, v, &mut (ind, x)) in izip!(indices, data, buf) {
-            *i = ind;
+        for (&(i, x), (ind, v)) in
+            buf.iter().zip(indices.iter_mut().zip(data.iter_mut()))
+        {
+            *ind = i;
             *v = x;
         }
     }

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -256,6 +256,7 @@ pub trait SparseMat {
 
 mod utils {
     use crate::indexing::SpIndex;
+    use itertools::izip;
 
     pub fn sort_indices_data_slices<N: Copy, I: SpIndex>(
         indices: &mut [I],
@@ -268,15 +269,15 @@ mod utils {
         let data = &mut data[..len];
         buf.clear();
         buf.reserve_exact(len);
-        for i in 0..len {
-            buf.push((indices[i], data[i]));
+        for (i, v) in indices.iter().zip(data.iter()) {
+            buf.push((*i, *v));
         }
 
         buf.sort_unstable_by_key(|x| x.0);
 
-        for (i, &(ind, x)) in buf.iter().enumerate() {
-            indices[i] = ind;
-            data[i] = x;
+        for (i, v, &mut (ind, x)) in izip!(indices, data, buf) {
+            *i = ind;
+            *v = x;
         }
     }
 }
@@ -297,3 +298,18 @@ pub mod triplet;
 pub mod triplet_iter;
 pub mod vec;
 pub mod visu;
+
+#[cfg(test)]
+mod test {
+
+    use super::utils;
+    #[test]
+    fn test_sort_indices() {
+        let mut idx: Vec<usize> = vec![4, 1, 6, 2];
+        let mut dat: Vec<i32> = vec![4, -1, 2, -3];
+        let mut buf: Vec<(usize, i32)> = Vec::new();
+        utils::sort_indices_data_slices(&mut idx[..], &mut dat[..], &mut buf);
+        assert_eq!(idx, vec![1, 2, 4, 6]);
+        assert_eq!(dat, vec![-1, -3, 4, 2]);
+    }
+}


### PR DESCRIPTION
Just improved the utils::sort_indices_data_slices a bit, while I'm using this crate (very nice crate!)
The change includes 1) the removal of the explicit bound check using iterators, and 2) a quick test to verify my changes.