### PR TITLE
Check for Minimum Supported Rust Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build:
-        - stable
-        - beta
-        - nightly
         include:
+        - build: msrv
+          os: ubuntu-18.04
+          rust: 1.42.0
         - build: stable
           os: ubuntu-18.04
           rust: stable

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Documentation is available at [docs.rs](https://docs.rs/sprs).
 
 See the [changelog](changelog.rst).
 
+## Minimum Supported Rust Version
+
+The minimum supported Rust version currently is 1.42. Prior to a 1.0 version,
+bumping the MSRV will not be considered a breaking change, but breakage will
+be avoided on a best effort basis.
+
 ## License
 
 Licensed under either of

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -2963,7 +2963,7 @@ mod test {
             (2, 2),
             vec![0, 2, 3],
             vec![0, 1, 1],
-            vec![2.0, f64::NAN, 2.0],
+            vec![2.0, std::f64::NAN, 2.0],
         );
 
         let onehot = mat.to_inner_onehot();

--- a/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
+++ b/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
@@ -2,6 +2,11 @@ use sprs::errors::SprsError;
 use sprs::{CsStructureI, CsStructureViewI, PermOwnedI, SpIndex};
 use suitesparse_camd_sys::*;
 
+// FIXME should be using SuiteSparseInt::MAX but this will not compile
+// in rust 1.42 as u32::MAX was introduced in 1.43. This can be changed if
+// the MSRV is bumped.
+const MAX_INT32: usize = std::u32::MAX as usize;
+
 /// Find a permutation matrix P which reduces the fill-in of the square
 /// sparse matrix `mat` in Cholesky factorization (ie, the number of nonzeros
 /// of the Cholesky factorization of P A P^T is less than for the Cholesky
@@ -27,7 +32,7 @@ where
     }
     let mut control = [0.; CAMD_CONTROL];
     let mut info = [0.; CAMD_INFO];
-    let (camd_res, perm) = if n <= SuiteSparseInt::MAX as usize {
+    let (camd_res, perm) = if n <= MAX_INT32 {
         let constraint: *const SuiteSparseInt = std::ptr::null();
         let mat: CsStructureI<SuiteSparseInt, SuiteSparseInt> =
             mat.to_other_types();


### PR DESCRIPTION
As evidenced by #222, it's important to explicitly state which rust version we require as a minimum, and to test for it in CI to ensure it does not change too fast.