### PR TITLE
Some pedantic clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 env:
     CARGO_TERM_COLOR: always
     RUSTFLAGS: -D warnings
+    CLIPPY_DISABLE_DOCS_LINKS: 1
 
 jobs:
   rustfmt:
@@ -61,7 +62,7 @@ jobs:
         profile: minimal
         components: clippy
     - name: Run Clippy
-      run: cargo clippy --workspace --all-features
+      run: cargo clippy --workspace --all-features -- -W clippy::doc_markdown -W clippy::needless_borrow -W clippy::checked_conversions -W clippy::unseparated_literal_suffix -W clippy::unreadable_literal -W clippy::if_not_else -W clippy::needless_continue -W clippy::match_same_arms -W clippy::match_wildcard_for_single_variants -W clippy::explicit_into_iter_loop -W clippy::needless_borrow
 
   test:
     name: test

--- a/sprs-benches/build.rs
+++ b/sprs-benches/build.rs
@@ -15,7 +15,9 @@ where
     let save_dir = save_dir.as_ref();
     let extracted_path = save_dir.join(extracted_path);
     let probe = save_dir.join(&extracted_path).join("dl_done");
-    if !probe.exists() {
+    if probe.exists() {
+        println!("Using cached archive {}", extracted_path.to_string_lossy());
+    } else {
         println!(
             "probe {} does not exist, downloading {}",
             probe.to_string_lossy(),
@@ -26,8 +28,6 @@ where
         )?)
         .unpack(save_dir)?;
         let _ = File::create(probe)?;
-    } else {
-        println!("Using cached archive {}", extracted_path.to_string_lossy());
     }
     Ok(())
 }

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -103,7 +103,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             ..Default::default()
         },
         BenchSpec {
-            shape: (15000, 25000),
+            shape: (15_000, 25_000),
             densities: vec![
                 1e-5, 2e-5, 5e-5, 1e-4, 2e-4,
                 5e-4, //1e-3, 2e-3, 3e-3, 5e-3,
@@ -111,13 +111,13 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
             ..Default::default()
         },
         BenchSpec {
-            shape: (150000, 25000),
+            shape: (15_0000, 25_000),
             densities: vec![1e-7, 1e-6, 1e-5, 1e-4],
             forbid_eigen: true,
             ..Default::default()
         },
         BenchSpec {
-            shape: (150000, 250000),
+            shape: (15_0000, 25_0000),
             densities: vec![1e-7, 1e-6, 1e-5, 1e-4],
             forbid_eigen: true,
             ..Default::default()
@@ -142,14 +142,14 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 (1500, 1500),
                 (3500, 3500),
                 (7500, 7500),
-                (15000, 15000),
-                (35000, 35000),
-                (75000, 75000),
-                (150000, 150000),
-                (350000, 350000),
-                (750000, 750000),
-                (1500000, 1500000),
-                (2500000, 2500000),
+                (15_000, 15_000),
+                (35_000, 35_000),
+                (75_000, 75_000),
+                (150_000, 150_000),
+                (350_000, 350_000),
+                (750_000, 750_000),
+                (1_500_000, 1_500_000),
+                (2_500_000, 2_500_000),
             ],
             forbid_eigen: true,
             nnz_over_rows: 4,

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -43,15 +43,16 @@ extern "C" {
 
 #[cfg(feature = "eigen")]
 fn eigen_prod(a: sprs::CsMatView<f64>, b: sprs::CsMatView<f64>) -> usize {
+    use std::convert::TryFrom;
     let (a_rows, a_cols) = a.shape();
     let (b_rows, b_cols) = b.shape();
     assert_eq!(a_cols, b_rows);
     assert!(a.is_csr());
-    assert!(a.rows() <= isize::MAX as usize);
-    assert!(a.indptr().nnz() <= isize::MAX as usize);
+    assert!(isize::try_from(a.rows()).is_ok());
+    assert!(isize::try_from(a.indptr().nnz()).is_ok());
     assert!(b.is_csr());
-    assert!(b.rows() <= isize::MAX as usize);
-    assert!(b.indptr().nnz() <= isize::MAX as usize);
+    assert!(isize::try_from(b.rows()).is_ok());
+    assert!(isize::try_from(b.indptr().nnz()).is_ok());
     let a_indptr_proper = a.proper_indptr();
     let a_indices = a.indices().as_ptr() as *const isize;
     let a_data = a.data().as_ptr();

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -357,7 +357,7 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
                 .margin(5)
                 .x_label_area_size(30)
                 .y_label_area_size(50)
-                .build_ranged(0f32..max_absciss, 0f32..max_time)?;
+                .build_ranged(0_f32..max_absciss, 0_f32..max_time)?;
 
             let abscisses = if is_shape_bench {
                 shapes.iter().map(|(rows, _)| *rows as f64).collect()

--- a/sprs-benches/src/main.rs
+++ b/sprs-benches/src/main.rs
@@ -7,7 +7,7 @@ use sprs_rand::rand_csr_std;
 
 fn scipy_mat<'a>(
     scipy_sparse: &'a PyModule,
-    py: &Python,
+    py: Python,
     mat: &sprs::CsMat<f64>,
 ) -> Result<&'a PyAny, String> {
     let indptr = mat.indptr().to_proper().to_vec();
@@ -15,11 +15,11 @@ fn scipy_mat<'a>(
         .call(
             "csr_matrix",
             ((mat.data().to_vec(), mat.indices().to_vec(), indptr),),
-            Some([("shape", mat.shape())].into_py_dict(*py)),
+            Some([("shape", mat.shape())].into_py_dict(py)),
         )
         .map_err(|e| {
             let res = format!("Python error: {:?}", e);
-            e.print_and_set_sys_last_vars(*py);
+            e.print_and_set_sys_last_vars(py);
             res
         })
 }
@@ -261,8 +261,8 @@ fn bench_densities() -> Result<(), Box<dyn std::error::Error>> {
 
             // bench scipy as well
             {
-                let m1_py = scipy_mat(scipy_sparse, &py, &m1)?;
-                let m2_py = scipy_mat(scipy_sparse, &py, &m2)?;
+                let m1_py = scipy_mat(scipy_sparse, py, &m1)?;
+                let m2_py = scipy_mat(scipy_sparse, py, &m2)?;
                 let now = std::time::Instant::now();
                 let _prod_py = py
                     .eval(

--- a/sprs-ldl/src/lib.rs
+++ b/sprs-ldl/src/lib.rs
@@ -427,7 +427,7 @@ impl<N, I: SpIndex> LdlNumeric<N, I> {
     }
 }
 
-/// Perform a symbolic LDLt decomposition of a symmetric sparse matrix
+/// Perform a symbolic LDLT decomposition of a symmetric sparse matrix
 pub fn ldl_symbolic<N, I, PStorage>(
     mat: CsMatViewI<N, I>,
     perm: &Permutation<I, PStorage>,
@@ -483,7 +483,7 @@ pub fn ldl_symbolic<N, I, PStorage>(
 
 /// Perform numeric LDLT decomposition
 ///
-/// pattern_workspace is a DStack of capacity n
+/// `pattern_workspace` is a [`DStack`](DStack) of capacity n
 #[allow(clippy::too_many_arguments)]
 pub fn ldl_numeric<N, I, PStorage>(
     mat: CsMatViewI<N, I>,

--- a/sprs-ldl/src/lib.rs
+++ b/sprs-ldl/src/lib.rs
@@ -230,13 +230,13 @@ impl<I: SpIndex> LdlSymbolic<I> {
     /// # Panics
     ///
     /// * if mat is not symmetric
-    pub fn new<N>(mat: CsMatViewI<N, I>) -> LdlSymbolic<I>
+    pub fn new<N>(mat: CsMatViewI<N, I>) -> Self
     where
         N: Copy + PartialEq,
     {
         assert_eq!(mat.rows(), mat.cols());
         let perm: Permutation<I, Vec<I>> = Permutation::identity(mat.rows());
-        LdlSymbolic::new_perm(mat, perm, SymmetryCheck::CheckSymmetry)
+        Self::new_perm(mat, perm, SymmetryCheck::CheckSymmetry)
     }
 
     /// Compute the symbolic decomposition L D L^T = P A P^T
@@ -252,7 +252,7 @@ impl<I: SpIndex> LdlSymbolic<I> {
         mat: CsMatViewI<N, I>,
         perm: PermOwnedI<I>,
         check_symmetry: SymmetryCheck,
-    ) -> LdlSymbolic<I>
+    ) -> Self
     where
         N: Copy + PartialEq,
         I: SpIndex,
@@ -273,7 +273,7 @@ impl<I: SpIndex> LdlSymbolic<I> {
             check_symmetry,
         );
 
-        LdlSymbolic {
+        Self {
             colptr: l_colptr,
             parents,
             nz: l_nz,

--- a/sprs-rand/src/lib.rs
+++ b/sprs-rand/src/lib.rs
@@ -32,7 +32,7 @@ where
     N: Copy,
     I: SpIndex,
 {
-    assert!(density >= 0. && density <= 1.);
+    assert!((0.0..=1.0).contains(&density));
     let exp_nnz =
         (density * (shape.0 as f64) * (shape.1 as f64)).ceil() as usize;
     let mut indptr = Vec::with_capacity(shape.0 + 1);

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -113,7 +113,7 @@ macro_rules! sp_index_impl {
             #[inline(always)]
             fn from_usize_unchecked(ind: usize) -> Self {
                 debug_assert!(Self::try_from_usize(ind).is_some());
-                ind as $int
+                ind as Self
             }
         }
     };

--- a/src/io.rs
+++ b/src/io.rs
@@ -51,7 +51,7 @@ impl PartialEq for IoError {
             IoError::UnsupportedMatrixMarketFormat => {
                 matches!(*rhs, IoError::UnsupportedMatrixMarketFormat)
             }
-            _ => false,
+            IoError::Io(..) => false,
         }
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -146,14 +146,13 @@ where
         return Err(UnsupportedMatrixMarketFormat);
     }
     // The header is followed by any number of comment or empty lines, skip
-    loop {
+    'header: loop {
         line.clear();
         let len = reader.read_line(&mut line)?;
         if len == 0 || line.starts_with('%') {
-            continue;
-        } else {
-            break;
+            continue 'header;
         }
+        break;
     }
     // read shape and number of entries
     // this is a line like:
@@ -182,15 +181,14 @@ where
     // one non-zero entry per non-empty line
     for _ in 0..entries {
         // skip empty lines (no comment line should appear)
-        loop {
+        'empty_lines: loop {
             line.clear();
             let len = reader.read_line(&mut line)?;
             // check for an all whitespace line
             if len != 0 && line.split_whitespace().next() == None {
-                continue;
-            } else {
-                break;
+                continue 'empty_lines;
             }
+            break;
         }
         // Non-zero entries are lines of the form:
         // row col value

--- a/src/io.rs
+++ b/src/io.rs
@@ -25,9 +25,8 @@ use self::IoError::*;
 impl fmt::Display for IoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            IoError::Io(ref err) => err.fmt(f),
-            IoError::BadMatrixMarketFile
-            | IoError::UnsupportedMatrixMarketFormat => {
+            Self::Io(ref err) => err.fmt(f),
+            Self::BadMatrixMarketFile | Self::UnsupportedMatrixMarketFormat => {
                 write!(f, "Bad matrix market file.")
             }
         }
@@ -37,21 +36,21 @@ impl fmt::Display for IoError {
 impl Error for IoError {}
 
 impl From<io::Error> for IoError {
-    fn from(err: io::Error) -> IoError {
-        IoError::Io(err)
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
     }
 }
 
 impl PartialEq for IoError {
-    fn eq(&self, rhs: &IoError) -> bool {
+    fn eq(&self, rhs: &Self) -> bool {
         match *self {
-            IoError::BadMatrixMarketFile => {
-                matches!(*rhs, IoError::BadMatrixMarketFile)
+            Self::BadMatrixMarketFile => {
+                matches!(*rhs, Self::BadMatrixMarketFile)
             }
-            IoError::UnsupportedMatrixMarketFormat => {
-                matches!(*rhs, IoError::UnsupportedMatrixMarketFormat)
+            Self::UnsupportedMatrixMarketFormat => {
+                matches!(*rhs, Self::UnsupportedMatrixMarketFormat)
             }
-            IoError::Io(..) => false,
+            Self::Io(..) => false,
         }
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -26,10 +26,8 @@ impl fmt::Display for IoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             IoError::Io(ref err) => err.fmt(f),
-            IoError::BadMatrixMarketFile => {
-                write!(f, "Bad matrix market file.")
-            }
-            IoError::UnsupportedMatrixMarketFormat => {
+            IoError::BadMatrixMarketFile
+            | IoError::UnsupportedMatrixMarketFormat => {
                 write!(f, "Bad matrix market file.")
             }
         }

--- a/src/io.rs
+++ b/src/io.rs
@@ -296,7 +296,7 @@ where
     writeln!(writer, "{} {} {}", rows, cols, nnz)?;
 
     // entries
-    for (val, (row, col)) in mat.into_iter() {
+    for (val, (row, col)) in mat {
         writeln!(writer, "{} {} {}", row.index() + 1, col.index() + 1, val)?;
     }
     Ok(())
@@ -361,7 +361,7 @@ where
     let mut entries = 0;
     match sym {
         SymmetryMode::General => {
-            for (val, (row, col)) in mat.into_iter() {
+            for (val, (row, col)) in mat {
                 writeln!(
                     writer,
                     "{} {} {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ It features a sparse matrix type, [**`CsMat`**](struct.CsMatBase.html), and a sp
 - sparse cholesky solver in the separate crate `sprs-ldl`.
 - fully generic integer type for the storage of indices, enabling compact
   representations.
-- planned interoperability with existing sparse solvers such as SuiteSparse.
+- planned interoperability with existing sparse solvers such as `SuiteSparse`.
 
 ## Quick Examples
 

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -286,15 +286,15 @@ pub(crate) mod utils {
     use super::*;
     use std::convert::TryInto;
 
-    /// Check the structure of CsMat components
+    /// Check the structure of `CsMat` components
     /// This will ensure that:
-    /// * indptr is of length outer_dim() + 1
-    /// * indices and data have the same length, nnz == indptr\[outer_dims()\]
+    /// * indptr is of length `outer_dim() + 1`
+    /// * indices and data have the same length, `nnz == indptr[outer_dims()]`
     /// * indptr is sorted
-    /// * indptr values do not exceed usize::MAX / 2, as that would mean
+    /// * indptr values do not exceed [`usize::MAX`](usize::MAX)`/ 2`, as that would mean
     ///   indices and indptr would take more space than the addressable memory
     /// * indices is sorted for each outer slice
-    /// * indices are lower than inner_dims()
+    /// * indices are lower than `inner_dims()`
     pub(crate) fn check_compressed_structure<I: SpIndex, Iptr: SpIndex>(
         inner: usize,
         outer: usize,

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -262,8 +262,8 @@ pub fn csmat_binop_dense_raw<'a, N, I, Iptr, F>(
         rhs.is_standard_layout(),
         out.is_standard_layout(),
     ) {
-        (CompressedStorage::CSR, true, true) => (),
-        (CompressedStorage::CSC, false, false) => (),
+        (CompressedStorage::CSR, true, true)
+        | (CompressedStorage::CSC, false, false) => (),
         (_, _, _) => panic!("Storage mismatch"),
     }
     let outer_axis = if rhs.is_standard_layout() {

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -292,7 +292,7 @@ pub fn csmat_binop_dense_raw<'a, N, I, Iptr, F>(
     }
 }
 
-/// Binary operations for CsVec
+/// Binary operations for [`CsVec`](CsVecBase)
 ///
 /// This function iterates the non-zero locations of `lhs` and `rhs`
 /// and applies the function `binop` to the matching elements (defaulting

--- a/src/sparse/compressed.rs
+++ b/src/sparse/compressed.rs
@@ -3,8 +3,8 @@ use crate::indexing::SpIndex;
 use crate::sparse::prelude::*;
 use std::ops::Deref;
 
-/// The SpMatView trait describes data that can be seen as a view
-/// into a CsMat
+/// The `SpMatView` trait describes data that can be seen as a view
+/// into a `CsMat`
 pub trait SpMatView<N, I: SpIndex, Iptr: SpIndex = I> {
     /// Return a view into the current matrix
     fn view(&self) -> CsMatViewI<N, I, Iptr>;
@@ -31,8 +31,8 @@ where
     }
 }
 
-/// The SpVecView trait describes types that can be seen as a view into
-/// a CsVec
+/// The `SpVecView` trait describes types that can be seen as a view into
+/// a `CsVec`
 pub trait SpVecView<N, I: SpIndex> {
     /// Return a view into the current vector
     fn view(&self) -> CsVecViewI<N, I>;

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1873,13 +1873,13 @@ where
 
     fn add(self, rhs: &'b ArrayBase<DS2, Ix2>) -> Array<N, Ix2> {
         match (self.storage(), rhs.is_standard_layout()) {
-            (CSR, true) => binop::add_dense_mat_same_ordering(
+            (CSR, true) | (CSC, false) => binop::add_dense_mat_same_ordering(
                 self,
                 rhs,
                 N::one(),
                 N::one(),
             ),
-            (CSR, false) => {
+            (CSR, false) | (CSC, true) => {
                 let lhs = self.to_other_storage();
                 binop::add_dense_mat_same_ordering(
                     &lhs,
@@ -1888,21 +1888,6 @@ where
                     N::one(),
                 )
             }
-            (CSC, true) => {
-                let lhs = self.to_other_storage();
-                binop::add_dense_mat_same_ordering(
-                    &lhs,
-                    rhs,
-                    N::one(),
-                    N::one(),
-                )
-            }
-            (CSC, false) => binop::add_dense_mat_same_ordering(
-                self,
-                rhs,
-                N::one(),
-                N::one(),
-            ),
         }
     }
 }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -934,7 +934,7 @@ where
     where
         N: Copy + Clone + Float + PartialOrd,
     {
-        let mut indptr_counter = 0usize;
+        let mut indptr_counter = 0_usize;
         let mut indptr: Vec<Iptr> = Vec::with_capacity(self.indptr.len());
 
         let max_data_len = self.indptr.len().min(self.data.len());

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -36,7 +36,7 @@ use crate::sparse::to_dense::assign_to_dense;
 use crate::sparse::utils;
 use crate::sparse::vec;
 
-/// Describe the storage of a CsMat
+/// Describe the storage of a `CsMat`
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CompressedStorage {
@@ -83,7 +83,7 @@ pub use self::CompressedStorage::{CSC, CSR};
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 /// Hold the index of a non-zero element in the compressed storage
 ///
-/// An NnzIndex can be used to later access the non-zero element in constant
+/// An `NnzIndex` can be used to later access the non-zero element in constant
 /// time.
 pub struct NnzIndex(pub usize);
 
@@ -296,7 +296,7 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
         let data = vec![N::one(); n];
         Self::new_trusted(CSC, (n, n), indptr, indices, data)
     }
-    /// Create an empty CsMat for building purposes
+    /// Create an empty `CsMat` for building purposes
     pub fn empty(storage: CompressedStorage, inner_size: usize) -> Self {
         let shape = match storage {
             CSR => (0, inner_size),
@@ -311,7 +311,7 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
         )
     }
 
-    /// Create a new CsMat representing the zero matrix.
+    /// Create a new `CsMat` representing the zero matrix.
     /// Hence it has no non-zero elements.
     pub fn zero(shape: Shape) -> Self {
         let (nrows, _ncols) = shape;
@@ -618,7 +618,7 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
 impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
     CsMatBase<N, I, &'a [Iptr], &'a [I], &'a [N], Iptr>
 {
-    /// Create a borrowed CsMat matrix from sliced data,
+    /// Create a borrowed `CsMat` matrix from sliced data,
     /// checking their validity
     pub fn new_view(
         storage: CompressedStorage,
@@ -631,12 +631,13 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
             .map_err(|(_, _, _, e)| e)
     }
 
-    /// Create a borrowed CsMat matrix from raw data,
+    /// Create a borrowed `CsMat` matrix from raw data,
     /// without checking their validity
     ///
     /// # Safety
     /// This is unsafe because algorithms are free to assume
-    /// that properties guaranteed by check_compressed_structure are enforced.
+    /// that properties guaranteed by
+    /// [`check_compressed_structure`](Self::check_compressed_structure) are enforced.
     /// For instance, non out-of-bounds indices can be relied upon to
     /// perform unchecked slice access.
     pub unsafe fn new_view_raw(
@@ -769,8 +770,8 @@ where
     ///
     /// This access is logarithmic in the number of non-zeros
     /// in the corresponding outer slice. It is therefore advisable not to rely
-    /// on this for algorithms, and prefer outer_iterator() which accesses
-    /// elements in storage order.
+    /// on this for algorithms, and prefer [`outer_iterator`](Self::outer_iterator)
+    /// which accesses elements in storage order.
     pub fn get(&self, i: usize, j: usize) -> Option<&N> {
         match self.storage {
             CSR => self.get_outer_inner(i, j),
@@ -919,7 +920,8 @@ where
     /// Returns a matrix with the same size, the same CSR/CSC type,
     /// and a single value of 1.0 within each populated inner vector.
     ///
-    /// See [CsMatBase::into_csc] and [CsMatBase::into_csr] if you need to prepare a matrix
+    /// See [`into_csc`](CsMatBase::into_csc) and [`into_csr`](CsMatBase::into_csr)
+    /// if you need to prepare a matrix
     /// for one-hot compression.
     pub fn to_inner_onehot(&self) -> CsMatI<N, I, Iptr>
     where
@@ -1137,7 +1139,7 @@ where
         })
     }
 
-    /// Iteration on outer blocks of size block_size
+    /// Iteration on outer blocks of size `block_size`
     ///
     /// # Panics
     ///
@@ -1175,13 +1177,13 @@ where
         }
     }
 
-    /// Access an element given its outer_ind and inner_ind.
+    /// Access an element given its `outer_ind` and `inner_ind`.
     /// Will return None if there is no non-zero element at this location.
     ///
     /// This access is logarithmic in the number of non-zeros
     /// in the corresponding outer slice. It is therefore advisable not to rely
-    /// on this for algorithms, and prefer outer_iterator() which accesses
-    /// elements in storage order.
+    /// on this for algorithms, and prefer [`outer_iterator`](Self::outer_iterator)
+    /// which accesses elements in storage order.
     pub fn get_outer_inner(
         &self,
         outer_ind: usize,
@@ -1195,7 +1197,7 @@ where
     ///
     /// Searching this index is logarithmic in the number of non-zeros
     /// in the corresponding outer slice.
-    /// Once it is available, the NnzIndex enables retrieving the data with
+    /// Once it is available, the `NnzIndex` enables retrieving the data with
     /// O(1) complexity.
     pub fn nnz_index(&self, row: usize, col: usize) -> Option<NnzIndex> {
         match self.storage() {
@@ -1204,8 +1206,8 @@ where
         }
     }
 
-    /// Find the non-zero index of the element specified by outer_ind and
-    /// inner_ind.
+    /// Find the non-zero index of the element specified by `outer_ind` and
+    /// `inner_ind`.
     ///
     /// Searching this index is logarithmic in the number of non-zeros
     /// in the corresponding outer slice.
@@ -1223,15 +1225,15 @@ where
             .map(|vec::NnzIndex(ind)| NnzIndex(ind + offset))
     }
 
-    /// Check the structure of CsMat components
+    /// Check the structure of `CsMat` components
     /// This will ensure that:
-    /// * indptr is of length outer_dim() + 1
-    /// * indices and data have the same length, nnz == indptr\[outer_dims()\]
+    /// * indptr is of length `outer_dim() + 1`
+    /// * indices and data have the same length, `nnz == indptr[outer_dims()]`
     /// * indptr is sorted
-    /// * indptr values do not exceed usize::MAX / 2, as that would mean
+    /// * indptr values do not exceed [`usize::MAX`](usize::MAX)`/ 2`, as that would mean
     ///   indices and indptr would take more space than the addressable memory
     /// * indices is sorted for each outer slice
-    /// * indices are lower than inner_dims()
+    /// * indices are lower than `inner_dims()`
     pub fn check_compressed_structure(&self) -> Result<(), SprsError> {
         let inner = self.inner_dims();
         let outer = self.outer_dims();
@@ -1406,9 +1408,9 @@ where
     ///
     /// This access is logarithmic in the number of non-zeros
     /// in the corresponding outer slice. It is therefore advisable not to rely
-    /// on this for algorithms, and prefer outer_iterator_mut() which accesses
-    /// elements in storage order.
-    /// TODO: outer_iterator_mut is not yet implemented
+    /// on this for algorithms, and prefer [`outer_iterator_mut`](Self::outer_iterator_mut)
+    /// which accesses elements in storage order.
+    /// TODO: `outer_iterator_mut` is not yet implemented
     pub fn get_mut(&mut self, i: usize, j: usize) -> Option<&mut N> {
         match self.storage {
             CSR => self.get_outer_inner_mut(i, j),
@@ -1416,13 +1418,13 @@ where
         }
     }
 
-    /// Get a mutable reference to an element given its outer_ind and inner_ind.
+    /// Get a mutable reference to an element given its `outer_ind` and `inner_ind`.
     /// Will return None if there is no non-zero element at this location.
     ///
     /// This access is logarithmic in the number of non-zeros
     /// in the corresponding outer slice. It is therefore advisable not to rely
-    /// on this for algorithms, and prefer outer_iterator_mut() which accesses
-    /// elements in storage order.
+    /// on this for algorithms, and prefer [`outer_iterator_mut`](Self::outer_iterator_mut)
+    /// which accesses elements in storage order.
     pub fn get_outer_inner_mut(
         &mut self,
         outer_ind: usize,
@@ -1504,8 +1506,8 @@ where
     ///
     /// # Panics
     ///
-    /// If the resulting matrix breaks the CsMat invariants (sorted indices,
-    /// no out of bounds indices).
+    /// If the resulting matrix breaks the `CsMat` invariants
+    /// (sorted indices, no out of bounds indices).
     ///
     /// # Example
     ///
@@ -1655,12 +1657,13 @@ pub mod raw {
 impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
     CsMatBase<N, I, Vec<Iptr>, &'a [I], &'a [N], Iptr>
 {
-    /// Create a borrowed row or column CsMat matrix from raw data,
+    /// Create a borrowed row or column `CsMat` matrix from raw data,
     /// without checking their validity
     ///
     /// # Safety
     /// This is unsafe because algorithms are free to assume
-    /// that properties guaranteed by check_compressed_structure are enforced.
+    /// that properties guaranteed by
+    /// [`check_compressed_structure`](Self::check_compressed_structure) are enforced.
     /// For instance, non out-of-bounds indices can be relied upon to
     /// perform unchecked slice access.
     pub unsafe fn new_vecview_raw(

--- a/src/sparse/linalg/ordering.rs
+++ b/src/sparse/linalg/ordering.rs
@@ -535,7 +535,7 @@ where
 /// configuration of the algorithm.
 ///
 /// This library also exposes a costomizable version of the algorithm,
-/// [cuthill_mckee_custom](fn.cuthill_mckee_custom.html).
+/// [`cuthill_mckee_custom`](cuthill_mckee_custom).
 ///
 /// Implemented as:
 /// ```text

--- a/src/sparse/linalg/ordering.rs
+++ b/src/sparse/linalg/ordering.rs
@@ -57,7 +57,7 @@ pub mod start {
             visited
                 .iter()
                 .enumerate()
-                .find_map(|(i, &a)| if !a { Some(i) } else { None })
+                .find_map(|(i, &a)| if a { None } else { Some(i) })
                 .expect(
                     "There should always be a unvisited vertex left to choose",
                 )
@@ -232,7 +232,7 @@ pub mod start {
             let mut current = visited
                 .iter()
                 .enumerate()
-                .find_map(|(i, &a)| if !a { Some(i) } else { None })
+                .find_map(|(i, &a)| if a { None } else { Some(i) })
                 .expect(
                     "There should always be a unvisited vertex left to choose",
                 );

--- a/src/sparse/linalg/ordering.rs
+++ b/src/sparse/linalg/ordering.rs
@@ -101,7 +101,7 @@ pub mod start {
     impl PseudoPeripheral {
         #[inline]
         pub fn new() -> Self {
-            PseudoPeripheral::default()
+            Self::default()
         }
 
         /// Computes the rooted level structure rooted at `root`, returning the

--- a/src/sparse/linalg/ordering.rs
+++ b/src/sparse/linalg/ordering.rs
@@ -57,8 +57,7 @@ pub mod start {
             visited
                 .iter()
                 .enumerate()
-                .find(|(_i, &a)| !a)
-                .map(|(i, _a)| i)
+                .find_map(|(i, &a)| if !a { Some(i) } else { None })
                 .expect(
                     "There should always be a unvisited vertex left to choose",
                 )
@@ -233,8 +232,7 @@ pub mod start {
             let mut current = visited
                 .iter()
                 .enumerate()
-                .find(|(_i, &a)| !a)
-                .map(|(i, _a)| i)
+                .find_map(|(i, &a)| if !a { Some(i) } else { None })
                 .expect(
                     "There should always be a unvisited vertex left to choose",
                 );

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -251,16 +251,16 @@ where
 
 /// Sparse triangular CSC / sparse vector solve
 ///
-/// lower_tri_mat is a sparse lower triangular matrix of shape (n, n)
-/// rhs is a sparse vector of size n
-/// dstack is a double stack with capacity 2*n
-/// x_workspace is a workspace vector with length equal to the number of
-/// rows of lower_tri_mat. Its input values can be anything.
-/// visited is a workspace vector of same size as upper_tri_mat.indptr(),
+/// `lower_tri_mat` is a sparse lower triangular matrix of shape (n, n)
+/// `rhs` is a sparse vector of size n
+/// `dstack` is a double stack with capacity 2*n
+/// `x_workspace` is a workspace vector with length equal to the number of
+/// rows of `lower_tri_mat`. Its input values can be anything.
+/// visited is a workspace vector of same size as `upper_tri_mat.indptr()`,
 /// and should be all false.
 ///
 /// On succesful execution, dstack will hold the non-zero pattern in its
-/// right stack, and x_workspace will contain the solve values at the indices
+/// right stack, and `x_workspace` will contain the solve values at the indices
 /// contained in right stack. The non-zero pattern indices are not guaranteed
 /// to be sorted (they are sorted for each connected component of the matrix's
 /// graph).
@@ -269,7 +269,7 @@ where
 ///
 /// * if dstack.capacity() is too small
 /// * if dstack is not empty
-/// * if w_workspace is not of length n
+/// * if `w_workspace` is not of length n
 ///
 pub fn lsolve_csc_sparse_rhs<N, I, Iptr>(
     lower_tri_mat: CsMatViewI<N, I, Iptr>,

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -47,18 +47,18 @@ pub fn perm_is_valid<I: SpIndex>(perm: &[I]) -> bool {
     true
 }
 
-impl<I: SpIndex> Permutation<I, Vec<I>> {
-    pub fn new(perm: Vec<I>) -> PermOwnedI<I> {
+impl<I: SpIndex> PermOwnedI<I> {
+    pub fn new(perm: Vec<I>) -> Self {
         assert!(perm_is_valid(&perm));
-        Permutation::new_trusted(perm)
+        Self::new_trusted(perm)
     }
 
-    pub(crate) fn new_trusted(perm: Vec<I>) -> PermOwnedI<I> {
+    pub(crate) fn new_trusted(perm: Vec<I>) -> Self {
         let mut perm_inv = perm.clone();
         for (ind, val) in perm.iter().enumerate() {
             perm_inv[val.index()] = I::from_usize(ind);
         }
-        PermOwnedI {
+        Self {
             dim: perm.len(),
             storage: FinitePerm { perm, perm_inv },
         }
@@ -109,8 +109,8 @@ impl<I: SpIndex, IndStorage> Permutation<I, IndStorage>
 where
     IndStorage: Deref<Target = [I]>,
 {
-    pub fn identity(dim: usize) -> Permutation<I, IndStorage> {
-        Permutation {
+    pub fn identity(dim: usize) -> Self {
+        Self {
             dim,
             storage: Identity,
         }

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -73,8 +73,8 @@ impl<'a, I: SpIndex> Permutation<I, &'a [I]> {
                 storage: Identity,
             },
             FinitePerm {
-                perm: ref p,
-                perm_inv: ref p_,
+                perm: p,
+                perm_inv: p_,
             } => PermViewI {
                 dim: self.dim,
                 storage: FinitePerm {
@@ -92,8 +92,8 @@ impl<'a, I: SpIndex> Permutation<I, &'a [I]> {
                 storage: Identity,
             },
             FinitePerm {
-                perm: ref p,
-                perm_inv: ref p_,
+                perm: p,
+                perm_inv: p_,
             } => PermViewI {
                 dim: self.dim,
                 storage: FinitePerm {

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -338,7 +338,7 @@ where
             );
         },
     );
-    res_indices.reserve(res_indices_chunks.iter().map(|x| x.len()).sum());
+    res_indices.reserve(res_indices_chunks.iter().map(Vec::len).sum());
     for res_indices_chunk in &res_indices_chunks {
         res_indices.extend_from_slice(res_indices_chunk);
     }

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -5,12 +5,12 @@ use num_traits::Num;
 ///!
 ///! Useful for building a matrix, but not for computations. Therefore this
 ///! struct is mainly used to initialize a matrix before converting to
-///! to a CsMat.
+///! to a [`CsMat`](CsMatBase).
 ///!
 ///! A triplet format matrix is formed of three arrays of equal length, storing
 ///! the row indices, the column indices, and the values of the non-zero
 ///! entries. By convention, duplicate locations are summed up when converting
-///! into CsMat.
+///! into `CsMat`.
 use std::ops::{Deref, DerefMut};
 use std::slice::Iter;
 
@@ -304,7 +304,7 @@ where
     DStorage: DerefMut<Target = [N]>,
 {
     /// Replace a non-zero value at the given index.
-    /// Indices can be obtained using find_locations.
+    /// Indices can be obtained using [`find_locations`](Self::find_locations).
     pub fn set_triplet(
         &mut self,
         TripletIndex(triplet_ind): TripletIndex,

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -83,10 +83,10 @@ where
 }
 
 /// # Methods for creating triplet matrices that own their data.
-impl<N, I: SpIndex> TriMatBase<Vec<I>, Vec<N>> {
+impl<N, I: SpIndex> TriMatI<N, I> {
     /// Create a new triplet matrix of shape `(nb_rows, nb_cols)`
-    pub fn new(shape: (usize, usize)) -> TriMatI<N, I> {
-        TriMatI {
+    pub fn new(shape: (usize, usize)) -> Self {
+        Self {
             rows: shape.0,
             cols: shape.1,
             row_inds: Vec::new(),
@@ -97,8 +97,8 @@ impl<N, I: SpIndex> TriMatBase<Vec<I>, Vec<N>> {
 
     /// Create a new triplet matrix of shape `(nb_rows, nb_cols)`, and
     /// pre-allocate `cap` elements on the backing storage
-    pub fn with_capacity(shape: (usize, usize), cap: usize) -> TriMatI<N, I> {
-        TriMatI {
+    pub fn with_capacity(shape: (usize, usize), cap: usize) -> Self {
+        Self {
             rows: shape.0,
             cols: shape.1,
             row_inds: Vec::with_capacity(cap),
@@ -119,7 +119,7 @@ impl<N, I: SpIndex> TriMatBase<Vec<I>, Vec<N>> {
         row_inds: Vec<I>,
         col_inds: Vec<I>,
         data: Vec<N>,
-    ) -> TriMatI<N, I> {
+    ) -> Self {
         assert_eq!(
             row_inds.len(),
             col_inds.len(),
@@ -143,7 +143,7 @@ impl<N, I: SpIndex> TriMatBase<Vec<I>, Vec<N>> {
             col_inds.iter().all(|&j| j.index() < shape.1),
             "col indices should be within shape"
         );
-        TriMatI {
+        Self {
             rows: shape.0,
             cols: shape.1,
             row_inds,

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -223,10 +223,13 @@ where
             .iter()
             .zip(self.col_inds.iter())
             .enumerate()
-            .filter(|&(_, (&i, &j))| {
-                i.index_unchecked() == row && j.index_unchecked() == col
+            .filter_map(|(ind, (&i, &j))| {
+                if i.index_unchecked() == row && j.index_unchecked() == col {
+                    Some(TripletIndex(ind))
+                } else {
+                    None
+                }
             })
-            .map(|(ind, _)| TripletIndex(ind))
             .collect()
     }
 

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -107,7 +107,7 @@ where
     CI: Clone + Iterator<Item = &'a I>,
     DI: Clone + Iterator<Item = &'a N>,
 {
-    /// Consume TriMatIter and produce a CSC matrix
+    /// Consume `TriMatIter` and produce a CSC matrix
     pub fn into_csc(self) -> CsMatI<N, I>
     where
         N: Num,
@@ -115,7 +115,7 @@ where
         self.into_cs(CompressedStorage::CSC)
     }
 
-    /// Consume TriMatIter and produce a CSR matrix
+    /// Consume `TriMatIter` and produce a CSR matrix
     pub fn into_csr(self) -> CsMatI<N, I>
     where
         N: Num,
@@ -123,7 +123,7 @@ where
         self.into_cs(CompressedStorage::CSR)
     }
 
-    /// Consume TriMatIter and produce a CsMat matrix with the chosen storage
+    /// Consume `TriMatIter` and produce a `CsMat` matrix with the chosen storage
     pub fn into_cs(self, storage: crate::CompressedStorage) -> CsMatI<N, I>
     where
         N: Num,

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -486,13 +486,13 @@ where
 
 /// # Methods operating on owning sparse vectors
 impl<N, I: SpIndex> CsVecI<N, I> {
-    /// Create an owning CsVec from vector data.
+    /// Create an owning `CsVec` from vector data.
     ///
     /// # Panics
     ///
     /// - if `indices` and `data` lengths differ
     /// - if the vector contains out of bounds indices
-    pub fn new(n: usize, indices: Vec<I>, data: Vec<N>) -> CsVecI<N, I>
+    pub fn new(n: usize, indices: Vec<I>, data: Vec<N>) -> Self
     where
         N: Copy,
     {
@@ -504,7 +504,7 @@ impl<N, I: SpIndex> CsVecI<N, I> {
         n: usize,
         indices: Vec<I>,
         data: Vec<N>,
-    ) -> Result<CsVecI<N, I>, SprsError>
+    ) -> Result<Self, SprsError>
     where
         N: Copy,
     {
@@ -525,8 +525,8 @@ impl<N, I: SpIndex> CsVecI<N, I> {
     }
 
     /// Create an empty `CsVec`, which can be used for incremental construction
-    pub fn empty(dim: usize) -> CsVecI<N, I> {
-        CsVecI {
+    pub fn empty(dim: usize) -> Self {
+        Self {
             dim,
             indices: Vec::new(),
             data: Vec::new(),

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1012,7 +1012,7 @@ where
     }
 
     pub fn view_mut(&mut self) -> CsVecViewMutI<N, I> {
-        CsVecBase {
+        CsVecViewMutI {
             dim: self.dim,
             indices: &self.indices[..],
             data: &mut self.data[..],
@@ -1112,7 +1112,7 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsVecBase<&'a [I], &'a [N], N, I> {
 }
 
 /// # Methods propagating the lifetome of a `CsVecViewMutI`.
-impl<'a, N, I> CsVecBase<&'a [I], &'a mut [N], N, I>
+impl<'a, N, I> CsVecViewMutI<'a, N, I>
 where
     N: 'a,
     I: 'a + SpIndex,
@@ -1132,8 +1132,8 @@ where
         nnz: usize,
         indices: *const I,
         data: *mut N,
-    ) -> CsVecViewMutI<'a, N, I> {
-        CsVecBase {
+    ) -> Self {
+        Self {
             dim: n,
             indices: slice::from_raw_parts(indices, nnz),
             data: slice::from_raw_parts_mut(data, nnz),
@@ -1271,9 +1271,9 @@ where
 }
 
 impl<N: Num + Copy + Neg<Output = N>, I: SpIndex> Neg for CsVecI<N, I> {
-    type Output = CsVecI<N, I>;
+    type Output = Self;
 
-    fn neg(mut self) -> CsVecI<N, I> {
+    fn neg(mut self) -> Self::Output {
         for value in &mut self.data {
             *value = -*value;
         }
@@ -1358,8 +1358,8 @@ where
 }
 
 impl<N: Num + Copy, I: SpIndex> Zero for CsVecI<N, I> {
-    fn zero() -> CsVecI<N, I> {
-        CsVecI::new(0, vec![], vec![])
+    fn zero() -> Self {
+        Self::new(0, vec![], vec![])
     }
 
     fn is_zero(&self) -> bool {
@@ -1376,14 +1376,14 @@ mod alga_impls {
     impl<N: Clone + Copy + Num, I: Clone + SpIndex> AbstractMagma<Additive>
         for CsVecI<N, I>
     {
-        fn operate(&self, right: &CsVecI<N, I>) -> CsVecI<N, I> {
+        fn operate(&self, right: &Self) -> Self {
             self + right
         }
     }
 
     impl<N: Copy + Num, I: SpIndex> Identity<Additive> for CsVecI<N, I> {
-        fn identity() -> CsVecI<N, I> {
-            CsVecI::zero()
+        fn identity() -> Self {
+            Self::zero()
         }
     }
 
@@ -1396,8 +1396,8 @@ mod alga_impls {
         N: Clone + Neg<Output = N> + Copy + Num,
         I: SpIndex,
     {
-        fn two_sided_inverse(&self) -> CsVecI<N, I> {
-            CsVecBase {
+        fn two_sided_inverse(&self) -> Self {
+            Self {
                 data: self.data.iter().map(|x| -*x).collect(),
                 indices: self.indices.clone(),
                 dim: self.dim,

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -40,7 +40,7 @@ use crate::sparse::{binop, prod};
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 /// Hold the index of a non-zero element in the compressed storage
 ///
-/// An NnzIndex can be used to later access the non-zero element in constant
+/// An `NnzIndex` can be used to later access the non-zero element in constant
 /// time.
 pub struct NnzIndex(pub usize);
 
@@ -499,7 +499,7 @@ impl<N, I: SpIndex> CsVecI<N, I> {
         Self::try_new(n, indices, data).unwrap()
     }
 
-    /// Try create an owning CsVec from vector data.
+    /// Try create an owning `CsVec` from vector data.
     pub fn try_new(
         n: usize,
         indices: Vec<I>,
@@ -524,7 +524,7 @@ impl<N, I: SpIndex> CsVecI<N, I> {
         .map_err(|(_, _, e)| e)
     }
 
-    /// Create an empty CsVec, which can be used for incremental construction
+    /// Create an empty `CsVec`, which can be used for incremental construction
     pub fn empty(dim: usize) -> CsVecI<N, I> {
         CsVecI {
             dim,
@@ -534,7 +534,7 @@ impl<N, I: SpIndex> CsVecI<N, I> {
     }
 
     /// Append an element to the sparse vector. Used for incremental
-    /// building of the CsVec. The append should preserve the structure
+    /// building of the `CsVec`. The append should preserve the structure
     /// of the vector, ie the newly added index should be strictly greater
     /// than the last element of indices.
     ///
@@ -822,8 +822,8 @@ where
     /// Find the non-zero index of the requested dimension index,
     /// returning None if no non-zero is present at the requested location.
     ///
-    /// Looking for the NnzIndex is done with logarithmic complexity, but
-    /// once it is available, the NnzIndex enables retrieving the data with
+    /// Looking for the `NnzIndex` is done with logarithmic complexity, but
+    /// once it is available, the `NnzIndex` enables retrieving the data with
     /// O(1) complexity.
     pub fn nnz_index(&self, index: usize) -> Option<NnzIndex> {
         self.indices
@@ -1063,13 +1063,13 @@ where
 }
 
 /// # Methods propagating the lifetime of a `CsVecViewI`.
-impl<'a, N: 'a, I: 'a + SpIndex> CsVecBase<&'a [I], &'a [N], N, I> {
-    /// Create a borrowed CsVec over slice data.
+impl<'a, N: 'a, I: 'a + SpIndex> CsVecViewI<'a, N, I> {
+    /// Create a borrowed `CsVec` over slice data.
     pub fn new_view(
         n: usize,
         indices: &'a [I],
         data: &'a [N],
-    ) -> Result<CsVecViewI<'a, N, I>, SprsError> {
+    ) -> Result<Self, SprsError> {
         Self::new_(n, indices, data).map_err(|(_, _, e)| e)
     }
 
@@ -1090,11 +1090,11 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsVecBase<&'a [I], &'a [N], N, I> {
         }
     }
 
-    /// Create a borrowed CsVec over slice data without checking the structure
+    /// Create a borrowed `CsVec` over slice data without checking the structure
     ///
     /// # Safety
     /// This is unsafe because algorithms are free to assume
-    /// that properties guaranteed by check_structure are enforced.
+    /// that properties guaranteed by [`check_structure`](CsVecBase::check_structure) are enforced.
     /// For instance, non out-of-bounds indices can be relied upon to
     /// perform unchecked slice access.
     pub unsafe fn new_view_raw(
@@ -1102,8 +1102,8 @@ impl<'a, N: 'a, I: 'a + SpIndex> CsVecBase<&'a [I], &'a [N], N, I> {
         nnz: usize,
         indices: *const I,
         data: *const N,
-    ) -> CsVecViewI<'a, N, I> {
-        CsVecViewI {
+    ) -> Self {
+        Self {
             dim: n,
             indices: slice::from_raw_parts(indices, nnz),
             data: slice::from_raw_parts(data, nnz),
@@ -1117,11 +1117,11 @@ where
     N: 'a,
     I: 'a + SpIndex,
 {
-    /// Create a borrowed CsVec over slice data without checking the structure
+    /// Create a borrowed [`CsVec`](CsMatBase) over slice data without checking the structure
     ///
     /// # Safety
     /// This is unsafe because algorithms are free to assume
-    /// that properties guaranteed by check_structure are enforced, and
+    /// that properties guaranteed by [`check_structure`](CsVecBase::check_structure) are enforced, and
     /// because the lifetime of the pointers is unconstrained.
     /// For instance, non out-of-bounds indices can be relied upon to
     /// perform unchecked slice access.

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -441,29 +441,30 @@ where
     type Item = NnzEither<'a, N1, N2>;
 
     fn next(&mut self) -> Option<NnzEither<'a, N1, N2>> {
+        use NnzEither::{Both, Left, Right};
         match (self.left.peek(), self.right.peek()) {
             (None, Some(&(_, _))) => {
                 let (rind, rval) = self.right.next().unwrap();
-                Some(NnzEither::Right((rind, rval)))
+                Some(Right((rind, rval)))
             }
             (Some(&(_, _)), None) => {
                 let (lind, lval) = self.left.next().unwrap();
-                Some(NnzEither::Left((lind, lval)))
+                Some(Left((lind, lval)))
             }
             (None, None) => None,
             (Some(&(lind, _)), Some(&(rind, _))) => match lind.cmp(&rind) {
                 std::cmp::Ordering::Less => {
                     let (lind, lval) = self.left.next().unwrap();
-                    Some(NnzEither::Left((lind, lval)))
+                    Some(Left((lind, lval)))
                 }
                 std::cmp::Ordering::Greater => {
                     let (rind, rval) = self.right.next().unwrap();
-                    Some(NnzEither::Right((rind, rval)))
+                    Some(Right((rind, rval)))
                 }
-                _ => {
+                std::cmp::Ordering::Equal => {
                     let (lind, lval) = self.left.next().unwrap();
                     let (_, rval) = self.right.next().unwrap();
-                    Some(NnzEither::Both((lind, lval, rval)))
+                    Some(Both((lind, lval, rval)))
                 }
             },
         }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -141,7 +141,7 @@ where
 
 /// Enable extraction of stack val from iterators
 pub fn extract_stack_val<I>(stack_val: &StackVal<I>) -> &I {
-    match *stack_val {
-        StackVal::Enter(ref i) | StackVal::Exit(ref i) => &i,
+    match stack_val {
+        StackVal::Enter(i) | StackVal::Exit(i) => i,
     }
 }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -142,7 +142,6 @@ where
 /// Enable extraction of stack val from iterators
 pub fn extract_stack_val<I>(stack_val: &StackVal<I>) -> &I {
     match *stack_val {
-        StackVal::Enter(ref i) => &i,
-        StackVal::Exit(ref i) => &i,
+        StackVal::Enter(ref i) | StackVal::Exit(ref i) => &i,
     }
 }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -22,8 +22,8 @@ pub enum StackVal<I> {
 }
 
 impl<I: Default> Default for StackVal<I> {
-    fn default() -> StackVal<I> {
-        StackVal::Enter(I::default())
+    fn default() -> Self {
+        Self::Enter(I::default())
     }
 }
 
@@ -32,12 +32,12 @@ where
     I: Copy,
 {
     /// Create a new double stacked suited for containing at most n elements
-    pub fn with_capacity(n: usize) -> DStack<I>
+    pub fn with_capacity(n: usize) -> Self
     where
         I: Default,
     {
         assert!(n > 1);
-        DStack {
+        Self {
             stacks: vec![I::default(); n],
             left_head: None,
             right_head: n,

--- a/suitesparse_bindings/suitesparse-src/src/lib.rs
+++ b/suitesparse_bindings/suitesparse-src/src/lib.rs
@@ -1,3 +1,3 @@
-//! This library is a stub to build SuiteSparse
+//! This library is a stub to build `SuiteSparse`
 //!
-//! Complete sources can be found at https://github.com/DrTimothyAldenDavis/SuiteSparse
+//! Complete sources can be found at `<https://github.com/DrTimothyAldenDavis/SuiteSparse>`

--- a/suitesparse_bindings/suitesparse_camd_sys/src/lib.rs
+++ b/suitesparse_bindings/suitesparse_camd_sys/src/lib.rs
@@ -1,4 +1,4 @@
-//! FFI bindings to the SuiteSparse component CAMD
+//! FFI bindings to the `SuiteSparse` component CAMD
 //!
 //! For a static build activate the "static" feature, which builds CAMD
 //! from source and includes this statically.


### PR DESCRIPTION
This is just a collection of clippy lints which are not enabled by default, but improves code consistency slightly. The documentation should be a bit prettier now with all `doc_markdown` lints fixed.