### PR TITLE
Build suitesparse from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with: {submodules: true}
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
@@ -35,6 +36,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with: {submodules: true}
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
@@ -50,6 +52,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with: {submodules: true}
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
@@ -90,6 +93,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with: {submodules: true}
 
     - name: Install suitesparse
       if: matrix.os == 'ubuntu-18.04'
@@ -129,6 +133,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with: {submodules: true}
     - name: Install dependencies
       run: |
           sudo apt-get install libeigen3-dev libsuitesparse-dev
@@ -148,6 +153,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with: {submodules: true}
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
@@ -164,6 +170,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with: {submodules: true}
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,3 +180,40 @@ jobs:
     - name: Run test
       run: |
           cargo test --features approx
+
+  static_suitesparse:
+    name: static SuiteSparse
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+        - build: stable
+          os: ubuntu-18.04
+          rust: stable
+        - build: macos
+          os: macos-latest
+          rust: stable
+        - build: win-msvc
+          os: windows-2019
+          rust: stable
+        - build: win-gnu
+          os: windows-2019
+          rust: stable
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with: {submodules: true}
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+    - name: Run tests (camd)
+      run: |
+          cd suitesparse_bindings/sprs_suitesparse_camd
+          cargo test --features suitesparse_camd_sys/static
+    - name: Run tests (ldl)
+      run: |
+          cd suitesparse_bindings/sprs_suitesparse_ldl
+          cargo test --features suitesparse_ldl_sys/static

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "suitesparse_bindings/suitesparse-src/SuiteSparse"]
+	path = suitesparse_bindings/suitesparse-src/SuiteSparse
+	url = https://github.com/DrTimothyAldenDavis/SuiteSparse.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "suitesparse_bindings/sprs_suitesparse_ldl",
     "suitesparse_bindings/suitesparse_camd_sys",
     "suitesparse_bindings/sprs_suitesparse_camd",
+    "suitesparse_bindings/suitesparse-src",
     "sprs-rand",
     "sprs-benches",
 ]

--- a/sprs-benches/Cargo.toml
+++ b/sprs-benches/Cargo.toml
@@ -3,6 +3,7 @@ name = "sprs-benches"
 version = "0.1.0"
 authors = ["Vincent Barrielle <vincent.barrielle@m4x.org>"]
 edition = "2018"
+publish = false
 
 [dependencies.sprs]
 version = "0.9.0"

--- a/suitesparse_bindings/sprs_suitesparse_ldl/Cargo.toml
+++ b/suitesparse_bindings/sprs_suitesparse_ldl/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 num-traits = "0.1.32"
-suitesparse_ldl_sys = { path = "../suitesparse_ldl_sys", version = "0.2.0", features = ["static"] }
+suitesparse_ldl_sys = { path = "../suitesparse_ldl_sys", version = "0.2.0" }
 
 [dependencies.sprs]
 version = "0.9.0"

--- a/suitesparse_bindings/sprs_suitesparse_ldl/Cargo.toml
+++ b/suitesparse_bindings/sprs_suitesparse_ldl/Cargo.toml
@@ -11,10 +11,7 @@ edition = "2018"
 
 [dependencies]
 num-traits = "0.1.32"
-
-[dependencies.suitesparse_ldl_sys]
-path = "../suitesparse_ldl_sys/"
-version = "0.2.0"
+suitesparse_ldl_sys = { path = "../suitesparse_ldl_sys", version = "0.2.0", features = ["static"] }
 
 [dependencies.sprs]
 version = "0.9.0"

--- a/suitesparse_bindings/suitesparse-src/Cargo.toml
+++ b/suitesparse_bindings/suitesparse-src/Cargo.toml
@@ -9,6 +9,51 @@ license-file = "SuiteSparse/LICENSE.txt"
 readme = "README.md"
 repository = "https://github.com/vbarrielle/sprs"
 description = "Builds the SuiteSparse components"
