### PR TITLE
More ergonomic slicing

### DIFF
--- a/Guidelines.rst
+++ b/Guidelines.rst
@@ -40,3 +40,16 @@ using ``rustfmt`` on the latest stable Rust channel:
   cargo fmt --all
 
 .. _rustfmt: https://github.com/rust-lang-nursery/rustfmt
+
+Reborrowing
+===========
+
+Some methods return views of their containers, eg ``CsMatBase::slice_outer``
+returns a ``CsMatViewI``. However, in certain situations, mostly when
+implementing iterators, we are calling these kind of methods on a view, and
+need to take the lifetime of the view, not the lifetime of ``self`` in the
+method call. To deal with this issue, the method should in fact be implemented
+on the view type (on ``CsMatViewI`` in the example), with a ``_rbr`` suffix (
+``CsMatViewI::slice_outer_rbr`` in the example), and the implementation on the
+base type should simply call the view version (in the example, it should call
+``self.view().slice_outer_rbr(range)``).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub mod errors;
 pub mod indexing;
 pub mod io;
 pub mod num_kinds;
+mod range;
 mod sparse;
 pub mod stack;
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -48,3 +48,23 @@ impl Range for std::ops::RangeFull {
         None
     }
 }
+
+impl Range for std::ops::RangeInclusive<usize> {
+    fn start(&self) -> Option<usize> {
+        Some(*self.start())
+    }
+
+    fn end(&self) -> Option<usize> {
+        Some(*self.end() + 1)
+    }
+}
+
+impl Range for std::ops::RangeToInclusive<usize> {
+    fn start(&self) -> Option<usize> {
+        None
+    }
+
+    fn end(&self) -> Option<usize> {
+        Some(self.end + 1)
+    }
+}

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,0 +1,50 @@
+//! This module abstracts over ranges to allow functions in the crate to take
+//! ranges as input in an ergonomic way. It howvers seals this abstractions to
+//! leave full control in this crate.
+
+/// Abstract over `std::ops::{Range,RangeFrom,RangeTo,RangeFull}`
+pub trait Range {
+    fn start(&self) -> Option<usize>;
+
+    fn end(&self) -> Option<usize>;
+}
+
+impl Range for std::ops::Range<usize> {
+    fn start(&self) -> Option<usize> {
+        Some(self.start)
+    }
+
+    fn end(&self) -> Option<usize> {
+        Some(self.end)
+    }
+}
+
+impl Range for std::ops::RangeFrom<usize> {
+    fn start(&self) -> Option<usize> {
+        Some(self.start)
+    }
+
+    fn end(&self) -> Option<usize> {
+        None
+    }
+}
+
+impl Range for std::ops::RangeTo<usize> {
+    fn start(&self) -> Option<usize> {
+        None
+    }
+
+    fn end(&self) -> Option<usize> {
+        Some(self.end)
+    }
+}
+
+impl Range for std::ops::RangeFull {
+    fn start(&self) -> Option<usize> {
+        None
+    }
+
+    fn end(&self) -> Option<usize> {
+        None
+    }
+}

