### PR TITLE
add miri workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,3 +218,20 @@ jobs:
       run: |
           cd suitesparse_bindings/sprs_suitesparse_ldl
           cargo test --features suitesparse_ldl_sys/static
+  miri:
+    name: Miri
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with: {submodules: false}
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+          components: miri
+    - name: Run test
+      run: |
+          cargo miri test --no-default-features --features alga,approx,serde

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ assert_eq!(a, b.to_csc());
 pub mod array_backend;
 pub mod errors;
 pub mod indexing;
+#[cfg(not(miri))]
 pub mod io;
 pub mod num_kinds;
 mod range;


### PR DESCRIPTION
If we have to add some unsafe code we should ensure we don't do it wildly wrong. I suggest adding `miri` to the CI which could catch some undefined behaviour.

The `io` module can not be tested with `miri` as file operations are not supported