+exclude = [
+    "SuiteSparse/AMD/",
+    "SuiteSparse/bin/",
+    "SuiteSparse/BTF/",
+    "SuiteSparse/CCOLAMD/",
+    "SuiteSparse/CHOLMOD/",
+    "SuiteSparse/COLAMD/",
+    "SuiteSparse/CSparse/",
+    "SuiteSparse/CSparse_to_CXSparse/",
+    "SuiteSparse/CXSparse/",
+    "SuiteSparse/CXSparse_newfiles/",
+    "SuiteSparse/GPUQREngine/",
+    "SuiteSparse/GraphBLAS/",
+    "SuiteSparse/KLU/",
+    "SuiteSparse/lib/",
+    "SuiteSparse/Makefile",
+    "SuiteSparse/MATLAB_Tools/",
+    "SuiteSparse/metis-5.1.0/",
+    "SuiteSparse/Mongoose/",
+    "SuiteSparse/RBio/",
+    "SuiteSparse/share/",
+    "SuiteSparse/SLIP_LU/",
+    "SuiteSparse/SPQR/",
+    "SuiteSparse/ssget/",
+    "SuiteSparse/UMFPACK/",
+
+    "SuiteSparse/contents.m",
+    "SuiteSparse/SuiteSparse_GPURuntime/",
+    "SuiteSparse/SuiteSparse_demo.m",
+    "SuiteSparse/SuiteSparse_install.m",
+    "SuiteSparse/SuiteSparse_test.m",
+
+    "SuiteSparse/CAMD/Demo/",
+    "SuiteSparse/CAMD/Doc/",
+    "SuiteSparse/CAMD/Lib/",
+    "SuiteSparse/CAMD/Makefile",
+    "SuiteSparse/CAMD/MATLAB/",
+
+    "SuiteSparse/LDL/Demo/",
+    "SuiteSparse/LDL/Doc/",
+    "SuiteSparse/LDL/Lib/",
+    "SuiteSparse/LDL/Makefile",
+    "SuiteSparse/LDL/MATLAB/",
+    "SuiteSparse/LDL/Matrix/",
+]
 
 [features]
 camd = []

--- a/suitesparse_bindings/suitesparse-src/Cargo.toml
+++ b/suitesparse_bindings/suitesparse-src/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "suitesparse-src"
+version = "0.1.0"
+authors = ["Magnus Ulimoen <magnus@ulimoen.dev>"]
+edition = "2018"
+build = "build.rs"
+links = "suitesparse-src"
+
+[features]
+camd = []
+ldl = []
+
+[dependencies]
+
+[build-dependencies]
+cc = "1.0.60"

--- a/suitesparse_bindings/suitesparse-src/Cargo.toml
+++ b/suitesparse_bindings/suitesparse-src/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Magnus Ulimoen <magnus@ulimoen.dev>"]
 edition = "2018"
 build = "build.rs"
 links = "suitesparse-src"
+license-file = "SuiteSparse/LICENSE.txt"
+readme = "README.md"
+repository = "https://github.com/vbarrielle/sprs"
+description = "Builds the SuiteSparse components"
 
 [features]
 camd = []

--- a/suitesparse_bindings/suitesparse-src/README.md
+++ b/suitesparse_bindings/suitesparse-src/README.md
@@ -1,0 +1,3 @@
+# SuiteSparse-src
+
+This crate is a meta-crate to compile the various components of `SuiteSparse`

--- a/suitesparse_bindings/suitesparse-src/README.md
+++ b/suitesparse_bindings/suitesparse-src/README.md
@@ -1,3 +1,3 @@
 # SuiteSparse-src
 
-This crate is a meta-crate to compile the various components of `SuiteSparse`
+This crate is a meta-crate to compile the various components of `SuiteSparse`. The current version of `SuiteSparse` is v5.8.1.

--- a/suitesparse_bindings/suitesparse-src/build.rs
+++ b/suitesparse_bindings/suitesparse-src/build.rs
@@ -2,7 +2,28 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let root = std::env::var_os("OUT_DIR").unwrap();
     println!("cargo:root={}", root.to_string_lossy());
