### PR TITLE
Refactor to allow partial views

### DIFF
--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -52,12 +52,10 @@ fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
     assert!(b.is_csr());
     assert!(b.rows() <= isize::MAX as usize);
     assert!(b.indptr().nnz() <= isize::MAX as usize);
-    let a_indptr = a.indptr();
-    let (_a_indptr_proper, a_indptr_ptr) = a_indptr.to_proper_ffi();
+    let a_indptr_proper = a.proper_indptr();
     let a_indices = a.indices().as_ptr() as *const isize;
     let a_data = a.data().as_ptr();
-    let b_indptr = b.indptr();
-    let (_b_indptr_proper, b_indptr_ptr) = b_indptr.to_proper_ffi();
+    let b_indptr_proper = b.proper_indptr();
     let b_indices = b.indices().as_ptr() as *const isize;
     let b_data = b.data().as_ptr();
     // Safety: sprs guarantees the validity of these pointers, and our wrapping
@@ -73,10 +71,10 @@ fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
             a_rows,
             a_cols,
             b_cols,
-            a_indptr_ptr as *const isize,
+            a_indptr_proper.as_ptr() as *const isize,
             a_indices,
             a_data,
-            b_indptr_ptr as *const isize,
+            b_indptr_proper.as_ptr() as *const isize,
             b_indices,
             b_data,
         )

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -53,13 +53,11 @@ fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
     assert!(b.rows() <= isize::MAX as usize);
     assert!(b.indptr().nnz() <= isize::MAX as usize);
     let a_indptr = a.indptr();
-    let a_indptr_proper = a_indptr.to_proper();
-    let a_indptr_isz = a_indptr_proper.as_ptr() as *const isize;
+    let (_a_indptr_proper, a_indptr_ptr) = a_indptr.to_proper_ffi();
     let a_indices = a.indices().as_ptr() as *const isize;
     let a_data = a.data().as_ptr();
     let b_indptr = b.indptr();
-    let b_indptr_proper = b_indptr.to_proper();
-    let b_indptr_isz = b_indptr_proper.as_ptr() as *const isize;
+    let (_b_indptr_proper, b_indptr_ptr) = b_indptr.to_proper_ffi();
     let b_indices = b.indices().as_ptr() as *const isize;
     let b_data = b.data().as_ptr();
     // Safety: sprs guarantees the validity of these pointers, and our wrapping
@@ -75,10 +73,10 @@ fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
             a_rows,
             a_cols,
             b_cols,
-            a_indptr_isz,
+            a_indptr_ptr as *const isize,
             a_indices,
             a_data,
-            b_indptr_isz,
+            b_indptr_ptr as *const isize,
             b_indices,
             b_data,
         )

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -48,14 +48,18 @@ fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
     assert_eq!(a_cols, b_rows);
     assert!(a.is_csr());
     assert!(a.rows() <= isize::MAX as usize);
-    assert!(a.indptr()[a.rows()] <= isize::MAX as usize);
+    assert!(a.indptr().nnz() <= isize::MAX as usize);
     assert!(b.is_csr());
     assert!(b.rows() <= isize::MAX as usize);
-    assert!(b.indptr()[b.rows()] <= isize::MAX as usize);
-    let a_indptr = a.indptr().as_ptr() as *const isize;
+    assert!(b.indptr().nnz() <= isize::MAX as usize);
+    let a_indptr = a.indptr();
+    let a_indptr_proper = a_indptr.to_proper();
+    let a_indptr_isz = a_indptr_proper.as_ptr() as *const isize;
     let a_indices = a.indices().as_ptr() as *const isize;
     let a_data = a.data().as_ptr();
-    let b_indptr = b.indptr().as_ptr() as *const isize;
+    let b_indptr = b.indptr();
+    let b_indptr_proper = b_indptr.to_proper();
+    let b_indptr_isz = b_indptr_proper.as_ptr() as *const isize;
     let b_indices = b.indices().as_ptr() as *const isize;
     let b_data = b.data().as_ptr();
     // Safety: sprs guarantees the validity of these pointers, and our wrapping
@@ -68,8 +72,15 @@ fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
     // reinterpretation of the data will not produce negative values.
     unsafe {
         prod_nnz(
-            a_rows, a_cols, b_cols, a_indptr, a_indices, a_data, b_indptr,
-            b_indices, b_data,
+            a_rows,
+            a_cols,
+            b_cols,
+            a_indptr_isz,
+            a_indices,
+            a_data,
+            b_indptr_isz,
+            b_indices,
+            b_data,
         )
     }
 }

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -10,14 +10,11 @@ fn scipy_mat<'a>(
     py: &Python,
     mat: &sprs::CsMat<f64>,
 ) -> Result<&'a PyAny, String> {