--- a/src/range.rs
+++ b/src/range.rs
@@ -4,14 +4,14 @@
 
 /// Abstract over `std::ops::{Range,RangeFrom,RangeTo,RangeFull}`
 pub trait Range {
-    fn start(&self) -> Option<usize>;
+    fn start(&self) -> usize;
 
     fn end(&self) -> Option<usize>;
 }
 
 impl Range for std::ops::Range<usize> {
-    fn start(&self) -> Option<usize> {
-        Some(self.start)
+    fn start(&self) -> usize {
+        self.start
     }
 
     fn end(&self) -> Option<usize> {
@@ -20,8 +20,8 @@ impl Range for std::ops::Range<usize> {
 }
 
 impl Range for std::ops::RangeFrom<usize> {
-    fn start(&self) -> Option<usize> {
-        Some(self.start)
+    fn start(&self) -> usize {
+        self.start
     }
 
     fn end(&self) -> Option<usize> {
@@ -30,8 +30,8 @@ impl Range for std::ops::RangeFrom<usize> {
 }
 
 impl Range for std::ops::RangeTo<usize> {
-    fn start(&self) -> Option<usize> {
-        None
+    fn start(&self) -> usize {
+        0
     }
 
     fn end(&self) -> Option<usize> {
@@ -40,8 +40,8 @@ impl Range for std::ops::RangeTo<usize> {
 }
 
 impl Range for std::ops::RangeFull {
-    fn start(&self) -> Option<usize> {
-        None
+    fn start(&self) -> usize {
+        0
     }
 
     fn end(&self) -> Option<usize> {
@@ -50,8 +50,8 @@ impl Range for std::ops::RangeFull {
 }
 
 impl Range for std::ops::RangeInclusive<usize> {
-    fn start(&self) -> Option<usize> {
-        Some(*self.start())
+    fn start(&self) -> usize {
+        *self.start()
     }
 
     fn end(&self) -> Option<usize> {
@@ -60,8 +60,8 @@ impl Range for std::ops::RangeInclusive<usize> {
 }
 
 impl Range for std::ops::RangeToInclusive<usize> {
-    fn start(&self) -> Option<usize> {
-        None
+    fn start(&self) -> usize {
+        0
     }
 
     fn end(&self) -> Option<usize> {

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -418,6 +418,7 @@ pub mod kronecker;
 pub mod linalg;
 pub mod permutation;
 pub mod prod;
+pub mod slicing;
 pub mod smmp;
 pub mod special_mats;
 pub mod symmetric;

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1194,7 +1194,7 @@ where
             } else {
                 block_size
             };
-            self.view().slice_outer(i..i + count)
+            self.view().slice_outer_rbr(i..i + count)
         })
     }
 

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -682,7 +682,7 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
             storage: self.storage,
             nrows,
             ncols,
-            indptr: self.indptr.middle_slice(i, iend),
+            indptr: self.indptr.middle_slice(i..iend),
             indices: &self.indices[data_range.clone()],
             data: &self.data[data_range],
         }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -691,7 +691,7 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
             storage: self.storage,
             nrows,
             ncols,
-            indptr: self.indptr.middle_slice(i..iend),
+            indptr: self.indptr.middle_slice_rbr(i..iend),
             indices: &self.indices[data_range.clone()],
             data: &self.data[data_range],
         }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -667,6 +667,15 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
     /// Get a view into count contiguous outer dimensions, starting from i.
     ///
     /// eg this gets the rows from i to i + count in a CSR matrix
+    ///
+    /// This function is now deprecated, as using an index and a count is not
+    /// ergonomic. The replacement, `slice_outer`, leverages the
+    /// `std::ops::Range` family of types, which is better integrated into the
+    /// ecosystem.
+    #[deprecated(
+        since = "0.10.0",
+        note = "Please use the `slice_outer` method instead"
+    )]
     pub fn middle_outer_views(
         &self,
         i: usize,
@@ -1185,7 +1194,7 @@ where
             } else {
                 block_size
             };
-            self.view().middle_outer_views(i, count)
+            self.view().slice_outer(i..i + count)
         })
     }
 
@@ -2556,11 +2565,13 @@ mod test {
     fn middle_outer_views() {
         let size = 11;
         let csr: CsMat<f64> = CsMat::eye(size);
+        #[allow(deprecated)]
         let v = csr.view().middle_outer_views(1, 3);
         assert_eq!(v.shape(), (3, size));
         assert_eq!(v.nnz(), 3);
 
         let csc = csr.to_other_storage();
+        #[allow(deprecated)]
         let v = csc.view().middle_outer_views(1, 3);
         assert_eq!(v.shape(), (size, 3));
         assert_eq!(v.nnz(), 3);

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1518,6 +1518,18 @@ where
             }
         })
     }
+
+    /// Return a mutable view into the current matrix
+    pub fn view_mut(&mut self) -> CsMatViewMutI<N, I, Iptr> {
+        CsMatViewMutI {
+            storage: self.storage,
+            nrows: self.nrows,
+            ncols: self.ncols,
+            indptr: crate::IndPtrView::new_trusted(self.indptr.raw_storage()),
+            indices: &self.indices[..],
+            data: &mut self.data[..],
+        }
+    }
 }
 
 impl<N, I, Iptr, IptrStorage, IndStorage, DataStorage>

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -388,7 +388,7 @@ impl<Iptr: SpIndex> IndPtr<Iptr> {
         &self,
         range: impl crate::range::Range,
     ) -> IndPtrView<Iptr> {
-        let start = range.start().unwrap_or(0);
+        let start = range.start();
         let end = range.end().unwrap_or_else(|| self.outer_dims());
         IndPtrView {
             storage: &self.storage[start..=end],
@@ -404,7 +404,7 @@ impl<'a, Iptr: SpIndex> IndPtrView<'a, Iptr> {
         &self,
         range: impl crate::range::Range,
     ) -> IndPtrView<'a, Iptr> {
-        let start = range.start().unwrap_or(0);
+        let start = range.start();
         let end = range.end().unwrap_or_else(|| self.outer_dims());
         IndPtrView {
             storage: &self.storage[start..=end],

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -389,7 +389,7 @@ impl<Iptr: SpIndex> IndPtr<Iptr> {
         range: impl crate::range::Range,
     ) -> IndPtrView<Iptr> {
         let start = range.start().unwrap_or(0);
-        let end = range.end().unwrap_or(self.outer_dims());
+        let end = range.end().unwrap_or_else(|| self.outer_dims());
         IndPtrView {
             storage: &self.storage[start..=end],
         }
@@ -405,7 +405,7 @@ impl<'a, Iptr: SpIndex> IndPtrView<'a, Iptr> {
         range: impl crate::range::Range,
     ) -> IndPtrView<'a, Iptr> {
         let start = range.start().unwrap_or(0);
-        let end = range.end().unwrap_or(self.outer_dims());
+        let end = range.end().unwrap_or_else(|| self.outer_dims());
         IndPtrView {
             storage: &self.storage[start..=end],
         }

--- a/src/sparse/indptr.rs
+++ b/src/sparse/indptr.rs
@@ -381,6 +381,19 @@ impl<Iptr: SpIndex> IndPtr<Iptr> {
             *val += Iptr::one();
         }
     }
+
+    /// Slice this indptr to include only the outer dimensions in the range
+    /// `start..end`.
+    pub(crate) fn middle_slice(
+        &self,
+        range: impl crate::range::Range,
+    ) -> IndPtrView<Iptr> {
+        let start = range.start().unwrap_or(0);
+        let end = range.end().unwrap_or(self.outer_dims());
+        IndPtrView {
+            storage: &self.storage[start..=end],
+        }
+    }
 }
 
 impl<'a, Iptr: SpIndex> IndPtrView<'a, Iptr> {
@@ -389,9 +402,10 @@ impl<'a, Iptr: SpIndex> IndPtrView<'a, Iptr> {
     /// in this view
     pub(crate) fn middle_slice(
         &self,
-        start: usize,
-        end: usize,
+        range: impl crate::range::Range,
     ) -> IndPtrView<'a, Iptr> {
+        let start = range.start().unwrap_or(0);
+        let end = range.end().unwrap_or(self.outer_dims());
         IndPtrView {
             storage: &self.storage[start..=end],
         }

--- a/src/sparse/slicing.rs
+++ b/src/sparse/slicing.rs
@@ -60,7 +60,7 @@ where
             nrows,
             ncols,
             storage: self.storage,
-            indptr: self.indptr.middle_slice(range),
+            indptr: self.indptr.middle_slice_rbr(range),
             indices: &self.indices[outer_inds_slice.clone()],
             data: &self.data[outer_inds_slice],
         }

--- a/src/sparse/slicing.rs
+++ b/src/sparse/slicing.rs
@@ -1,0 +1,122 @@
+//! This module implementations to slice a matrix along the desired dimension.
+//! We're using a sealed trait to enable using ranges for an idiomatic API.
+
+use crate::range::Range;
+
+impl<N, I, Iptr> crate::CsMatI<N, I, Iptr>
+where
+    I: crate::SpIndex,
+    Iptr: crate::SpIndex,
+{
+    /// Slice the outer dimension of the matrix according to the specified
+    /// range.
+    pub fn slice_outer<S>(&self, range: S) -> crate::CsMatViewI<N, I, Iptr>
+    where
+        S: Range,
+    {
+        let start = range.start().unwrap_or(0);
+        let end = range.end().unwrap_or(self.outer_dims());
+        if end < start {
+            panic!("Invalid view");
+        }
+        let outer_inds_slice = self.indptr.outer_inds_slice(start, end);
+        let (nrows, ncols) = match self.storage() {
+            crate::CSR => ((end - start), self.ncols),
+            crate::CSC => (self.nrows, (end - start)),
+        };
+        crate::CsMatViewI {
+            nrows,
+            ncols,
+            storage: self.storage,
+            indptr: self.indptr.middle_slice(range),
+            indices: &self.indices[outer_inds_slice.clone()],
+            data: &self.data[outer_inds_slice],
+        }
+    }
+}
+
+impl<'a, N, I, Iptr> crate::CsMatViewI<'a, N, I, Iptr>
+where
+    I: crate::SpIndex,
+    Iptr: crate::SpIndex,
+{
+    /// Slice the outer dimension of the matrix according to the specified
+    /// range.
+    pub fn slice_outer<S>(&self, range: S) -> crate::CsMatViewI<'a, N, I, Iptr>
+    where
+        S: Range,
+    {
+        let start = range.start().unwrap_or(0);
+        let end = range.end().unwrap_or(self.outer_dims());
+        if end < start {
+            panic!("Invalid view");
+        }
+        let outer_inds_slice = self.indptr.outer_inds_slice(start, end);
+        let (nrows, ncols) = match self.storage() {
+            crate::CSR => ((end - start), self.ncols),
+            crate::CSC => (self.nrows, (end - start)),
+        };
+        crate::CsMatViewI {
+            nrows,
+            ncols,
+            storage: self.storage,
+            indptr: self.indptr.middle_slice(range),
+            indices: &self.indices[outer_inds_slice.clone()],
+            data: &self.data[outer_inds_slice],
+        }
+    }
+}
+
+impl<'a, N, I, Iptr> crate::CsMatViewMutI<'a, N, I, Iptr>
+where
+    I: crate::SpIndex,
+    Iptr: crate::SpIndex,
+{
+    /// Slice the outer dimension of the matrix according to the specified
+    /// range.
+    pub fn slice_outer<S>(
+        &mut self,
+        range: S,
+    ) -> crate::CsMatViewMutI<N, I, Iptr>
+    where
+        S: Range,
+    {
+        let start = range.start().unwrap_or(0);
+        let end = range.end().unwrap_or(self.outer_dims());
+        if end < start {
+            panic!("Invalid view");
+        }
+        let outer_inds_slice = self.indptr.outer_inds_slice(start, end);
+        let (nrows, ncols) = match self.storage() {
+            crate::CSR => ((end - start), self.ncols),
+            crate::CSC => (self.nrows, (end - start)),
+        };
+        crate::CsMatViewMutI {
+            nrows,
+            ncols,
+            storage: self.storage,
+            indptr: self.indptr.middle_slice(range),
+            indices: &self.indices[outer_inds_slice.clone()],
+            data: &mut self.data[outer_inds_slice],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::CsMat;
+
+    #[test]
+    fn slice_outer() {
+        let size = 11;
+        let csr: CsMat<f64> = CsMat::eye(size);
+        let sliced = csr.view().slice_outer(2..7);
+        let mut iter = sliced.into_iter();
+        assert_eq!(iter.next().unwrap(), (&1., (0, 2)));
+        assert_eq!(iter.next().unwrap(), (&1., (1, 3)));
+        assert_eq!(iter.next().unwrap(), (&1., (2, 4)));
+        assert_eq!(iter.next().unwrap(), (&1., (3, 5)));
+        assert_eq!(iter.next().unwrap(), (&1., (4, 6)));
+        assert!(iter.next().is_none());
+    }
+}

--- a/src/sparse/slicing.rs
+++ b/src/sparse/slicing.rs
@@ -15,7 +15,7 @@ where
         S: Range,
     {
         let start = range.start().unwrap_or(0);
-        let end = range.end().unwrap_or(self.outer_dims());
+        let end = range.end().unwrap_or_else(|| self.outer_dims());
         if end < start {
             panic!("Invalid view");
         }
@@ -47,7 +47,7 @@ where
         S: Range,
     {
         let start = range.start().unwrap_or(0);
-        let end = range.end().unwrap_or(self.outer_dims());
+        let end = range.end().unwrap_or_else(|| self.outer_dims());
         if end < start {
             panic!("Invalid view");
         }
@@ -82,7 +82,7 @@ where
         S: Range,
     {
         let start = range.start().unwrap_or(0);
-        let end = range.end().unwrap_or(self.outer_dims());
+        let end = range.end().unwrap_or_else(|| self.outer_dims());
         if end < start {
             panic!("Invalid view");
         }

--- a/src/sparse/slicing.rs
+++ b/src/sparse/slicing.rs
@@ -14,7 +14,7 @@ where
     where
         S: Range,
     {
-        let start = range.start().unwrap_or(0);
+        let start = range.start();
         let end = range.end().unwrap_or_else(|| self.outer_dims());
         if end < start {
             panic!("Invalid view");
@@ -46,7 +46,7 @@ where
     where
         S: Range,
     {
-        let start = range.start().unwrap_or(0);
+        let start = range.start();
         let end = range.end().unwrap_or_else(|| self.outer_dims());
         if end < start {
             panic!("Invalid view");
@@ -81,7 +81,7 @@ where
     where
         S: Range,
     {
-        let start = range.start().unwrap_or(0);
+        let start = range.start();
         let end = range.end().unwrap_or_else(|| self.outer_dims());
         if end < start {
             panic!("Invalid view");

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -304,7 +304,7 @@ where
         } else {
             l_rows
         };
-        lhs_chunks.push(lhs.middle_outer_views(start, stop - start));
+        lhs_chunks.push(lhs.slice_outer(start..stop));
         res_indptr_chunks.push(vec![Iptr::zero(); stop - start + 1]);
         res_indices_chunks
             .push(Vec::with_capacity(lhs.nnz() + rhs.nnz() / chunk_size));
@@ -366,8 +366,7 @@ where
     for (row, nnz) in res_indptr.iter().enumerate() {
         let nnz = nnz.index();
         if nnz - split_nnz > chunk_size && row > 0 {
-            lhs_chunks
-                .push(lhs.middle_outer_views(split_row, row - 1 - split_row));
+            lhs_chunks.push(lhs.slice_outer(split_row..row - 1));
 
             res_indptr_chunks.push(&res_indptr[split_row..row]);
 
@@ -386,7 +385,7 @@ where
         }
         prev_nnz = nnz;
     }
-    lhs_chunks.push(lhs.middle_outer_views(split_row, lhs.rows() - split_row));
+    lhs_chunks.push(lhs.slice_outer(split_row..lhs.rows()));
     res_indptr_chunks.push(&res_indptr[split_row..]);
     res_indices_chunks.push(res_indices_rem);
     res_data_chunks.push(res_data_rem);

--- a/tests/slicing.rs
+++ b/tests/slicing.rs
@@ -21,8 +21,7 @@ fn slice_outer_mut() {
     use sprs::CsMat;
     let size = 11;
     let mut csr: CsMat<f64> = CsMat::eye(size);
-    let mut csr_mut_view = csr.view_mut();
-    let mut sliced = csr_mut_view.slice_outer(2..7);
+    let mut sliced = csr.slice_outer_mut(2..7);
     sliced.scale(2.);
     let mut iter = sliced.into_iter();
     assert_eq!(iter.next().unwrap(), (&2., (0, 2)));
@@ -52,7 +51,7 @@ fn slice_outer_other_ranges() {
     use sprs::CsMat;
     let size = 11;
     let csr: CsMat<f64> = CsMat::eye(size);
-    let sliced = csr.view().slice_outer(..5);
+    let sliced = csr.slice_outer(..5);
     let mut iter = sliced.into_iter();
     assert_eq!(iter.next().unwrap(), (&1., (0, 0)));
     assert_eq!(iter.next().unwrap(), (&1., (1, 1)));
@@ -61,12 +60,12 @@ fn slice_outer_other_ranges() {
     assert_eq!(iter.next().unwrap(), (&1., (4, 4)));
     assert!(iter.next().is_none());
 
-    let sliced = csr.view().slice_outer(9..);
+    let sliced = csr.slice_outer(9..);
     let mut iter = sliced.into_iter();
     assert_eq!(iter.next().unwrap(), (&1., (0, 9)));
     assert_eq!(iter.next().unwrap(), (&1., (1, 10)));
     assert!(iter.next().is_none());
 
-    let sliced = csr.view().slice_outer(..);
+    let sliced = csr.slice_outer(..);
     assert_eq!(sliced, csr.view());
 }

--- a/tests/slicing.rs
+++ b/tests/slicing.rs
@@ -1,0 +1,72 @@
+//! Test slicing from outside the crate to ensure the sealed trait
+//! for ranges is effective
+
+#[test]
+fn slice_outer() {
+    use sprs::CsMat;
+    let size = 11;
+    let csr: CsMat<f64> = CsMat::eye(size);
+    let sliced = csr.slice_outer(2..7);
+    let mut iter = sliced.into_iter();
+    assert_eq!(iter.next().unwrap(), (&1., (0, 2)));
+    assert_eq!(iter.next().unwrap(), (&1., (1, 3)));
+    assert_eq!(iter.next().unwrap(), (&1., (2, 4)));
+    assert_eq!(iter.next().unwrap(), (&1., (3, 5)));
+    assert_eq!(iter.next().unwrap(), (&1., (4, 6)));
+    assert!(iter.next().is_none());
+}
+
+#[test]
+fn slice_outer_mut() {
+    use sprs::CsMat;
+    let size = 11;
+    let mut csr: CsMat<f64> = CsMat::eye(size);
+    let mut csr_mut_view = csr.view_mut();
+    let mut sliced = csr_mut_view.slice_outer(2..7);
+    sliced.scale(2.);
+    let mut iter = sliced.into_iter();
+    assert_eq!(iter.next().unwrap(), (&2., (0, 2)));
+    assert_eq!(iter.next().unwrap(), (&2., (1, 3)));
+    assert_eq!(iter.next().unwrap(), (&2., (2, 4)));
+    assert_eq!(iter.next().unwrap(), (&2., (3, 5)));
+    assert_eq!(iter.next().unwrap(), (&2., (4, 6)));
+    assert!(iter.next().is_none());
+
+    let mut iter = csr.into_iter();
+    assert_eq!(iter.next().unwrap(), (&1., (0, 0)));
+    assert_eq!(iter.next().unwrap(), (&1., (1, 1)));
+    assert_eq!(iter.next().unwrap(), (&2., (2, 2)));
+    assert_eq!(iter.next().unwrap(), (&2., (3, 3)));
+    assert_eq!(iter.next().unwrap(), (&2., (4, 4)));
+    assert_eq!(iter.next().unwrap(), (&2., (5, 5)));
+    assert_eq!(iter.next().unwrap(), (&2., (6, 6)));
+    assert_eq!(iter.next().unwrap(), (&1., (7, 7)));
+    assert_eq!(iter.next().unwrap(), (&1., (8, 8)));
+    assert_eq!(iter.next().unwrap(), (&1., (9, 9)));
+    assert_eq!(iter.next().unwrap(), (&1., (10, 10)));
+    assert!(iter.next().is_none());
+}
+
+#[test]
+fn slice_outer_other_ranges() {
+    use sprs::CsMat;
+    let size = 11;
+    let csr: CsMat<f64> = CsMat::eye(size);
+    let sliced = csr.view().slice_outer(..5);
+    let mut iter = sliced.into_iter();
+    assert_eq!(iter.next().unwrap(), (&1., (0, 0)));
+    assert_eq!(iter.next().unwrap(), (&1., (1, 1)));
+    assert_eq!(iter.next().unwrap(), (&1., (2, 2)));
+    assert_eq!(iter.next().unwrap(), (&1., (3, 3)));
+    assert_eq!(iter.next().unwrap(), (&1., (4, 4)));
+    assert!(iter.next().is_none());
+
+    let sliced = csr.view().slice_outer(9..);
+    let mut iter = sliced.into_iter();
+    assert_eq!(iter.next().unwrap(), (&1., (0, 9)));
+    assert_eq!(iter.next().unwrap(), (&1., (1, 10)));
+    assert!(iter.next().is_none());
+
+    let sliced = csr.view().slice_outer(..);
+    assert_eq!(sliced, csr.view());
+}


### PR DESCRIPTION
As mentionned in #250, the slicing of middle matrices along the outer dimension is quite cumbersome to use, which is particularly visible in the matrix product implementation in `smmp.rs`. This PR tries to propose a more ergonomic API.