+
+    let mut suitesparse_config = false;
     if std::env::var_os("CARGO_FEATURE_CAMD").is_some() {
+        suitesparse_config = true;
+        cc::Build::new()
+            .define("DLONG", None)
+            .include("SuiteSparse/SuiteSparse_config")
+            .include("SuiteSparse/CAMD/Include")
+            .file("SuiteSparse/CAMD/Source/camd_1.c")
+            .file("SuiteSparse/CAMD/Source/camd_2.c")
+            .file("SuiteSparse/CAMD/Source/camd_aat.c")
+            .file("SuiteSparse/CAMD/Source/camd_control.c")
+            .file("SuiteSparse/CAMD/Source/camd_defaults.c")
+            .file("SuiteSparse/CAMD/Source/camd_dump.c")
+            .file("SuiteSparse/CAMD/Source/camd_global.c")
+            .file("SuiteSparse/CAMD/Source/camd_info.c")
+            .file("SuiteSparse/CAMD/Source/camd_order.c")
+            .file("SuiteSparse/CAMD/Source/camd_postorder.c")
+            .file("SuiteSparse/CAMD/Source/camd_preprocess.c")
+            .file("SuiteSparse/CAMD/Source/camd_valid.c")
+            .cargo_metadata(false)
+            .compile("camdl");
         cc::Build::new()
             .include("SuiteSparse/SuiteSparse_config")
             .include("SuiteSparse/CAMD/Include")
@@ -46,5 +67,12 @@ fn main() {
             .object(&ldll_path)
             .cargo_metadata(false)
             .compile("ldl");
+    }
+    if suitesparse_config {
+        cc::Build::new()
+            .include("SuiteSparse/SuiteSparse_config")
+            .file("SuiteSparse/SuiteSparse_config/SuiteSparse_config.c")
+            .cargo_metadata(false)
+            .compile("suitesparseconfig");
     }
 }

--- a/suitesparse_bindings/suitesparse-src/build.rs
+++ b/suitesparse_bindings/suitesparse-src/build.rs
@@ -1,0 +1,29 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:root={}", std::env::var("OUT_DIR").unwrap());
+    if std::env::var_os("CARGO_FEATURE_CAMD").is_some() {
+        cc::Build::new()
+            .include("SuiteSparse/CAMD/Include")
+            .file("SuiteSparse/CAMD/Source/camd_1.c")
+            .file("SuiteSparse/CAMD/Source/camd_2.c")
+            .file("SuiteSparse/CAMD/Source/camd_aat.c")
+            .file("SuiteSparse/CAMD/Source/camd_control.c")
+            .file("SuiteSparse/CAMD/Source/camd_defaults.c")
+            .file("SuiteSparse/CAMD/Source/camd_dump.c")
+            .file("SuiteSparse/CAMD/Source/camd_global.c")
+            .file("SuiteSparse/CAMD/Source/camd_info.c")
+            .file("SuiteSparse/CAMD/Source/camd_order.c")
+            .file("SuiteSparse/CAMD/Source/camd_postorder.c")
+            .file("SuiteSparse/CAMD/Source/camd_preprocess.c")
+            .file("SuiteSparse/CAMD/Source/camd_valid.c")
+            .cargo_metadata(false)
+            .compile("camd");
+    }
+    if std::env::var_os("CARGO_FEATURE_LDL").is_some() {
+        cc::Build::new()
+            .include("SuiteSparse/LDL/Include")
+            .file("SuiteSparse/LDL/Source/ldl.c")
+            .cargo_metadata(false)
+            .compile("ldl")
+    }
+}