+    let indptr = mat.indptr().to_proper().to_vec();
     scipy_sparse
         .call(
             "csr_matrix",
-            ((
-                mat.data().to_vec(),
-                mat.indices().to_vec(),
-                mat.indptr().to_vec(),
-            ),),
+            ((mat.data().to_vec(), mat.indices().to_vec(), indptr),),
             Some([("shape", mat.shape())].into_py_dict(*py)),
         )
         .map_err(|e| {

--- a/sprs-ldl/src/lib.rs
+++ b/sprs-ldl/src/lib.rs
@@ -146,7 +146,9 @@ impl Ldl {
             }
             FillInReduction::CAMDSuiteSparse => {
                 #[cfg(not(feature = "sprs_suitesparse_camd"))]
-                panic!("Unavailable without the `sprs_suitesparse_camd` feature");
+                panic!(
+                    "Unavailable without the `sprs_suitesparse_camd` feature"
+                );
                 #[cfg(feature = "sprs_suitesparse_camd")]
                 sprs_suitesparse_camd::camd(mat.structure_view())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,12 @@ pub type Ix2 = ndarray::Ix2;
 pub use crate::indexing::SpIndex;
 
 pub use crate::sparse::{
-    csmat::CsIter, csmat::OuterIterator, csmat::OuterIteratorMut,
-    csmat::OuterIteratorPerm, indptr::IndPtr, kronecker::kronecker_product,
+    csmat::CsIter,
+    csmat::OuterIterator,
+    csmat::OuterIteratorMut,
+    csmat::OuterIteratorPerm,
+    indptr::{IndPtr, IndPtrBase, IndPtrView},
+    kronecker::kronecker_product,
     CsMat, CsMatBase, CsMatI, CsMatVecView, CsMatView, CsMatViewI,
     CsMatViewMut, CsMatViewMutI, CsStructure, CsStructureI, CsStructureView,
     CsStructureViewI, CsVec, CsVecBase, CsVecI, CsVecView, CsVecViewI,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,9 +89,6 @@ pub use crate::indexing::SpIndex;
 
 pub use crate::sparse::{
     csmat::CsIter,
-    csmat::OuterIterator,
-    csmat::OuterIteratorMut,
-    csmat::OuterIteratorPerm,
     indptr::{IndPtr, IndPtrBase, IndPtrView},
     kronecker::kronecker_product,
     CsMat, CsMatBase, CsMatI, CsMatVecView, CsMatView, CsMatViewI,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,13 @@ pub use crate::indexing::SpIndex;
 
 pub use crate::sparse::{
     csmat::CsIter, csmat::OuterIterator, csmat::OuterIteratorMut,
-    csmat::OuterIteratorPerm, kronecker::kronecker_product, CsMat, CsMatBase,
-    CsMatI, CsMatVecView, CsMatView, CsMatViewI, CsMatViewMut, CsMatViewMutI,
-    CsStructure, CsStructureI, CsStructureView, CsStructureViewI, CsVec,
-    CsVecBase, CsVecI, CsVecView, CsVecViewI, CsVecViewMut, CsVecViewMutI,
-    SparseMat, TriMat, TriMatBase, TriMatI, TriMatIter, TriMatView,
-    TriMatViewI, TriMatViewMut, TriMatViewMutI,
+    csmat::OuterIteratorPerm, indptr::IndPtrStorage,
+    kronecker::kronecker_product, CsMat, CsMatBase, CsMatI, CsMatVecView,
+    CsMatView, CsMatViewI, CsMatViewMut, CsMatViewMutI, CsStructure,
+    CsStructureI, CsStructureView, CsStructureViewI, CsVec, CsVecBase, CsVecI,
+    CsVecView, CsVecViewI, CsVecViewMut, CsVecViewMutI, SparseMat, TriMat,
+    TriMatBase, TriMatI, TriMatIter, TriMatView, TriMatViewI, TriMatViewMut,
+    TriMatViewMutI,
 };
 
 pub use crate::sparse::symmetric::is_symmetric;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,13 +89,12 @@ pub use crate::indexing::SpIndex;
 
 pub use crate::sparse::{
     csmat::CsIter, csmat::OuterIterator, csmat::OuterIteratorMut,
-    csmat::OuterIteratorPerm, indptr::IndPtrStorage,
-    kronecker::kronecker_product, CsMat, CsMatBase, CsMatI, CsMatVecView,
-    CsMatView, CsMatViewI, CsMatViewMut, CsMatViewMutI, CsStructure,
-    CsStructureI, CsStructureView, CsStructureViewI, CsVec, CsVecBase, CsVecI,
-    CsVecView, CsVecViewI, CsVecViewMut, CsVecViewMutI, SparseMat, TriMat,
-    TriMatBase, TriMatI, TriMatIter, TriMatView, TriMatViewI, TriMatViewMut,
-    TriMatViewMutI,
+    csmat::OuterIteratorPerm, indptr::IndPtr, kronecker::kronecker_product,
+    CsMat, CsMatBase, CsMatI, CsMatVecView, CsMatView, CsMatViewI,
+    CsMatViewMut, CsMatViewMutI, CsStructure, CsStructureI, CsStructureView,
+    CsStructureViewI, CsVec, CsVecBase, CsVecI, CsVecView, CsVecViewI,
+    CsVecViewMut, CsVecViewMutI, SparseMat, TriMat, TriMatBase, TriMatI,
+    TriMatIter, TriMatView, TriMatViewI, TriMatViewMut, TriMatViewMutI,
 };
 
 pub use crate::sparse::symmetric::is_symmetric;

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -410,6 +410,7 @@ pub mod binop;
 pub mod compressed;
 pub mod construct;
 pub mod csmat;
+pub mod indptr;
 pub mod kronecker;
 pub mod linalg;
 pub mod permutation;

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -1,6 +1,7 @@
 use crate::array_backend::Array2;
 use crate::errors::SprsError;
 use crate::indexing::SpIndex;
+use crate::IndPtrBase;
 use std::ops::Deref;
 
 #[cfg(feature = "serde")]
@@ -93,7 +94,7 @@ where
     storage: CompressedStorage,
     nrows: usize,
     ncols: usize,
-    indptr: IptrStorage,
+    indptr: IndPtrBase<Iptr, IptrStorage>,
     indices: IndStorage,
     data: DataStorage,
 }

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -94,6 +94,7 @@ where
     storage: CompressedStorage,
     nrows: usize,
     ncols: usize,
+    #[cfg_attr(feature = "serde", serde(flatten))]
     indptr: IndPtrBase<Iptr, IptrStorage>,
     indices: IndStorage,
     data: DataStorage,

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -5,6 +5,7 @@ use crate::sparse::csmat::CompressedStorage;
 use crate::sparse::prelude::*;
 use crate::sparse::vec::NnzEither::{Both, Left, Right};
 use crate::sparse::vec::SparseIterTools;
+use crate::IndPtr;
 use ndarray::{
     self, Array, ArrayBase, ArrayView, ArrayViewMut, Axis, ShapeBuilder,
 };
@@ -125,7 +126,7 @@ where
         storage,
         nrows,
         ncols,
-        indptr: out_indptr,
+        indptr: IndPtr::new_trusted(out_indptr),
         indices: out_indices,
         data: out_data,
     }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1464,7 +1464,7 @@ where
             data = next;
             CsVecViewMutI {
                 dim: inner_dim,
-                indices: &indices[range.clone()],
+                indices: &indices[range],
                 data: yield_data,
             }
         })

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -15,8 +15,8 @@ use std::cmp;
 use std::default::Default;
 use std::iter::{Enumerate, Zip};
 use std::mem;
-use std::ops::{Add, Deref, DerefMut, Index, IndexMut, Mul, Range, Sub};
-use std::slice::{self, Iter, Windows};
+use std::ops::{Add, Deref, DerefMut, Index, IndexMut, Mul, Sub};
+use std::slice::{self, Iter};
 
 use crate::{Ix1, Ix2, Shape};
 use ndarray::linalg::Dot;
@@ -87,188 +87,14 @@ pub use self::CompressedStorage::{CSC, CSR};
 /// time.
 pub struct NnzIndex(pub usize);
 
-/// Iterator on the matrix' outer dimension
-/// Implemented over an iterator on the indptr array
-pub struct OuterIterator<'iter, N: 'iter, I: 'iter, Iptr: 'iter = I> {
-    inner_len: usize,
-    indptr_iter: Windows<'iter, Iptr>,
-    indices: &'iter [I],
-    data: &'iter [N],
-}
-
-/// Iterator on the matrix' outer dimension, permuted
-/// Implemented over an iterator on the indptr array
-pub struct OuterIteratorPerm<
-    'iter,
-    'perm: 'iter,
-    N: 'iter,
-    I: 'perm,
-    Iptr: 'perm = I,
-> {
-    inner_len: usize,
-    outer_ind_iter: Range<usize>,
-    indptr: &'iter [Iptr],
-    indices: &'iter [I],
-    data: &'iter [N],
-    perm: PermViewI<'perm, I>,
-}
-
-/// Iterator on the matrix' outer dimension
-/// Implemented over an iterator on the indptr array
-pub struct OuterIteratorMut<'iter, N: 'iter, I: 'iter, Iptr: 'iter = I> {
-    inner_len: usize,
-    indptr_iter: Windows<'iter, Iptr>,
-    indices: &'iter [I],
-    data: &'iter mut [N],
-}
-
-/// Outer iteration on a compressed matrix yields
-/// a tuple consisting of the outer index and of a sparse vector
-/// containing the associated inner dimension
-impl<'iter, N: 'iter, I: 'iter + SpIndex, Iptr: 'iter + SpIndex> Iterator
-    for OuterIterator<'iter, N, I, Iptr>
+pub struct CsIter<'a, N: 'a, I: 'a, Iptr: 'a = I>
+where
+    I: SpIndex,
+    Iptr: SpIndex,
 {
-    type Item = CsVecBase<&'iter [I], &'iter [N]>;
-    #[inline]
-    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        match self.indptr_iter.next() {
-            None => None,
-            Some(window) => {
-                let inner_start = window[0].index_unchecked();
-                let inner_end = window[1].index_unchecked();
-                let indices = &self.indices[inner_start..inner_end];
-                let data = &self.data[inner_start..inner_end];
-                // CsMat invariants imply CsVec invariants
-                Some(CsVecBase {
-                    dim: self.inner_len,
-                    indices,
-                    data,
-                })
-            }
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.indptr_iter.size_hint()
-    }
-}
-
-/// Permuted outer iteration on a compressed matrix yields
-/// a tuple consisting of the outer index and of a sparse vector
-/// containing the associated inner dimension
-impl<
-        'iter,
-        'perm: 'iter,
-        N: 'iter,
-        I: 'iter + SpIndex,
-        Iptr: 'iter + SpIndex,
-    > Iterator for OuterIteratorPerm<'iter, 'perm, N, I, Iptr>
-{
-    type Item = (usize, CsVecBase<&'iter [I], &'iter [N]>);
-    #[inline]
-    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        match self.outer_ind_iter.next() {
-            None => None,
-            Some(outer_ind) => {
-                let outer_ind_perm = self.perm.at(outer_ind);
-                let inner_start = self.indptr[outer_ind_perm].index_unchecked();
-                let inner_end =
-                    self.indptr[outer_ind_perm + 1].index_unchecked();
-                let indices = &self.indices[inner_start..inner_end];
-                let data = &self.data[inner_start..inner_end];
-                // CsMat invariants imply CsVec invariants
-                let vec = CsVecBase {
-                    dim: self.inner_len,
-                    indices,
-                    data,
-                };
-                Some((outer_ind_perm, vec))
-            }
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.outer_ind_iter.size_hint()
-    }
-}
-
-/// Mutable outer iteration on a compressed matrix yields
-/// a tuple consisting of the outer index and of a mutable sparse vector view
-/// containing the associated inner dimension
-impl<'iter, N: 'iter, I: 'iter + SpIndex, Iptr: 'iter + SpIndex> Iterator
-    for OuterIteratorMut<'iter, N, I, Iptr>
-{
-    type Item = CsVecViewMutI<'iter, N, I>;
-    #[inline]
-    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        match self.indptr_iter.next() {
-            None => None,
-            Some(window) => {
-                let inner_start = window[0].index_unchecked();
-                let inner_end = window[1].index_unchecked();
-                let indices = &self.indices[inner_start..inner_end];
-
-                let tmp = mem::replace(&mut self.data, &mut []);
-                let (data, next) = tmp.split_at_mut(inner_end - inner_start);
-                self.data = next;
-
-                // CsMat invariants imply CsVec invariants
-                Some(CsVecBase {
-                    dim: self.inner_len,
-                    indices,
-                    data,
-                })
-            }
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.indptr_iter.size_hint()
-    }
-}
-
-/// Reverse outer iteration on a compressed matrix yields
-/// a tuple consisting of the outer index and of a sparse vector
-/// containing the associated inner dimension
-///
-/// Only the outer dimension iteration is reverted. If you wish to also
-/// revert the inner dimension, you should call rev() again when iterating
-/// the vector.
-impl<'iter, N: 'iter, I: 'iter + SpIndex, Iptr: 'iter + SpIndex>
-    DoubleEndedIterator for OuterIterator<'iter, N, I, Iptr>
-{
-    #[inline]
-    fn next_back(&mut self) -> Option<<Self as Iterator>::Item> {
-        match self.indptr_iter.next_back() {
-            None => None,
-            Some(window) => {
-                let inner_start = window[0].index_unchecked();
-                let inner_end = window[1].index_unchecked();
-                let indices = &self.indices[inner_start..inner_end];
-                let data = &self.data[inner_start..inner_end];
-                // CsMat invariants imply CsVec invariants
-                Some(CsVecBase {
-                    dim: self.inner_len,
-                    indices,
-                    data,
-                })
-            }
-        }
-    }
-}
-
-impl<'iter, N: 'iter, I: 'iter + SpIndex, Iptr: 'iter + SpIndex>
-    ExactSizeIterator for OuterIterator<'iter, N, I, Iptr>
-{
-    fn len(&self) -> usize {
-        self.indptr_iter.len()
-    }
-}
-
-pub struct CsIter<'a, N: 'a, I: 'a, Iptr: 'a = I> {
     storage: CompressedStorage,
     cur_outer: I,
-    indptr: &'a [Iptr],
+    indptr: crate::IndPtrView<'a, Iptr>,
     inner_iter: Enumerate<Zip<Iter<'a, I>, Iter<'a, N>>>,
 }
 
@@ -287,8 +113,10 @@ where
                 // is necessary because there can be several adjacent
                 // empty outer dimensions.
                 loop {
-                    let nnz_end =
-                        self.indptr[self.cur_outer.index_unchecked() + 1];
+                    let nnz_end = self
+                        .indptr
+                        .outer_inds_sz(self.cur_outer.index_unchecked())
+                        .end;
                     if nnz_index == nnz_end.index_unchecked() {
                         self.cur_outer += I::one();
                     } else {
@@ -349,7 +177,7 @@ where
                 storage,
                 nrows,
                 ncols,
-                indptr,
+                indptr: crate::IndPtrBase::new_trusted(indptr),
                 indices,
                 data,
             }),
@@ -415,7 +243,7 @@ where
                 storage,
                 nrows,
                 ncols,
-                indptr,
+                indptr: crate::IndPtrBase::new_trusted(indptr),
                 indices,
                 data,
             }),
