### PR TITLE
Serde deserialization for IndPtr

### DIFF
--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -94,6 +94,7 @@ where
     storage: CompressedStorage,
     nrows: usize,
     ncols: usize,
+    #[cfg_attr(feature = "serde", serde(flatten))]
     indptr: IndPtrBase<Iptr, IptrStorage>,
     indices: IndStorage,
     data: DataStorage,

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -5,10 +5,13 @@
 
 use crate::errors::SprsError;
 use crate::indexing::SpIndex;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::ops::Range;
 use std::ops::{Deref, DerefMut};
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IndPtrBase<Iptr, Storage>
 where
     Iptr: SpIndex,


### PR DESCRIPTION
This does not uphold the invariants of `IndPtr`, but this would be easier to introduce in #237

Flattening `IndPtr` gives us backwards compatibility.