### PR TITLE
add a PartialEq for indptr and slices

### DIFF
--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -2723,7 +2723,7 @@ mod test {
     fn convert_types() {
         let mat: CsMat<f32> = CsMat::eye(3);
         let mat_: CsMatI<f64, u32> = mat.to_other_types();
-        assert_eq!(mat_.indptr().raw_storage(), &[0, 1, 2, 3]);
+        assert_eq!(mat_.indptr(), &[0, 1, 2, 3][..]);
 
         let mat = CsMatI::new_csc(
             (3, 3),
@@ -2732,7 +2732,7 @@ mod test {
             vec![1.; 4],
         );
         let mat_: CsMatI<f32, usize, u32> = mat.to_other_types();
-        assert_eq!(mat_.indptr().raw_storage(), &[0, 1, 3, 4]);
+        assert_eq!(mat_.indptr(), &[0, 1, 3, 4][..]);
         assert_eq!(mat_.data(), &[1.0f32, 1., 1., 1.]);
     }
 

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -361,6 +361,18 @@ impl<'a, Iptr: SpIndex> IndPtrView<'a, Iptr> {
     }
 }
 
+/// Allows comparison to vectors and slices
+impl<Iptr: SpIndex, IptrStorage, IptrStorage2> std::cmp::PartialEq<IptrStorage2>
+    for IndPtrBase<Iptr, IptrStorage>
+where
+    IptrStorage: Deref<Target = [Iptr]>,
+    IptrStorage2: Deref<Target = [Iptr]>,
+{
+    fn eq(&self, other: &IptrStorage2) -> bool {
+        self.raw_storage() == other.deref()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{IndPtr, IndPtrView};
@@ -478,5 +490,14 @@ mod tests {
         assert_eq!(iter.next().unwrap(), 2);
         assert_eq!(iter.next().unwrap(), 2);
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn compare_with_slices() {
+        let iptr = IndPtrView::new(&[0, 1, 3, 8]).unwrap();
+        assert!(iptr == &[0, 1, 3, 8][..]);
+        assert!(iptr == vec![0, 1, 3, 8]);
+        let iptr = IndPtrView::new(&[1, 1, 3, 8]).unwrap();
+        assert!(iptr == &[1, 1, 3, 8][..]);
     }
 }

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -490,7 +490,7 @@ mod test {
             &mut c_data,
             &mut tmp,
         );
-        assert_eq!(exp.indptr().raw_storage(), c_indptr);
+        assert_eq!(exp.indptr(), &c_indptr[..]);
         assert_eq!(exp.indices(), &c_indices[..]);
         assert_eq!(exp.data(), &c_data[..]);
     }

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -568,12 +568,12 @@ mod test {
         // regression test for https://github.com/vbarrielle/sprs/issues/170
         let tri_mat = TriMatI::new((2, 4));
         let m: CsMat<u64> = tri_mat.to_csr();
-        assert_eq!(m.indptr().raw_storage(), &[0, 0, 0]);
+        assert_eq!(m.indptr(), &[0, 0, 0][..]);
         assert_eq!(m.indices(), &[]);
         assert_eq!(m.data(), &[]);
 
         let m: CsMat<u64> = tri_mat.to_csc();
-        assert_eq!(m.indptr().raw_storage(), &[0, 0, 0, 0, 0]);
+        assert_eq!(m.indptr(), &[0, 0, 0, 0, 0][..]);
         assert_eq!(m.indices(), &[]);
         assert_eq!(m.data(), &[]);
 
@@ -631,7 +631,7 @@ mod test {
         triplet_mat.add_triplet(0, 3, 2);
 
         let m = triplet_mat.to_csc();
-        assert_eq!(m.indptr().raw_storage(), &[0, 0, 1, 1, 2, 2, 2]);
+        assert_eq!(m.indptr(), &[0, 0, 1, 1, 2, 2, 2][..]);
         assert_eq!(m.indices(), &[1, 0]);
         assert_eq!(m.data(), &[1, 2]);
     }


### PR DESCRIPTION
Advantage is in comparing a slice and an `IndPtr`, without the drawbacks of a `Deref` on `IndPtr` which would ignore the properness