@@ -616,7 +444,7 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
             storage,
             nrows: shape.0,
             ncols: shape.1,
-            indptr,
+            indptr: crate::IndPtr::new_trusted(indptr),
             indices,
             data,
         }
@@ -661,7 +489,7 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
             storage: CompressedStorage::CSR,
             nrows,
             ncols,
-            indptr,
+            indptr: crate::IndPtr::new_trusted(indptr),
             indices,
             data,
         }
@@ -715,9 +543,7 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
             CSR => self.nrows += 1,
             CSC => self.ncols += 1,
         }
-        let nnz = Iptr::from_usize(
-            self.indptr.last().unwrap().index_unchecked() + vec.nnz(),
-        );
+        let nnz = Iptr::from_usize(self.indptr.nnz() + vec.nnz());
         self.indptr.push(nnz);
         self
     }
@@ -748,7 +574,7 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
         let inner_ind_idx = I::from_usize(inner_ind);
         if outer_ind >= outer_dims {
             // we need to add a new outer dimension
-            let last_nnz = *self.indptr.last().unwrap(); // indptr never empty
+            let last_nnz = self.indptr.nnz_i();
             self.indptr.resize(outer_ind + 1, last_nnz);
             self.set_outer_dims(outer_ind + 1);
             self.indptr.push(last_nnz + Iptr::one());
@@ -756,23 +582,20 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
             self.data.push(val);
         } else {
             // we need to search for an insertion spot
-            let start = self.indptr[outer_ind].index_unchecked();
-            let stop = self.indptr[outer_ind + 1].index_unchecked();
+            let range = self.indptr.outer_inds_sz(outer_ind);
             let location =
-                self.indices[start..stop].binary_search(&inner_ind_idx);
+                self.indices[range.clone()].binary_search(&inner_ind_idx);
             match location {
                 Ok(ind) => {
-                    let ind = start + ind.index_unchecked();
+                    let ind = range.start + ind.index_unchecked();
                     self.data[ind] = val;
                     return;
                 }
                 Err(ind) => {
-                    let ind = start + ind.index_unchecked();
+                    let ind = range.start + ind.index_unchecked();
                     self.indices.insert(ind, inner_ind_idx);
                     self.data.insert(ind, val);
-                    for k in (outer_ind + 1)..=outer_dims {
-                        self.indptr[k] += Iptr::one();
-                    }
+                    self.indptr.record_new_element(outer_ind);
                 }
             }
         }
@@ -843,7 +666,7 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
             storage,
             nrows,
             ncols,
-            indptr,
+            indptr: crate::IndPtrView::new_trusted(indptr),
             indices: slice::from_raw_parts(indices, nnz),
             data: slice::from_raw_parts(data, nnz),
         }
@@ -857,24 +680,19 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
         i: usize,
         count: usize,
     ) -> CsMatViewI<'a, N, I, Iptr> {
-        if count == 0 {
-            panic!("Empty view");
-        }
         let iend = i.checked_add(count).unwrap();
-        if i >= self.outer_dims() || iend > self.outer_dims() {
-            panic!("Out of bounds index");
-        }
         let (nrows, ncols) = match self.storage {
             CSR => (count, self.cols()),
             CSC => (self.rows(), count),
         };
+        let data_range = self.indptr.outer_inds_slice(i, iend);
         CsMatViewI {
             storage: self.storage,
             nrows,
             ncols,
-            indptr: &self.indptr[i..=iend],
-            indices: &self.indices[..],
-            data: &self.data[..],
+            indptr: self.indptr.middle_slice(i, iend),
+            indices: &self.indices[data_range.clone()],
+            data: &self.data[data_range],
         }
     }
 
@@ -887,7 +705,7 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
         CsIter {
             storage: self.storage,
             cur_outer: I::zero(),
-            indptr: &self.indptr[..],
+            indptr: self.indptr.reborrow(),
             inner_iter: self.indices.iter().zip(self.data.iter()).enumerate(),
         }
     }
@@ -928,8 +746,7 @@ where
     /// This is often relevant for the complexity of most sparse matrix
     /// algorithms, which are often linear in the number of non-zeros.
     pub fn nnz(&self) -> usize {
-        self.indptr.last().unwrap().index_unchecked()
-            - self.indptr.first().unwrap().index_unchecked()
+        self.indptr.nnz()
     }
 
     /// The density of the sparse matrix, defined as the number of non-zero
@@ -983,14 +800,14 @@ where
     /// // get the element of row 3
     /// // there is only one element in this row, with a column index of 3
     /// // and a value of 1.
-    /// let loc = eye.indptr()[3];
-    /// assert_eq!(eye.indptr()[4], loc + 1);
-    /// assert_eq!(loc, 3);
-    /// assert_eq!(eye.indices()[loc], 3);
-    /// assert_eq!(eye.data()[loc], 1.);
+    /// let range = eye.indptr().outer_inds_sz(3);
+    /// assert_eq!(range.start, 3);
+    /// assert_eq!(range.end, 4);
+    /// assert_eq!(eye.indices()[range.start], 3);
+    /// assert_eq!(eye.data()[range.start], 1.);
     /// ```
-    pub fn indptr(&self) -> &[Iptr] {
-        &self.indptr[..]
+    pub fn indptr(&self) -> crate::IndPtrView<Iptr> {
+        crate::IndPtrView::new_trusted(self.indptr.raw_storage())
     }
 
     /// The inner dimension location for each non-zero value. See
@@ -1023,7 +840,7 @@ where
             data,
             ..
         } = self;
-        (indptr, indices, data)
+        (indptr.into_raw_storage(), indices, data)
     }
 
     /// Test whether the matrix is in CSC storage
@@ -1057,7 +874,7 @@ where
             storage: self.storage.other_storage(),
             nrows: self.ncols,
             ncols: self.nrows,
-            indptr: &self.indptr[..],
+            indptr: crate::IndPtrView::new_trusted(self.indptr.raw_storage()),
             indices: &self.indices[..],
             data: &self.data[..],
         }
