### PR TITLE
Add  `diag` method to CsMatBase

### DIFF
--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1140,7 +1140,7 @@ where
     }
 
     /// Get the diagonal of a sparse matrix
-    pub fn diag(&self) -> CsVecI<N, I> 
+    pub fn diag(&self) -> CsVecI<N, I>
     where
         N: Clone,
     {
@@ -1155,7 +1155,7 @@ where
                 Some(idx) => {
                     data_vec.push(self[idx].clone());
                     index_vec.push(I::from_usize(i));
-                },
+                }
                 None => (),
             }
         }
@@ -2248,7 +2248,7 @@ where
 mod test {
     use super::CompressedStorage::{CSC, CSR};
     use crate::errors::SprsError;
-    use crate::sparse::{CsMat, CsVec, CsMatI, CsMatView};
+    use crate::sparse::{CsMat, CsMatI, CsMatView, CsVec};
     use crate::test_data::{mat1, mat1_csc, mat1_times_2};
     use ndarray::{arr2, Array};
 
@@ -2823,7 +2823,6 @@ mod test {
         let expected = CsVec::new(5, vec![0, 1, 3, 4], vec![1, 2, 1, 1]);
         assert_eq!(diag, expected);
     }
-
 
     #[test]
     fn onehot_zero() {

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -2827,25 +2827,6 @@ mod test {
     }
 
     #[test]
-    fn diag_using_shrink_to_fit() {
-        // | 1 0 0 3 1 |
-        // | 0 0 0 0 0 |
-        // | 0 0 0 1 0 |
-        // | 3 0 1 0 0 |
-        // | 1 0 0 0 0 |
-        let mat = CsMat::new_csc(
-            (5, 5),
-            vec![0, 3, 3, 4, 6, 7],
-            vec![0, 3, 4, 3, 0, 2, 0],
-            vec![1, 3, 1, 1, 3, 1, 1],
-        );
-
-        let diag = mat.diag();
-        let expected = CsVec::new(5, vec![0], vec![1]);
-        assert_eq!(diag, expected);
-    }
-
-    #[test]
     fn diag_rectangular() {
         // | 1 0 0 3 1 3|
         // | 0 2 0 0 0 0|

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1151,12 +1151,9 @@ where
         let mut optional_index: Option<NnzIndex>;
         for i in 0..smallest_dim {
             optional_index = self.nnz_index(i, i);
-            match optional_index {
-                Some(idx) => {
-                    data_vec.push(self[idx].clone());
-                    index_vec.push(I::from_usize(i));
-                }
-                None => (),
+            if let Some(idx) = optional_index {
+                data_vec.push(self[idx].clone());
+                index_vec.push(I::from_usize(i));
             }
         }
         CsVecI {

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -2827,6 +2827,25 @@ mod test {
     }
 
     #[test]
+    fn diag_using_shrink_to_fit() {
+        // | 1 0 0 3 1 |
+        // | 0 0 0 0 0 |
+        // | 0 0 0 1 0 |
+        // | 3 0 1 0 0 |
+        // | 1 0 0 0 0 |
+        let mat = CsMat::new_csc(
+            (5, 5),
+            vec![0, 3, 3, 4, 6, 7],
+            vec![0, 3, 4, 3, 0, 2, 0],
+            vec![1, 3, 1, 1, 3, 1, 1],
+        );
+
+        let diag = mat.diag();
+        let expected = CsVec::new(5, vec![0], vec![1]);
+        assert_eq!(diag, expected);
+    }
+
+    #[test]
     fn diag_rectangular() {
         // | 1 0 0 3 1 3|
         // | 0 2 0 0 0 0|

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1159,6 +1159,8 @@ where
                 index_vec.push(I::from_usize(i));
             }
         }
+        data_vec.shrink_to_fit();
+        index_vec.shrink_to_fit();
         CsVecI {
             dim: smallest_dim,
             indices: index_vec,


### PR DESCRIPTION
A method to add fetching the diagonal of a matrix. 

I'm quite new to Rust, so I'm not sure if this useful. It's intended to spark a discussion around the implementation. I really wanted the a `diag_view` method, but I'm not sure how to implement it, so ideas are welcome.