### PR TITLE
fixed a bug in mul_acc_mat_vec_csr and mul_acc_mat_vec_csc

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -47,14 +47,12 @@ impl From<io::Error> for IoError {
 impl PartialEq for IoError {
     fn eq(&self, rhs: &IoError) -> bool {
         match *self {
-            IoError::BadMatrixMarketFile => match *rhs {
-                IoError::BadMatrixMarketFile => true,
-                _ => false,
-            },
-            IoError::UnsupportedMatrixMarketFormat => match *rhs {
-                IoError::UnsupportedMatrixMarketFormat => true,
-                _ => false,
-            },
+            IoError::BadMatrixMarketFile => {
+                matches!(*rhs, IoError::BadMatrixMarketFile)
+            }
+            IoError::UnsupportedMatrixMarketFormat => {
+                matches!(*rhs, IoError::UnsupportedMatrixMarketFormat)
+            }
             _ => false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ assert_eq!(a, b.to_csc());
 ```
 
 */
+#![deny(warnings)]
 
 pub mod array_backend;
 pub mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,6 @@ assert_eq!(a, b.to_csc());
 
 */
 
-#![deny(warnings)]
-
 pub mod array_backend;
 pub mod errors;
 pub mod indexing;

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1186,7 +1186,7 @@ where
             indptr: &self.indptr[..],
             indices: &self.indices[..],
             data: &self.data[..],
-            perm: perm,
+            perm,
         }
     }
 

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -44,7 +44,7 @@ pub fn perm_is_valid<I: SpIndex>(perm: &[I]) -> bool {
         }
         seen[i.index()] = true;
     }
-    return true;
+    true
 }
 
 impl<I: SpIndex> Permutation<I, Vec<I>> {

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -65,7 +65,6 @@ pub fn mul_acc_mat_vec_csc<N, I, Iptr, V>(
         panic!("Storage mismatch");
     }
 
-    res_vec.iter_mut().for_each(|v| *v = N::zero());
     for (col_ind, vec) in mat.outer_iterator().enumerate() {
         let multiplier = in_vec.index(col_ind);
         for (row_ind, &value) in vec.iter() {
@@ -95,8 +94,10 @@ pub fn mul_acc_mat_vec_csr<N, I, Iptr, V>(
     }
 
     for (row_ind, vec) in mat.outer_iterator().enumerate() {
-        let tv = res_vec.get_mut(row_ind).unwrap(); // this unwrap is ok because we did the check
-        *tv = N::zero();
+        // this unwrap is ok because we did the check before to ensure
+        // mat.row() == res_vec.len() and now the row_ind is within the
+        // range of [0, mat.row). So it should be safe.
+        let tv = res_vec.get_mut(row_ind).unwrap();
         for (col_ind, &value) in vec.iter() {
             // TODO: unsafe access to value? needs bench
             *tv = *tv + *in_vec.index(col_ind) * value;

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -65,6 +65,7 @@ pub fn mul_acc_mat_vec_csc<N, I, Iptr, V>(
         panic!("Storage mismatch");
     }
 
+    res_vec.iter_mut().for_each(|v| *v = N::zero());
     for (col_ind, vec) in mat.outer_iterator().enumerate() {
         let multiplier = in_vec.index(col_ind);
         for (row_ind, &value) in vec.iter() {
@@ -94,10 +95,11 @@ pub fn mul_acc_mat_vec_csr<N, I, Iptr, V>(
     }
 
     for (row_ind, vec) in mat.outer_iterator().enumerate() {
+        let tv = res_vec.get_mut(row_ind).unwrap(); // this unwrap is ok because we did the check
+        *tv = N::zero();
         for (col_ind, &value) in vec.iter() {
             // TODO: unsafe access to value? needs bench
-            res_vec[row_ind] =
-                res_vec[row_ind] + *in_vec.index(col_ind) * value;
+            *tv = *tv + *in_vec.index(col_ind) * value;
         }
     }
 }

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -249,7 +249,8 @@ where
     for _ in 0..nb_threads {
         tmps.push(vec![N::zero(); workspace_len].into_boxed_slice())
     }
-    let mut seens = vec![vec![false; workspace_len].into_boxed_slice(); nb_threads];
+    let mut seens =
+        vec![vec![false; workspace_len].into_boxed_slice(); nb_threads];
     mul_csr_csr_with_workspace(lhs, rhs, &mut seens, &mut tmps)
 }
 

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -249,10 +249,7 @@ where
     for _ in 0..nb_threads {
         tmps.push(vec![N::zero(); workspace_len].into_boxed_slice())
     }
-    let mut seens = Vec::with_capacity(nb_threads);
-    for _ in 0..nb_threads {
-        seens.push(vec![false; workspace_len].into_boxed_slice());
-    }
+    let mut seens = vec![vec![false; workspace_len].into_boxed_slice(); nb_threads];
     mul_csr_csr_with_workspace(lhs, rhs, &mut seens, &mut tmps)
 }
 

--- a/src/sparse/special_mats.rs
+++ b/src/sparse/special_mats.rs
@@ -15,11 +15,8 @@ where
     I: SpIndex,
 {
     assert!(triangles.shape()[1] == 3);
-    let mut neighbors = Vec::with_capacity(nb_vertices);
-    for _ in 0..nb_vertices {
-        let vert_neighbs: SmallVec<[usize; 16]> = SmallVec::new();
-        neighbors.push(vert_neighbs);
-    }
+    let mut neighbors = vec![SmallVec::<[usize; 16]>::new(); nb_vertices];
+
     let mut insert_edge = |v0, v1| {
         let vert_neighbs: &mut SmallVec<[usize; 16]> = &mut neighbors[v0];
         if let Err(pos) = vert_neighbs.binary_search(&v1) {


### PR DESCRIPTION
There is a bug in `mul_acc_mat_vec_csr` and `mul_acc_mat_vec_csc`. Basically, the output `res_vec` needs to be set to zero before accumulating values in the matrix vector multiplication.

I also btw did some small tweaks following the suggestions from `cargo clippy`