@@ -1073,7 +890,7 @@ where
             storage: self.storage,
             nrows: self.nrows,
             ncols: self.ncols,
-            indptr: self.indptr.to_vec(),
+            indptr: self.indptr.to_owned(),
             indices: self.indices.to_vec(),
             data: self.data.to_vec(),
         }
@@ -1121,7 +938,7 @@ where
             storage: self.storage,
             nrows: self.rows(),
             ncols: self.cols(),
-            indptr,
+            indptr: crate::IndPtr::new_trusted(indptr),
             indices,
             data,
         }
@@ -1139,11 +956,13 @@ where
         I2: SpIndex,
         Iptr2: SpIndex,
     {
-        let indptr = self
-            .indptr
-            .iter()
-            .map(|i| Iptr2::from_usize(i.index_unchecked()))
-            .collect();
+        let indptr = crate::IndPtr::new_trusted(
+            self.indptr
+                .raw_storage()
+                .iter()
+                .map(|i| Iptr2::from_usize(i.index_unchecked()))
+                .collect(),
+        );
         let indices = self
             .indices
             .iter()
@@ -1166,7 +985,7 @@ where
             storage: self.storage,
             nrows: self.nrows,
             ncols: self.ncols,
-            indptr: &self.indptr[..],
+            indptr: crate::IndPtrView::new_trusted(self.indptr.raw_storage()),
             indices: &self.indices[..],
             data: &self.data[..],
         }
@@ -1188,7 +1007,7 @@ where
             storage: self.storage,
             nrows: self.nrows,
             ncols: self.ncols,
-            indptr: &self.indptr[..],
+            indptr: crate::IndPtrView::new_trusted(self.indptr.raw_storage()),
             indices: &self.indices[..],
             data: zst_data,
         }
@@ -1217,17 +1036,16 @@ where
     ///     assert_eq!(val, 1.);
     /// }
     /// ```
-    pub fn outer_iterator(&self) -> OuterIterator<N, I, Iptr> {
-        let inner_len = match self.storage {
-            CSR => self.ncols,
-            CSC => self.nrows,
-        };
-        OuterIterator {
-            inner_len,
-            indptr_iter: self.indptr.windows(2),
-            indices: &self.indices[..],
-            data: &self.data[..],
-        }
+    pub fn outer_iterator(
+        &self,
+    ) -> impl std::iter::DoubleEndedIterator<Item = CsVecViewI<N, I>>
+           + std::iter::ExactSizeIterator<Item = CsVecViewI<N, I>>
+           + '_ {
+        self.indptr.iter_outer_sz().map(move |range| CsVecViewI {
+            dim: self.inner_dims(),
+            indices: &self.indices[range.clone()],
+            data: &self.data[range],
+        })
     }
 
     /// Return an outer iterator over P*A*P^T, where it is necessary to use
@@ -1238,20 +1056,22 @@ where
     pub fn outer_iterator_papt<'a, 'perm: 'a>(
         &'a self,
         perm: PermViewI<'perm, I>,
-    ) -> OuterIteratorPerm<'a, 'perm, N, I, Iptr> {
-        let inner_len = match self.storage {
-            CSR => self.ncols,
-            CSC => self.nrows,
-        };
-        let n = self.indptr.len() - 1;
-        OuterIteratorPerm {
-            inner_len,
-            outer_ind_iter: (0..n),
-            indptr: &self.indptr[..],
-            indices: &self.indices[..],
-            data: &self.data[..],
-            perm,
-        }
+    ) -> impl std::iter::DoubleEndedIterator<Item = (usize, CsVecViewI<N, I>)>
+           + std::iter::ExactSizeIterator<Item = (usize, CsVecViewI<N, I>)>
+           + '_ {
+        (0..self.outer_dims()).into_iter().map(move |outer_ind| {
+            let outer_ind_perm = perm.at(outer_ind);
+            let range = self.indptr.outer_inds_sz(outer_ind_perm);
+            let indices = &self.indices[range.clone()];
+            let data = &self.data[range];
+            // CsMat invariants imply CsVec invariants
+            let vec = CsVecBase {
+                dim: self.inner_dims(),
+                indices,
+                data,
+            };
+            (outer_ind_perm, vec)
+        })
     }
 
     /// Get the max number of nnz for each outer dim
@@ -1290,34 +1110,34 @@ where
         if i >= self.outer_dims() {
             return None;
         }
-        let start = self.indptr[i].index_unchecked();
-        let stop = self.indptr[i + 1].index_unchecked();
+        let range = self.indptr.outer_inds_sz(i);
         // CsMat invariants imply CsVec invariants
         Some(CsVecBase {
             dim: self.inner_dims(),
-            indices: &self.indices[start..stop],
-            data: &self.data[start..stop],
+            indices: &self.indices[range.clone()],
+            data: &self.data[range],
         })
     }
 
     /// Iteration on outer blocks of size block_size
+    ///
+    /// # Panics
+    ///
+    /// If the block size is 0.
     pub fn outer_block_iter(
         &self,
         block_size: usize,
-    ) -> ChunkOuterBlocks<N, I, Iptr> {
-        let m = CsMatBase {
-            storage: self.storage,
-            nrows: self.rows(),
-            ncols: self.cols(),
-            indptr: &self.indptr[..],
-            indices: &self.indices[..],
-            data: &self.data[..],
-        };
-        ChunkOuterBlocks {
-            mat: m,
-            dims_in_bloc: block_size,
-            bloc_count: 0,
-        }
+    ) -> impl std::iter::DoubleEndedIterator<Item = CsMatViewI<N, I, Iptr>>
+           + std::iter::ExactSizeIterator<Item = CsMatViewI<N, I, Iptr>>
+           + '_ {
+        (0..self.outer_dims()).step_by(block_size).map(move |i| {
+            let count = if i + block_size > self.outer_dims() {
+                self.outer_dims() - i
+            } else {
+                block_size
+            };
+            self.view().middle_outer_views(i, count)
+        })
     }
 
     /// Return a new sparse matrix with the same sparsity pattern, with all non-zero values mapped by the function `f`.
@@ -1331,7 +1151,7 @@ where
             storage: self.storage,
             nrows: self.nrows,
             ncols: self.ncols,
-            indptr: self.indptr.to_vec(),
+            indptr: self.indptr.to_owned(),
             indices: self.indices.to_vec(),
             data,
         }
@@ -1379,7 +1199,7 @@ where
         if outer_ind >= self.outer_dims() {
             return None;
         }
-        let offset = self.indptr[outer_ind].index_unchecked();
+        let offset = self.indptr.outer_inds_sz(outer_ind).start;
         self.outer_view(outer_ind)
             .and_then(|vec| vec.nnz_index(inner_ind))
             .map(|vec::NnzIndex(ind)| NnzIndex(ind + offset))
@@ -1407,7 +1227,7 @@ where
         utils::check_compressed_structure(
             inner,
             outer,
-            &self.indptr,
+            self.indptr.raw_storage(),
             &self.indices,
         )
     }
@@ -1418,7 +1238,7 @@ where
         CsIter {
             storage: self.storage,
             cur_outer: I::zero(),
-            indptr: &self.indptr[..],
+            indptr: crate::IndPtrView::new_trusted(self.indptr.raw_storage()),
             inner_iter: self.indices.iter().zip(self.data.iter()).enumerate(),
         }
     }
@@ -1454,7 +1274,7 @@ where
             storage: self.storage().other_storage(),
             nrows: self.nrows,
             ncols: self.ncols,
-            indptr,
+            indptr: crate::IndPtr::new_trusted(indptr),
             indices,
             data,
         }
@@ -1554,13 +1374,12 @@ where
         if i >= self.outer_dims() {
             return None;
         }
-        let start = self.indptr[i].index_unchecked();
-        let stop = self.indptr[i + 1].index_unchecked();
+        let range = self.indptr.outer_inds_sz(i);
         // CsMat invariants imply CsVec invariants
         Some(CsVecBase {
             dim: self.inner_dims(),
-            indices: &self.indices[start..stop],
-            data: &mut self.data[start..stop],
+            indices: &self.indices[range.clone()],
+            data: &mut self.data[range],
         })
     }
 
@@ -1631,17 +1450,24 @@ where
     /// This iterator yields mutable sparse vector views for each outer
     /// dimension. Only the non-zero values can be modified, the
     /// structure is kept immutable.