--- a/suitesparse_bindings/suitesparse-src/build.rs
+++ b/suitesparse_bindings/suitesparse-src/build.rs
@@ -1,7 +1,6 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let root = std::env::var_os("OUT_DIR").unwrap();
-    println!("cargo:root={}", root.to_string_lossy());
 
     let mut suitesparse_config = false;
     if std::env::var_os("CARGO_FEATURE_CAMD").is_some() {
@@ -75,4 +74,5 @@ fn main() {
             .cargo_metadata(false)
             .compile("suitesparseconfig");
     }
+    println!("cargo:root={}", root.to_string_lossy());
 }

--- a/suitesparse_bindings/suitesparse-src/build.rs
+++ b/suitesparse_bindings/suitesparse-src/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:root={}", std::env::var("OUT_DIR").unwrap());
+    let root = std::env::var_os("OUT_DIR").unwrap();
+    println!("cargo:root={}", root.to_string_lossy());
     if std::env::var_os("CARGO_FEATURE_CAMD").is_some() {
         cc::Build::new()
             .include("SuiteSparse/SuiteSparse_config")
@@ -21,11 +22,29 @@ fn main() {
             .compile("camd");
     }
     if std::env::var_os("CARGO_FEATURE_LDL").is_some() {
+        // We first build ldl with LDL_LONG to make the bindings to
+        // the long bits of the library
         cc::Build::new()
             .include("SuiteSparse/SuiteSparse_config")
             .include("SuiteSparse/LDL/Include")
             .file("SuiteSparse/LDL/Source/ldl.c")
             .cargo_metadata(false)
-            .compile("ldl")
+            .define("LDL_LONG", None)
+            .compile("ldll");
+        // We must then copy this to another location since the next
+        // invocation is just a compile definition
+        let mut ldl_path = std::path::PathBuf::from(root.clone());
+        ldl_path.push("SuiteSparse/LDL/Source/ldl.o");
+        let mut ldll_path = ldl_path.clone();
+        ldll_path.set_file_name("ldll.o");
+        std::fs::copy(&ldl_path, &ldll_path).unwrap();
+        // And now we build ldl again (in int form), and link with the long bits
+        cc::Build::new()
+            .include("SuiteSparse/SuiteSparse_config")
+            .include("SuiteSparse/LDL/Include")
+            .file("SuiteSparse/LDL/Source/ldl.c")
+            .object(&ldll_path)
+            .cargo_metadata(false)
+            .compile("ldl");
     }
 }

