### PR TITLE
Fix (CSC, CSR) multiplication

### DIFF
--- a/src/array_backend.rs
+++ b/src/array_backend.rs
@@ -6,6 +6,7 @@
 use std::ops::{Deref, DerefMut};
 
 /// Wrapper around a size 2 array, with `Deref` implementation.
+#[derive(Debug, Copy, Clone)]
 pub struct Array2<T> {
     pub data: [T; 2],
 }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1992,9 +1992,12 @@ where
                 smmp::mul_csr_csr(self.view(), rhs_csr.view())
             }
             (CSC, CSR) => {
-                let rhs_csr = rhs.to_other_storage();
-                smmp::mul_csr_csr(rhs_csr.view(), self.transpose_view())
-                    .transpose_into()
+                let rhs_csc = rhs.to_other_storage();
+                smmp::mul_csr_csr(
+                    rhs_csc.transpose_view(),
+                    self.transpose_view(),
+                )
+                .transpose_into()
             }
             (CSC, CSC) => {
                 smmp::mul_csr_csr(rhs.transpose_view(), self.transpose_view())
@@ -3050,6 +3053,13 @@ mod test {
                 _ => panic!(),
             }
         }
+    }
+
+    #[test]
+    fn issue_99() {
+        let a = crate::TriMat::<i32>::new((10, 1)).to_csc();
+        let b = crate::TriMat::<i32>::new((1, 9)).to_csr();
+        let _c = &a * &b;
     }
 }
 


### PR DESCRIPTION
Multiplication of `(CSC, CSR)` matrices would lead to a crash for valid matrices. `(CSC, CSR)` should instead copy the format of `(CSC, CSC)` with `rhs` transposed.

Ref #99