-    pub fn outer_iterator_mut(&mut self) -> OuterIteratorMut<N, I, Iptr> {
-        let inner_len = match self.storage {
-            CSR => self.ncols,
-            CSC => self.nrows,
-        };
-        OuterIteratorMut {
-            inner_len,
-            indptr_iter: self.indptr.windows(2),
-            indices: &self.indices[..],
-            data: &mut self.data[..],
-        }
+    pub fn outer_iterator_mut(
+        &mut self,
+    ) -> impl std::iter::DoubleEndedIterator<Item = CsVecViewMutI<N, I>>
+           + std::iter::ExactSizeIterator<Item = CsVecViewMutI<N, I>>
+           + '_ {
+        let inner_dim = self.inner_dims();
+        let indices = &self.indices[..];
+        let mut data = &mut self.data[..];
+        self.indptr.iter_outer_sz().map(move |range| {
+            let tmp = mem::replace(&mut data, &mut []);
+            let (yield_data, next) = tmp.split_at_mut(range.end - range.start);
+            data = next;
+            CsVecViewMutI {
+                dim: inner_dim,
+                indices: &indices[range.clone()],
+                data: yield_data,
+            }
+        })
     }
 }
 
@@ -1692,7 +1518,7 @@ where
         F: FnMut(&mut [Iptr], &mut [I], &mut [N]),
     {
         f(
-            &mut self.indptr[..],
+            self.indptr.raw_storage_mut(),
             &mut self.indices[..],
             &mut self.data[..],
         );
@@ -1833,9 +1659,9 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
             storage,
             nrows,
             ncols,
-            indptr: Array2 {
+            indptr: crate::IndPtrBase::new_trusted(Array2 {
                 data: [indptr[0], indptr[1]],
-            },
+            }),
             indices: slice::from_raw_parts(indices, nnz),
             data: slice::from_raw_parts(data, nnz),
         }
@@ -2383,37 +2209,6 @@ where
     }
 }
 
-/// An iterator over non-overlapping blocks of a matrix,
-/// along the least-varying dimension
-pub struct ChunkOuterBlocks<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex = I>
-{
-    mat: CsMatViewI<'a, N, I, Iptr>,
-    dims_in_bloc: usize,
-    bloc_count: usize,
-}
-
-impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex> Iterator
-    for ChunkOuterBlocks<'a, N, I, Iptr>
-{
-    type Item = CsMatViewI<'a, N, I, Iptr>;
-    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        let cur_dim = self.dims_in_bloc * self.bloc_count;
-        let end_dim = self.dims_in_bloc + cur_dim;
-        let count = if self.dims_in_bloc == 0 {
-            return None;
-        } else if end_dim > self.mat.outer_dims() {
-            let count = self.mat.outer_dims() - cur_dim;
-            self.dims_in_bloc = 0;
-            count
-        } else {
-            self.dims_in_bloc
-        };
-        let view = self.mat.middle_outer_views(cur_dim, count);
-        self.bloc_count += 1;
-        Some(view)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::CompressedStorage::{CSC, CSR};
@@ -2928,7 +2723,7 @@ mod test {
     fn convert_types() {
         let mat: CsMat<f32> = CsMat::eye(3);
         let mat_: CsMatI<f64, u32> = mat.to_other_types();
-        assert_eq!(mat_.indptr(), &[0, 1, 2, 3]);
+        assert_eq!(mat_.indptr().raw_storage(), &[0, 1, 2, 3]);
 
         let mat = CsMatI::new_csc(
             (3, 3),
@@ -2937,7 +2732,7 @@ mod test {
             vec![1.; 4],
         );
         let mat_: CsMatI<f32, usize, u32> = mat.to_other_types();
-        assert_eq!(mat_.indptr(), &[0, 1, 3, 4]);
+        assert_eq!(mat_.indptr().raw_storage(), &[0, 1, 3, 4]);
         assert_eq!(mat_.data(), &[1.0f32, 1., 1., 1.]);
     }
 

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -297,12 +297,10 @@ where
     /// actual storage type
     pub fn nnz_i(&self) -> Iptr {
         let offset = self.offset();
+        let zero = Iptr::zero();
         // index_unchecked validity: structure checks ensure that the last index
         // larger than the first, and that both can be represented as an usize
-        self.storage
-            .last()
-            .map(|i| *i - offset)
-            .unwrap_or(Iptr::zero())
+        self.storage.last().map(|i| *i - offset).unwrap_or(zero)
     }
 }
 

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -159,6 +159,31 @@ where
         }
     }
 