--- a/suitesparse_bindings/suitesparse-src/build.rs
+++ b/suitesparse_bindings/suitesparse-src/build.rs
@@ -3,6 +3,7 @@ fn main() {
     println!("cargo:root={}", std::env::var("OUT_DIR").unwrap());
     if std::env::var_os("CARGO_FEATURE_CAMD").is_some() {
         cc::Build::new()
+            .include("SuiteSparse/SuiteSparse_config")
             .include("SuiteSparse/CAMD/Include")
             .file("SuiteSparse/CAMD/Source/camd_1.c")
             .file("SuiteSparse/CAMD/Source/camd_2.c")
@@ -21,6 +22,7 @@ fn main() {
     }
     if std::env::var_os("CARGO_FEATURE_LDL").is_some() {
         cc::Build::new()
+            .include("SuiteSparse/SuiteSparse_config")
             .include("SuiteSparse/LDL/Include")
             .file("SuiteSparse/LDL/Source/ldl.c")
             .cargo_metadata(false)

--- a/suitesparse_bindings/suitesparse-src/src/lib.rs
+++ b/suitesparse_bindings/suitesparse-src/src/lib.rs
@@ -1,0 +1,1 @@
+//! This library is a stub to build SuiteSparse

--- a/suitesparse_bindings/suitesparse-src/src/lib.rs
+++ b/suitesparse_bindings/suitesparse-src/src/lib.rs
@@ -1,1 +1,3 @@
 //! This library is a stub to build SuiteSparse
+//!
+//! Complete sources can be found at https://github.com/DrTimothyAldenDavis/SuiteSparse

--- a/suitesparse_bindings/suitesparse_camd_sys/Cargo.toml
+++ b/suitesparse_bindings/suitesparse_camd_sys/Cargo.toml
@@ -5,8 +5,12 @@ authors = ["Vincent Barrielle <vincent.barrielle@m4x.org>"]
 edition = "2018"
 description = "Raw bindings to SuiteSparse's CAMD algorithm"
 license = "MIT OR Apache-2.0"
+build = "build.rs"
+links = "camd"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+static = ["suitesparse-src/camd"]
 
 [dependencies]
 libc = "0.2.74"
+suitesparse-src = { path = "../suitesparse-src", optional = true }

--- a/suitesparse_bindings/suitesparse_camd_sys/build.rs
+++ b/suitesparse_bindings/suitesparse_camd_sys/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if std::env::var_os("CARGO_FEATURE_STATIC").is_some() {
+        let path_to_camd = std::env::var("DEP_SUITESPARSE_SRC_ROOT").unwrap();
+        println!("cargo:rustc-link-search=native={}", path_to_camd);
+    }
+}

--- a/suitesparse_bindings/suitesparse_camd_sys/build.rs
+++ b/suitesparse_bindings/suitesparse_camd_sys/build.rs
@@ -3,5 +3,10 @@ fn main() {
     if std::env::var_os("CARGO_FEATURE_STATIC").is_some() {
         let path_to_camd = std::env::var("DEP_SUITESPARSE_SRC_ROOT").unwrap();
         println!("cargo:rustc-link-search=native={}", path_to_camd);
+        println!("cargo:rustc-link-lib=static=camd");
+        println!("cargo:rustc-link-lib=static=camdl");
+        println!("cargo:rustc-link-lib=static=suitesparseconfig");
+    } else {
+        println!("cargo:rustc-link-lib=camd");
     }
 }

--- a/suitesparse_bindings/suitesparse_camd_sys/src/lib.rs
+++ b/suitesparse_bindings/suitesparse_camd_sys/src/lib.rs
@@ -5,7 +5,6 @@ pub type SuiteSparseLong = libc::c_long;
 
 pub type SuiteSparseInt = libc::c_int;
 
-#[link(name = "camd")]
 extern "C" {
     /// Find a permutation matrix P, represented by the permutation indices
     /// `p`, which reduces the fill-in of the symmetric sparse matrix A

--- a/suitesparse_bindings/suitesparse_camd_sys/src/lib.rs
+++ b/suitesparse_bindings/suitesparse_camd_sys/src/lib.rs
@@ -1,3 +1,7 @@
+//! FFI bindings to the SuiteSparse component CAMD
+//!
+//! For a static build activate the "static" feature, which builds CAMD
+//! from source and includes this statically.
 #[cfg(target_os = "windows")]
 pub type SuiteSparseLong = libc::c_longlong;
 #[cfg(not(target_os = "windows"))]

--- a/suitesparse_bindings/suitesparse_ldl_sys/Cargo.toml
+++ b/suitesparse_bindings/suitesparse_ldl_sys/Cargo.toml
@@ -8,6 +8,12 @@ readme = "README.md"
 repository = "https://github.com/vbarrielle/sprs"
 keywords = ["sparse", "cholesky", "factorization", "suitesparse", "binding"]
 edition = "2018"
+build = "build.rs"
+links = "ldl"
+
+[features]
+static = ["suitesparse-src/ldl"]
 
 [dependencies]
 libc = "0.2"
+suitesparse-src = { path = "../suitesparse-src", optional = true }

--- a/suitesparse_bindings/suitesparse_ldl_sys/README.md
+++ b/suitesparse_bindings/suitesparse_ldl_sys/README.md
@@ -4,3 +4,7 @@ LDL is a simple sparse Cholesky factorization algorithm. This crate exposes
 the signatures exposed by this library as extern functions.
 
 For a nicer API, the crate `sprs_suitesparse_ldl` is available.
+
+## Features
+
+The `ldl` part of `SuiteSparse` can be built from source by passing the `static` feature to this crate. Please observe that the license of this component is LGPL-2.1 or later.

--- a/suitesparse_bindings/suitesparse_ldl_sys/README.rst
+++ b/suitesparse_bindings/suitesparse_ldl_sys/README.rst
@@ -1,2 +1,0 @@
-Rust bindings to the SuiteSparse LDL library
-============================================

--- a/suitesparse_bindings/suitesparse_ldl_sys/build.rs
+++ b/suitesparse_bindings/suitesparse_ldl_sys/build.rs
@@ -3,5 +3,8 @@ fn main() {
     if std::env::var_os("CARGO_FEATURE_STATIC").is_some() {
         let path_to_ldl = std::env::var("DEP_SUITESPARSE_SRC_ROOT").unwrap();
         println!("cargo:rustc-link-search=native={}", path_to_ldl);
+        println!("cargo:rustc-link-lib=static=ldl");
+    } else {
+        println!("cargo:rustc-link-lib=ldl");
     }
 }

--- a/suitesparse_bindings/suitesparse_ldl_sys/build.rs
+++ b/suitesparse_bindings/suitesparse_ldl_sys/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if std::env::var_os("CARGO_FEATURE_STATIC").is_some() {
+        let path_to_ldl = std::env::var("DEP_SUITESPARSE_SRC_ROOT").unwrap();
+        println!("cargo:rustc-link-search=native={}", path_to_ldl);
+    }
+}

--- a/suitesparse_bindings/suitesparse_ldl_sys/src/lib.rs
+++ b/suitesparse_bindings/suitesparse_ldl_sys/src/lib.rs
@@ -1,13 +1,11 @@
-#[allow(non_camel_case_types)]
+#![allow(non_camel_case_types)]
 pub type ldl_int = libc::c_int;
-#[allow(non_camel_case_types)]
-pub type ldl_long = libc::c_long;
-#[allow(non_camel_case_types)]
-pub type ldl_double = libc::c_double;
 
-pub const LDL_MAIN_VERSION: usize = 2;
-pub const LDL_SUB_VERSION: usize = 1;
-pub const LDL_SUBSUB_VERSION: usize = 0;
+#[cfg(target_os = "windows")]
+pub type ldl_long = i64;
+#[cfg(not(target_os = "windows"))]
+pub type ldl_long = libc::c_long;
+pub type ldl_double = libc::c_double;
 
 extern "C" {
     pub fn ldl_symbolic(

--- a/suitesparse_bindings/suitesparse_ldl_sys/src/lib.rs
+++ b/suitesparse_bindings/suitesparse_ldl_sys/src/lib.rs
@@ -9,7 +9,6 @@ pub const LDL_MAIN_VERSION: usize = 2;
 pub const LDL_SUB_VERSION: usize = 1;
 pub const LDL_SUBSUB_VERSION: usize = 0;
 
-#[link(name = "ldl")]
 extern "C" {
     pub fn ldl_symbolic(
         n: ldl_int,
@@ -161,4 +160,16 @@ extern "C" {
         ap: *const ldl_long,
         ai: *const ldl_long,
     ) -> ldl_long;
+}
+
+#[test]
+fn sanity() {
+    let n = 1;
+    let ap = &[0, 1];
+    let ai = &[0];
+    let valid;
+    unsafe {
+        valid = ldl_valid_matrix(n, ap.as_ptr(), ai.as_ptr());
+    }
+    assert_eq!(valid, 1);
 }


### PR DESCRIPTION
This adds feature flags for `suitesparse_ldl_sys` and `suitesparse_camd_sys` to build `SuiteSparse` from source and statically link it. This should be easily extendable to more components later on if more parts are wanted. We might want to add this feature flag to the `sprs_suitesparse` packages.

The build script for `SuiteSparse` reimplements the `Makefile`s, as these were hard to reuse, I've added CI which should ensure we won't break this.

The targeted version of `SuiteSparse` is v5.8.1, and parts of this will be uploaded to `crates.io`. This should be compatible with the licenses of the included components.