### PR TITLE
Check if needs to be sorted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tempdir = "0.3.5"
 bincode = "1.2.0"
 tobj = "2.0.0"
 image = { version = "0.23.0", default-features = false, features = ["png"] }
+rand = { version = "0.7.3", default-features = false, features = ["small_rng"] }
 
 [[bench]]
 name = "suite"
@@ -44,6 +45,10 @@ harness = false
 
 [[bench]]
 name = "sparse_dense_products"
+harness = false
+
+[[bench]]
+name = "sorting"
 harness = false
 
 [workspace]

--- a/benches/sorting.rs
+++ b/benches/sorting.rs
@@ -1,0 +1,48 @@
+use bencher::{benchmark_group, benchmark_main, Bencher};
+use sprs::CsVec;
+
+const NNZ: usize = 900;
+const N: usize = 9000;
+
+fn cloning(bench: &mut Bencher) {
+    let indices = (0..NNZ).collect::<Vec<_>>();
+    let values = vec![1_i64; NNZ];
+
+    bench.iter(|| {
+        let _indicies = indices.clone();
+        let _values = values.clone();
+    });
+}
+
+fn create_csmat_from_sorted(bench: &mut Bencher) {
+    let indices = (0..NNZ).collect::<Vec<_>>();
+    let values = vec![1_i64; NNZ];
+
+    bench.iter(|| {
+        let indices = indices.clone();
+        let values = values.clone();
+        let _v = CsVec::new(N, indices, values);
+    });
+}
+
+fn create_csmat_from_unsorted(bench: &mut Bencher) {
+    use rand::{seq::SliceRandom, SeedableRng};
+    let indices = (0..NNZ).collect::<Vec<_>>();
+    let values = vec![1_i64; NNZ];
+
+    bench.iter(|| {
+        let mut indices = indices.clone();
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+        indices.shuffle(&mut rng);
+        let values = values.clone();
+        let _v = CsVec::new(N, indices, values);
+    });
+}
+
+benchmark_group!(
+    benches,
+    cloning,
+    create_csmat_from_sorted,
+    create_csmat_from_unsorted
+);
+benchmark_main!(benches);

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -262,6 +262,18 @@ pub trait SparseMat {
 
 mod utils {
     use crate::indexing::SpIndex;
+    use std::convert::TryInto;
+
+    pub fn sorted_indices<I: SpIndex>(indices: &[I]) -> bool {
+        for w in indices.windows(2) {
+            // w will always be a size 2
+            let &[i1, i2]: &[I; 2] = w.try_into().unwrap();
+            if i2 <= i1 {
+                return false;
+            }
+        }
+        true
+    }
 
     pub fn sort_indices_data_slices<N: Copy, I: SpIndex>(
         indices: &mut [I],
@@ -318,5 +330,16 @@ mod test {
         utils::sort_indices_data_slices(&mut idx[..], &mut dat[..], &mut buf);
         assert_eq!(idx, vec![1, 2, 4, 6]);
         assert_eq!(dat, vec![-1, -3, 4, 2]);
+    }
+
+    #[test]
+    fn test_sorted_indices() {
+        use utils::sorted_indices;
+        assert!(sorted_indices(&[1, 2, 3]));
+        assert!(sorted_indices(&[1, 2, 8]));
+        assert!(!sorted_indices(&[1, 1, 3]));
+        assert!(!sorted_indices(&[2, 1, 3]));
+        assert!(sorted_indices(&[1, 2]));
+        assert!(sorted_indices(&[1]));
     }
 }

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -78,7 +78,7 @@ pub use self::csmat::CompressedStorage;
 /// [`vstack`]: fn.vstack.html
 /// [`hstack`]: fn.hstack.html
 /// [`bmat`]: fn.bmat.html
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CsMatBase<N, I, IptrStorage, IndStorage, DataStorage, Iptr = I>
 where
@@ -143,7 +143,7 @@ pub type CsStructure = CsStructureI<usize>;
 /// [`CsVecI`]: type.CsVecI.html
 /// [`CsVecViewI`]: type.CsVecViewI.html
 /// [`CsVecViewMutI`]: type.CsVecViewMutI.html
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CsVecBase<IStorage, DStorage> {
     dim: usize,

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -625,6 +625,9 @@ impl<N, I: SpIndex, Iptr: SpIndex>
             let start = start_stop[0].index_unchecked();
             let stop = start_stop[1].index_unchecked();
             let indices = &mut self.indices[start..stop];
+            if utils::sorted_indices(indices) {
+                continue;
+            }
             let data = &mut self.data[start..stop];
             let len = stop - start;
             let indices = &mut indices[..len];

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -36,18 +36,6 @@ use crate::sparse::to_dense::assign_to_dense;
 use crate::sparse::utils;
 use crate::sparse::vec;
 
-impl<N, I, IptrStorage, IndStorage, DataStorage, Iptr> Copy
-    for CsMatBase<N, I, IptrStorage, IndStorage, DataStorage, Iptr>
-where
-    I: SpIndex,
-    N: Copy,
-    Iptr: SpIndex,
-    IptrStorage: Deref<Target = [Iptr]> + Copy,
-    IndStorage: Deref<Target = [I]> + Copy,
-    DataStorage: Deref<Target = [N]> + Copy,
-{
-}
-
 /// Describe the storage of a CsMat
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -507,12 +507,14 @@ impl<N, I: SpIndex> CsVecBase<Vec<I>, Vec<N>> {
     where
         N: Copy,
     {
-        let mut buf = Vec::with_capacity(indices.len());
-        utils::sort_indices_data_slices(
-            &mut indices[..],
-            &mut data[..],
-            &mut buf,
-        );
+        if !utils::sorted_indices(&indices) {
+            let mut buf = Vec::with_capacity(indices.len());
+            utils::sort_indices_data_slices(
+                &mut indices[..],
+                &mut data[..],
+                &mut buf,
+            );
+        }
         let v = CsVecI {
             dim: n,
             indices,

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -499,26 +499,31 @@ impl<N, I: SpIndex> CsVecBase<Vec<I>, Vec<N>> {
     /// Try create an owning CsVec from vector data.
     pub fn try_new(
         n: usize,
-        mut indices: Vec<I>,
-        mut data: Vec<N>,
+        indices: Vec<I>,
+        data: Vec<N>,
     ) -> Result<CsVecI<N, I>, SprsError>
     where
         N: Copy,
     {
-        if !utils::sorted_indices(&indices) {
-            let mut buf = Vec::with_capacity(indices.len());
-            utils::sort_indices_data_slices(
-                &mut indices[..],
-                &mut data[..],
-                &mut buf,
-            );
-        }
-        let v = CsVecI {
+        if !utils::sorted_indices(&indices) {}
+        let mut v = CsVecI {
             dim: n,
             indices,
             data,
         };
-        v.check_structure().and(Ok(v))
+        match v.check_structure() {
+            Err(SprsError::NonSortedIndices) => {
+                let mut buf = Vec::with_capacity(v.indices.len());
+                utils::sort_indices_data_slices(
+                    &mut v.indices[..],
+                    &mut v.data[..],
+                    &mut buf,
+                );
+                v.check_structure()
+            }
+            v => v,
+        }
+        .and(Ok(v))
     }
 
     /// Create an empty CsVec, which can be used for incremental construction
@@ -655,8 +660,7 @@ where
         for i in self.indices.iter() {
             i.index();
         }
-
-        if !self.indices.windows(2).all(|x| x[0] < x[1]) {
+        if !utils::sorted_indices(&self.indices) {
             return Err(SprsError::NonSortedIndices);
         }
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -37,8 +37,6 @@ use crate::sparse::prelude::*;
 use crate::sparse::utils;
 use crate::sparse::{binop, prod};
 
-impl<IS: Copy, DS: Copy> Copy for CsVecBase<IS, DS> {}
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 /// Hold the index of a non-zero element in the compressed storage
 ///


### PR DESCRIPTION
The current behaviour is to always copy the indices and data to a new vector, sort it, then copy back. This PR instead checks if the vector/matrix needs sorting before doing this.

This PR does introduce a regression in the the `csvec_additive_inverse` and `csvec_neg` benchmarks, which is because of `malloc` being called more often for some reason. I think we are dealing with a (not so?) clever optimiser, and this should not be a regresson in code used elsewhere.

The additional commit adds the Copy clone to `derive` which should produce the same code, and adds the `must_use` attribute so one does not accidentally drop the result of a(n expensive) calculation.