### PR TITLE
Fix shape-bug for CSC in middle_outer_views

### DIFF
--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -2708,6 +2708,16 @@ mod test {
     }
 
     #[test]
+    fn middle_outer_views() {
+        let size = 11;
+        let csr: CsMat<f64> = CsMat::eye(size);
+        assert_eq!(csr.view().middle_outer_views(1, 3).shape(), (3, size));
+
+        let csc = csr.to_other_storage();
+        assert_eq!(csc.view().middle_outer_views(1, 3).shape(), (size, 3));
+    }
+
+    #[test]
     fn nnz_index() {
         let mat: CsMat<f64> = CsMat::eye(11);
 

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -864,10 +864,14 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
         if i >= self.outer_dims() || iend > self.outer_dims() {
             panic!("Out of bounds index");
         }
+        let (nrows, ncols) = match self.storage {
+            CSR => (count, self.cols()),
+            CSC => (self.rows(), count),
+        };
         CsMatViewI {
             storage: self.storage,
-            nrows: count,
-            ncols: self.cols(),
+            nrows,
+            ncols,
             indptr: &self.indptr[i..=iend],
             indices: &self.indices[..],
             data: &self.data[..],


### PR DESCRIPTION
Create the correct shape of the view returned from `middle_outer_views` when `self` is a `CSC`