+    /// Returns a proper indptr representation, cloning if we do not have
+    /// a proper indptr, and a pointer to this proper representation for use
+    /// in ffi. The returned pointer has thus the same lifetime as the
+    /// proper representation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mat: sprs::CsMat<f64> = sprs::CsMat::eye(5);
+    /// let mid = mat.view().middle_outer_views(1, 2);
+    /// let (_indptr_proper_owned, ptr) = mid.indptr().to_proper_ffi();
+    /// println!(
+    ///     "ptr {:?} is valid as long as _indptr_proper_owned is in scope",
+    ///     ptr
+    /// );
+    /// unsafe {
+    ///     assert_eq!(*ptr, 0)
+    /// };
+    /// ```
+    pub fn to_proper_ffi(&self) -> (std::borrow::Cow<[Iptr]>, *const Iptr) {
+        let proper = self.to_proper();
+        let ptr = proper.as_ptr();
+        (proper, ptr)
+    }
+
     fn offset(&self) -> Iptr {
         let zero = Iptr::zero();
         self.storage.get(0).cloned().unwrap_or(zero)

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -1,0 +1,66 @@
+//! This module defines the behavior of types suitable to be used
+//! as `indptr` storage in a [`CsMatBase`].
+///
+/// [`CsMatBase`]: type.CsMatBase.html
+use crate::indexing::SpIndex;
+
+/// Iterator type for types implementing `IndPtrStorage`. Since the language
+/// does not allow `impl Iterator` in traits yet, we have to use a concrete
+/// type.
+pub enum IptrIter<'a, Iptr> {
+    Trivial(std::slice::Windows<'a, Iptr>),
+    Offset(Iptr, std::slice::Windows<'a, Iptr>),
+}
+
+impl<'a, Iptr: SpIndex> Iterator for IptrIter<'a, Iptr> {
+    type Item = (Iptr, Iptr);
+
+    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
+        match self {
+            IptrIter::Trivial(iter) => iter.next().map(|x| (x[0], x[1])),
+            IptrIter::Offset(offset, iter) => {
+                iter.next().map(|x| (x[0] + *offset, x[1] + *offset))
+            }
+        }
+    }
+}
+
+/// Index Pointer Storage specification.
+///
+/// A type implementing this trait can be used in sparse matrix algorithms in
+/// the CSR or CSC format.
+pub trait IndPtrStorage<Iptr: SpIndex> {
+    /// The length of the index pointer storage.
+    fn len(&self) -> usize;
+
+    /// Access the index pointer element at location `i`. Returns `None`
+    /// if `i >= self.len()`.
+    fn get(&self, i: usize) -> Option<Iptr>;
+
+    /// Access the index pointer element at location `i`.
+    ///
+    /// # Panics
+    ///
+    /// If `i >= self.len()`
+    fn at(&self, i: usize) -> Iptr {
+        <Self as IndPtrStorage<Iptr>>::get(self, i).unwrap()
+    }
+
+    /// Iterate over elements in the index pointer storage
+    fn iter(&self) -> IptrIter<Iptr>;
+}
+
+impl<'a, Iptr: SpIndex> IndPtrStorage<Iptr> for &'a [Iptr] {
+    fn len(&self) -> usize {
+        <[Iptr]>::len(self)
+    }
+
+    fn get(&self, i: usize) -> Option<Iptr> {
+        <[Iptr]>::get(self, i).map(|x| *x)
+    }
+
+    /// Iterate over elements in the index pointer storage
+    fn iter(&self) -> IptrIter<Iptr> {
+        IptrIter::Trivial(self.windows(2))
+    }
+}

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -97,7 +97,7 @@ where
     /// Return a view on the underlying slice if it is a proper `indptr` slice,
     /// which is the case if its first element is 0. `None` will be returned
     /// otherwise.
-    pub fn slice(&self) -> Option<&[Iptr]> {
+    pub fn as_slice(&self) -> Option<&[Iptr]> {
         if self.is_proper() {
             Some(&self.storage[..])
         } else {

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -112,6 +112,18 @@ where
         &self.storage[..]
     }
 
+    /// Returns a proper indptr representation, cloning if we do not have
+    /// a proper indptr.
+    pub fn to_proper(&self) -> std::borrow::Cow<[Iptr]> {
+        if self.is_proper() {
+            std::borrow::Cow::Borrowed(&self.storage[..])
+        } else {
+            let offset = self.offset();
+            let proper = self.storage.iter().map(|i| *i - offset).collect();
+            std::borrow::Cow::Owned(proper)
+        }
+    }
+
     fn offset(&self) -> Iptr {
         let zero = Iptr::zero();
         self.storage.get(0).cloned().unwrap_or(zero)

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -1,66 +1,157 @@
 //! This module defines the behavior of types suitable to be used
 //! as `indptr` storage in a [`CsMatBase`].
-///
-/// [`CsMatBase`]: type.CsMatBase.html
-use crate::indexing::SpIndex;
+//!
+//! [`CsMatBase`]: type.CsMatBase.html
 
-/// Iterator type for types implementing `IndPtrStorage`. Since the language
-/// does not allow `impl Iterator` in traits yet, we have to use a concrete
-/// type.
-pub enum IptrIter<'a, Iptr> {
-    Trivial(std::slice::Windows<'a, Iptr>),
-    Offset(Iptr, std::slice::Windows<'a, Iptr>),
+use crate::errors::SprsError;
+use crate::indexing::SpIndex;
+use std::ops::Deref;
+
+pub struct IndPtr<Iptr, Storage>
+where
+    Iptr: SpIndex,
+    Storage: Deref<Target = [Iptr]>,
+{
+    storage: Storage,
 }
 
-impl<'a, Iptr: SpIndex> Iterator for IptrIter<'a, Iptr> {
-    type Item = (Iptr, Iptr);
-
-    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        match self {
-            IptrIter::Trivial(iter) => iter.next().map(|x| (x[0], x[1])),
-            IptrIter::Offset(offset, iter) => {
-                iter.next().map(|x| (x[0] + *offset, x[1] + *offset))
+impl<Iptr, Storage> IndPtr<Iptr, Storage>
+where
+    Iptr: SpIndex,
+    Storage: Deref<Target = [Iptr]>,
+{
+    pub(crate) fn check_structure(storage: &Storage) -> Result<(), SprsError> {
+        for i in storage.iter() {
+            if i.try_index().is_none() {
+                return Err(SprsError::IllegalArguments(
+                    "Indptr value out of range of usize",
+                ));
             }
         }
+        if !storage
+            .windows(2)
+            .all(|x| x[0].index_unchecked() <= x[1].index_unchecked())
+        {
+            return Err(SprsError::UnsortedIndptr);
+        }
+        if storage
+            .last()
+            .cloned()
+            .map(Iptr::index_unchecked)
+            .map(|i| i > usize::max_value() / 2)
+            .unwrap_or(false)
+        {
+            // We do not allow indptr values to be larger than half
+            // the maximum value of an usize, as that would clearly exhaust
+            // all available memory
+            // This means we could have an isize, but in practice it's
+            // easier to work with usize for indexing.
+            return Err(SprsError::IllegalArguments(
+                "An indptr value is larger than allowed",
+            ));
+        }
+        Ok(())
     }
-}
 
-/// Index Pointer Storage specification.
-///
-/// A type implementing this trait can be used in sparse matrix algorithms in
-/// the CSR or CSC format.
-pub trait IndPtrStorage<Iptr: SpIndex> {
-    /// The length of the index pointer storage.
-    fn len(&self) -> usize;
+    pub fn new(storage: Storage) -> Result<Self, crate::errors::SprsError> {
+        IndPtr::check_structure(&storage).map(|_| IndPtr::new_trusted(storage))
+    }
 
-    /// Access the index pointer element at location `i`. Returns `None`
-    /// if `i >= self.len()`.
-    fn get(&self, i: usize) -> Option<Iptr>;
+    pub(crate) fn new_trusted(storage: Storage) -> Self {
+        IndPtr { storage }
+    }
 
-    /// Access the index pointer element at location `i`.
+    /// The length of the underlying storage
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    /// The number of outer dimensions this indptr represents
+    pub fn outer_dims(&self) -> usize {
+        if self.storage.len() >= 1 {
+            self.storage.len() - 1
+        } else {
+            0
+        }
+    }
+
+    /// Indicates whether the underlying storage is proper, which means the
+    /// indptr corresponds to a non-sliced matrix.
+    ///
+    /// An empty matrix is considered non-proper.
+    pub fn is_proper(&self) -> bool {
+        self.storage
+            .get(0)
+            .map(|i| *i == Iptr::zero())
+            .unwrap_or(false)
+    }
+
+    /// Return a view on the underlying slice if it is a proper `indptr` slice,
+    /// which is the case if its first element is 0. `None` will be returned
+    /// otherwise.
+    pub fn slice(&self) -> Option<&[Iptr]> {
+        if self.is_proper() {
+            Some(&self.storage[..])
+        } else {
+            None
+        }
+    }
+
+    /// Return a view of the underlying storage. Should be used with care in
+    /// sparse algorithms, as this won't check if the storage corresponds to a
+    /// proper matrix
+    pub fn raw_storage(&self) -> &[Iptr] {
+        &self.storage[..]
+    }
+
+    fn offset(&self) -> Iptr {
+        self.storage.get(0).cloned().unwrap_or(Iptr::zero())
+    }
+
+    /// Iterate over outer dimensions, yielding start and end indices for each
+    /// outer dimension.
+    pub fn iter_outer(
+        &self,
+    ) -> impl std::iter::DoubleEndedIterator<Item = (Iptr, Iptr)>
+           + std::iter::DoubleEndedIterator<Item = (Iptr, Iptr)>
+           + '_ {
+        let offset = self.offset();
+        self.storage.windows(2).map(move |x| {
+            if offset == Iptr::zero() {
+                (x[0], x[1])
+            } else {
+                (x[0] - offset, x[1] - offset)
+            }
+        })
+    }
+
+    /// Return the value of the indptr at index i. This method is intended for
+    /// low-level usage only, `outer_inds` should be preferred most of the time
+    pub fn index(&self, i: usize) -> Iptr {
+        let offset = self.offset();
+        self.storage[i] - offset
+    }
+
+    /// Get the start and end indices for the requested outer dimension
     ///
     /// # Panics
     ///
-    /// If `i >= self.len()`
-    fn at(&self, i: usize) -> Iptr {
-        <Self as IndPtrStorage<Iptr>>::get(self, i).unwrap()
+    /// If `i >= self.outer_dims()`
+    pub fn outer_inds(&self, i: usize) -> (Iptr, Iptr) {
+        assert!(i + 1 < self.storage.len());
+        let offset = self.offset();
+        (self.storage[i] - offset, self.storage[i + 1] - offset)
     }
 
-    /// Iterate over elements in the index pointer storage
-    fn iter(&self) -> IptrIter<Iptr>;
-}
-
-impl<'a, Iptr: SpIndex> IndPtrStorage<Iptr> for &'a [Iptr] {
-    fn len(&self) -> usize {
-        <[Iptr]>::len(self)
-    }
-
-    fn get(&self, i: usize) -> Option<Iptr> {
-        <[Iptr]>::get(self, i).map(|x| *x)
-    }
-
-    /// Iterate over elements in the index pointer storage
-    fn iter(&self) -> IptrIter<Iptr> {
-        IptrIter::Trivial(self.windows(2))
+    /// The number of nonzero elements described by this indptr
+    pub fn nnz(&self) -> usize {
+        let offset = self.offset();
+        // index_unchecked validity: structure checks ensure that the last index
+        // larger than the first, and that both can be represented as an usize
+        self.storage
+            .last()
+            .map(|i| *i - offset)
+            .map(Iptr::index_unchecked)
+            .unwrap_or(0)
     }
 }

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -5,10 +5,13 @@
 
 use crate::errors::SprsError;
 use crate::indexing::SpIndex;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::ops::Range;
 use std::ops::{Deref, DerefMut};
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IndPtrBase<Iptr, Storage>
 where
     Iptr: SpIndex,

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -66,6 +66,14 @@ where
         self.storage.len()
     }
 
+    /// Tests whether this indptr is empty
+    pub fn is_empty(&self) -> bool {
+        // An indptr of len 1 is nonsensical, we should treat that as empty
+        // but fail on debug
+        debug_assert!(self.storage.len() != 1);
+        self.storage.len() <= 1
+    }
+
     /// The number of outer dimensions this indptr represents
     pub fn outer_dims(&self) -> usize {
         if self.storage.len() >= 1 {
@@ -105,7 +113,8 @@ where
     }
 
     fn offset(&self) -> Iptr {
-        self.storage.get(0).cloned().unwrap_or(Iptr::zero())
+        let zero = Iptr::zero();
+        self.storage.get(0).cloned().unwrap_or(zero)
     }
 
     /// Iterate over outer dimensions, yielding start and end indices for each

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -304,9 +304,7 @@ where
     indptr.push(nnz);
     let mut tmp = Vec::with_capacity(mat.max_outer_nnz());
     for in_outer in p {
-        let nnz_in_outer =
-            mat.indptr()[in_outer.index() + 1] - mat.indptr()[in_outer.index()];
-        nnz += nnz_in_outer;
+        nnz += mat.indptr().nnz_in_outer(in_outer.index());
         indptr.push(nnz);
         tmp.clear();
         let outer = mat.outer_view(in_outer.index()).unwrap();

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -4,6 +4,7 @@
 use crate::indexing::SpIndex;
 use crate::sparse::prelude::*;
 use crate::sparse::CompressedStorage::CSR;
+use crate::IndPtrView;
 use num_traits::Num;
 #[cfg(feature = "multi_thread")]
 use rayon::prelude::*;
@@ -80,10 +81,10 @@ pub fn thread_threading_strategy() -> ThreadingStrategy {
 /// to have reserved at least this amount of memory.
 #[allow(clippy::too_many_arguments)]
 pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
-    a_indptr: &[Iptr],
+    a_indptr: IndPtrView<Iptr>,
     a_indices: &[I],
     b_cols: usize,
-    b_indptr: &[Iptr],
+    b_indptr: IndPtrView<Iptr>,
     b_indices: &[I],
     c_indptr: &mut [Iptr],
     // TODO look for litterature on the nnz of C to be able to have a slice here
@@ -93,8 +94,8 @@ pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
     assert!(a_indptr.len() == c_indptr.len());
     let a_rows = a_indptr.len() - 1;
     let b_rows = b_indptr.len() - 1;
-    let a_nnz = a_indptr[a_rows].index();
-    let b_nnz = b_indptr[b_rows].index();
+    let a_nnz = a_indptr.nnz();
+    let b_nnz = b_indptr.nnz();
     c_indices.clear();
     c_indices.reserve_exact(a_nnz + b_nnz);
 
@@ -105,16 +106,13 @@ pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
     }
 
     c_indptr[0] = Iptr::from_usize(0);
-    for a_row in 0..a_rows {
+    for (a_row, a_range) in a_indptr.iter_outer_sz().enumerate() {
         let mut length = 0;
 
-        let a_start = a_indptr[a_row].index();
-        let a_stop = a_indptr[a_row + 1].index();
-        for &a_col in &a_indices[a_start..a_stop] {
+        for &a_col in &a_indices[a_range] {
             let b_row = a_col.index();
-            let b_start = b_indptr[b_row].index();
-            let b_stop = b_indptr[b_row + 1].index();
-            for b_col in &b_indices[b_start..b_stop] {
+            let b_range = b_indptr.outer_inds_sz(b_row);
+            for b_col in &b_indices[b_range] {
                 let b_col = b_col.index();
                 if !seen[b_col] {
                     seen[b_col] = true;
@@ -159,10 +157,10 @@ pub fn numeric<
     I: SpIndex,
     N: Num + Copy + std::ops::AddAssign,
 >(
-    a_indptr: &[Iptr],
+    a_indptr: IndPtrView<Iptr>,
     a_indices: &[I],
     a_data: &[N],
-    b_indptr: &[Iptr],
+    b_indptr: IndPtrView<Iptr>,
     b_indices: &[I],
     b_data: &[N],
     c_indptr: &[Iptr],
@@ -171,24 +169,19 @@ pub fn numeric<
     tmp: &mut [N],
 ) {
     assert!(a_indptr.len() == c_indptr.len());
-    let a_rows = a_indptr.len() - 1;
-    let b_rows = b_indptr.len() - 1;
-    assert!(b_indices.len() == b_indptr[b_rows].index());
-    assert!(b_data.len() == b_indptr[b_rows].index());
+    assert!(b_indices.len() == b_indptr.nnz());
+    assert!(b_data.len() == b_indptr.nnz());
 
     for elt in tmp.iter_mut() {
         *elt = N::zero();
     }
-    for a_row in 0..a_rows {
-        let a_start = a_indptr[a_row].index();
-        let a_stop = a_indptr[a_row + 1].index();
-        for a_cur in a_start..a_stop {
+    for (a_row, a_range) in a_indptr.iter_outer_sz().enumerate() {
+        for a_cur in a_range {
             let a_col = a_indices[a_cur].index();
             let a_val = a_data[a_cur];
             let b_row = a_col;
-            let b_start = b_indptr[b_row].index();
-            let b_stop = b_indptr[b_row + 1].index();
-            for b_cur in b_start..b_stop {
+            let b_range = b_indptr.outer_inds_sz(b_row);
+            for b_cur in b_range {
                 let b_col = b_indices[b_cur].index();
                 let b_val = b_data[b_cur];
                 tmp[b_col] += a_val * b_val;
@@ -297,7 +290,7 @@ where
     let nb_threads = seens.len();
     assert!(nb_threads > 0);
     let chunk_size = lhs.indptr().len() / nb_threads;
-    let mut lhs_indptr_chunks = Vec::with_capacity(nb_threads);
+    let mut lhs_chunks = Vec::with_capacity(nb_threads);
     let mut res_indptr_chunks = Vec::with_capacity(nb_threads);
     let mut res_indices_chunks = Vec::with_capacity(nb_threads);
     for chunk_id in 0..nb_threads {
@@ -307,35 +300,35 @@ where
             chunk_id * chunk_size
         };
         let stop = if chunk_id + 1 < nb_threads {
-            (chunk_id + 1) * chunk_size + 1
+            (chunk_id + 1) * chunk_size
         } else {
-            indptr_len
+            l_rows
         };
-        lhs_indptr_chunks.push(&lhs.indptr()[start..stop]);
-        res_indptr_chunks.push(vec![Iptr::zero(); stop - start]);
+        lhs_chunks.push(lhs.middle_outer_views(start, stop - start));
+        res_indptr_chunks.push(vec![Iptr::zero(); stop - start + 1]);
         res_indices_chunks
             .push(Vec::with_capacity(lhs.nnz() + rhs.nnz() / chunk_size));
     }
     #[cfg(feature = "multi_thread")]
-    let iter = lhs_indptr_chunks
+    let iter = lhs_chunks
         .par_iter()
         .zip(res_indptr_chunks.par_iter_mut())
         .zip(res_indices_chunks.par_iter_mut())
         .zip(seens.par_iter_mut());
     #[cfg(not(feature = "multi_thread"))]
-    let iter = lhs_indptr_chunks
+    let iter = lhs_chunks
         .iter()
         .zip(res_indptr_chunks.iter_mut())
         .zip(res_indices_chunks.iter_mut())
         .zip(seens.iter_mut());
     iter.for_each(
         |(
-            ((lhs_indptr_chunk, mut res_indptr_chunk), mut res_indices_chunk),
+            ((lhs_chunk, mut res_indptr_chunk), mut res_indices_chunk),
             mut seen,
         )| {
             symbolic(
-                lhs_indptr_chunk,
-                lhs.indices(),
+                lhs_chunk.indptr(),
+                lhs_chunk.indices(),
                 r_cols,
                 rhs.indptr(),
                 rhs.indices(),
@@ -366,14 +359,15 @@ where
     let mut prev_nnz = 0;
     let mut split_nnz = 0;
     let mut split_row = 0;
-    let mut lhs_indptr_chunks = Vec::with_capacity(nb_threads);
+    let mut lhs_chunks = Vec::with_capacity(nb_threads);
     let mut res_indptr_chunks = Vec::with_capacity(nb_threads);
     let mut res_indices_chunks = Vec::with_capacity(nb_threads);
     let mut res_data_chunks = Vec::with_capacity(nb_threads);
     for (row, nnz) in res_indptr.iter().enumerate() {
         let nnz = nnz.index();
         if nnz - split_nnz > chunk_size && row > 0 {
-            lhs_indptr_chunks.push(&lhs.indptr()[split_row..row]);
+            lhs_chunks
+                .push(lhs.middle_outer_views(split_row, row - 1 - split_row));
 
             res_indptr_chunks.push(&res_indptr[split_row..row]);
 
@@ -392,19 +386,19 @@ where
         }
         prev_nnz = nnz;
     }
-    lhs_indptr_chunks.push(&lhs.indptr()[split_row..]);
+    lhs_chunks.push(lhs.middle_outer_views(split_row, lhs.rows() - split_row));
     res_indptr_chunks.push(&res_indptr[split_row..]);
     res_indices_chunks.push(res_indices_rem);
     res_data_chunks.push(res_data_rem);
     #[cfg(feature = "multi_thread")]
-    let iter = lhs_indptr_chunks
+    let iter = lhs_chunks
         .par_iter()
         .zip(res_indptr_chunks.par_iter())
         .zip(res_indices_chunks.par_iter())
         .zip(res_data_chunks.par_iter_mut())
         .zip(tmps.par_iter_mut());
     #[cfg(not(feature = "multi_thread"))]
-    let iter = lhs_indptr_chunks
+    let iter = lhs_chunks
         .iter()
         .zip(res_indptr_chunks.iter())
         .zip(res_indices_chunks.iter())
@@ -413,15 +407,15 @@ where
     iter.for_each(
         |(
             (
-                ((lhs_indptr_chunk, res_indptr_chunk), res_indices_chunk),
+                ((lhs_chunk, res_indptr_chunk), res_indices_chunk),
                 res_data_chunk,
             ),
             tmp,
         )| {
             numeric(
-                lhs_indptr_chunk,
-                lhs.indices(),
-                lhs.data(),
+                lhs_chunk.indptr(),
+                lhs_chunk.indices(),
+                lhs_chunk.data(),
                 rhs.indptr(),
                 rhs.indices(),
                 rhs.data(),
@@ -496,7 +490,7 @@ mod test {
             &mut c_data,
             &mut tmp,
         );
-        assert_eq!(exp.indptr(), c_indptr);
+        assert_eq!(exp.indptr().raw_storage(), c_indptr);
         assert_eq!(exp.indices(), &c_indices[..]);
         assert_eq!(exp.data(), &c_data[..]);
     }

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -568,12 +568,12 @@ mod test {
         // regression test for https://github.com/vbarrielle/sprs/issues/170
         let tri_mat = TriMatI::new((2, 4));
         let m: CsMat<u64> = tri_mat.to_csr();
-        assert_eq!(m.indptr(), &[0, 0, 0]);
+        assert_eq!(m.indptr().raw_storage(), &[0, 0, 0]);
         assert_eq!(m.indices(), &[]);
         assert_eq!(m.data(), &[]);
 
         let m: CsMat<u64> = tri_mat.to_csc();
-        assert_eq!(m.indptr(), &[0, 0, 0, 0, 0]);
+        assert_eq!(m.indptr().raw_storage(), &[0, 0, 0, 0, 0]);
         assert_eq!(m.indices(), &[]);
         assert_eq!(m.data(), &[]);
 
@@ -631,7 +631,7 @@ mod test {
         triplet_mat.add_triplet(0, 3, 2);
 
         let m = triplet_mat.to_csc();
-        assert_eq!(m.indptr(), &[0, 0, 1, 1, 2, 2, 2]);
+        assert_eq!(m.indptr().raw_storage(), &[0, 0, 1, 1, 2, 2, 2]);
         assert_eq!(m.indices(), &[1, 0]);
         assert_eq!(m.data(), &[1, 2]);
     }

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -214,7 +214,7 @@ where
             storage,
             nrows: self.rows,
             ncols: self.cols,
-            indptr,
+            indptr: crate::IndPtr::new_trusted(indptr),
             indices,
             data,
         }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -782,7 +782,7 @@ where
             storage: CSR,
             nrows: 1,
             ncols: self.dim,
-            indptr,
+            indptr: crate::IndPtrBase::new_trusted(indptr),
             indices: &self.indices[..],
             data: &self.data[..],
         }
@@ -802,7 +802,7 @@ where
             storage: CSC,
             nrows: self.dim,
             ncols: 1,
-            indptr,
+            indptr: crate::IndPtrBase::new_trusted(indptr),
             indices: &self.indices[..],
             data: &self.data[..],
         }

--- a/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
+++ b/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
@@ -38,11 +38,10 @@ where
             mat.to_other_types();
         let mut perm: Vec<SuiteSparseInt> = vec![0; n];
         let camd_res = unsafe {
-            let indptr = mat.indptr();
-            let indptr_proper = indptr.to_proper();
+            let (_indptr_proper, indptr_ptr) = mat.indptr().to_proper_ffi();
             camd_order(
                 n as SuiteSparseInt,
-                indptr_proper.as_ptr(),
+                indptr_ptr,
                 mat.indices().as_ptr(),
                 perm.as_mut_ptr(),
                 control.as_mut_ptr(),
@@ -58,11 +57,10 @@ where
             mat.to_other_types();
         let mut perm: Vec<SuiteSparseLong> = vec![0; n];
         let camd_res = unsafe {
-            let indptr = mat.indptr();
-            let indptr_proper = indptr.to_proper();
+            let (_indptr_proper, indptr_ptr) = mat.indptr().to_proper_ffi();
             camd_l_order(
                 n as SuiteSparseLong,
-                indptr_proper.as_ptr(),
+                indptr_ptr,
                 mat.indices().as_ptr(),
                 perm.as_mut_ptr(),
                 control.as_mut_ptr(),

--- a/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
+++ b/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
@@ -38,9 +38,11 @@ where
             mat.to_other_types();
         let mut perm: Vec<SuiteSparseInt> = vec![0; n];
         let camd_res = unsafe {
+            let indptr = mat.indptr();
+            let indptr_proper = indptr.to_proper();
             camd_order(
                 n as SuiteSparseInt,
-                mat.indptr().as_ptr(),
+                indptr_proper.as_ptr(),
                 mat.indices().as_ptr(),
                 perm.as_mut_ptr(),
                 control.as_mut_ptr(),
@@ -56,9 +58,11 @@ where
             mat.to_other_types();
         let mut perm: Vec<SuiteSparseLong> = vec![0; n];
         let camd_res = unsafe {
+            let indptr = mat.indptr();
+            let indptr_proper = indptr.to_proper();
             camd_l_order(
                 n as SuiteSparseLong,
-                mat.indptr().as_ptr(),
+                indptr_proper.as_ptr(),
                 mat.indices().as_ptr(),
                 perm.as_mut_ptr(),
                 control.as_mut_ptr(),

--- a/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
+++ b/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
@@ -38,10 +38,10 @@ where
             mat.to_other_types();
         let mut perm: Vec<SuiteSparseInt> = vec![0; n];
         let camd_res = unsafe {
-            let (_indptr_proper, indptr_ptr) = mat.indptr().to_proper_ffi();
+            let indptr_proper = mat.proper_indptr();
             camd_order(
                 n as SuiteSparseInt,
-                indptr_ptr,
+                indptr_proper.as_ptr(),
                 mat.indices().as_ptr(),
                 perm.as_mut_ptr(),
                 control.as_mut_ptr(),
@@ -57,10 +57,10 @@ where
             mat.to_other_types();
         let mut perm: Vec<SuiteSparseLong> = vec![0; n];
         let camd_res = unsafe {
-            let (_indptr_proper, indptr_ptr) = mat.indptr().to_proper_ffi();
+            let indptr_proper = mat.proper_indptr();
             camd_l_order(
                 n as SuiteSparseLong,
-                indptr_ptr,
+                indptr_proper.as_ptr(),
                 mat.indices().as_ptr(),
                 perm.as_mut_ptr(),
                 control.as_mut_ptr(),

--- a/suitesparse_bindings/sprs_suitesparse_ldl/src/lib.rs
+++ b/suitesparse_bindings/sprs_suitesparse_ldl/src/lib.rs
@@ -84,7 +84,9 @@ macro_rules! ldl_impl {
                 let n = mat.rows();
                 let n_ = n as $int;
                 let mat: CsMatI<f64, $int> = mat.to_other_types();
-                let ap = mat.indptr().as_ptr();
+                let indptr = mat.indptr();
+                let indptr_proper = indptr.to_proper();
+                let ap = indptr_proper.as_ptr();
                 let ai = mat.indices().as_ptr();
                 let valid_mat = unsafe { $valid_matrix(n_, ap, ai) };
                 assert!(valid_mat == 1);
@@ -225,7 +227,9 @@ macro_rules! ldl_impl {
                 I: SpIndex,
             {
                 let mat: CsMatI<f64, $int> = mat.to_other_types();
-                let ap = mat.indptr().as_ptr();
+                let indptr = mat.indptr();
+                let indptr_proper = indptr.to_proper();
+                let ap = indptr_proper.as_ptr();
                 let ai = mat.indices().as_ptr();
                 let ax = mat.data().as_ptr();
                 assert!(unsafe { $valid_matrix(self.symbolic.n, ap, ai) } != 0);


### PR DESCRIPTION
This is a refactoring that should fix #244. This is very much WIP, but the basic test suite is passing. @mulimoen I'd be very interested in your feedback.

This introduces lots of breaking changes, for instance lots of iterators are now using an `impl Iterator` pattern instead of an explicit type.

There are still a few rough edges, which may not be addressed in this PR but should be addressed before 0.10 is released:
- `middle_outer_views` is cumbersome to use, it probably should take a start and end parameter (or a range) to be more convenient and less error prone.
- the `IndPtr` type is not used to build owned indptr types, but it could be interesting to use it to enforce good patterns. As it would not be practical to have runtime checks, this would be a crate-only API
- smmp was quite hard to port, mostly because it does not take a `CsMatViewI` in its API. I probably should change that before 0.10.