### PR TITLE
Split the error type between structural and linalg errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,37 +1,134 @@
 //! Error type for sprs
 
-use std::error::Error;
-use std::fmt;
-
-#[derive(PartialEq, Debug)]
-pub enum SprsError {
-    NonSortedIndices,
-    UnsortedIndptr,
-    SingularMatrix,
-    IllegalArguments(&'static str),
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum StructureError {
+    Unsorted(&'static str),
+    SizeMismatch(&'static str),
+    OutOfRange(&'static str),
 }
 
-use self::SprsError::*;
+#[derive(PartialEq, Debug, Copy, Clone)]
+#[non_exhaustive]
+pub enum StructureErrorKind {
+    Unsorted,
+    SizeMismatch,
+    OutOfRange,
+}
 
-impl SprsError {
-    fn descr(&self) -> &str {
-        match *self {
-            NonSortedIndices => "a vector's indices are not sorted",
-            UnsortedIndptr => "indptr is not sorted",
-            SingularMatrix => "matrix is singular",
-            IllegalArguments(s) => s,
+impl StructureError {
+    pub fn kind(&self) -> StructureErrorKind {
+        match self {
+            StructureError::Unsorted(_) => StructureErrorKind::Unsorted,
+            StructureError::SizeMismatch(_) => StructureErrorKind::SizeMismatch,
+            StructureError::OutOfRange(_) => StructureErrorKind::OutOfRange,
+        }
+    }
+
+    fn kind_str(&self) -> &str {
+        match self {
+            StructureError::Unsorted(_) => "unsorted",
+            StructureError::SizeMismatch(_) => "size mismatch",
+            StructureError::OutOfRange(_) => "out of range",
+        }
+    }
+
+    fn msg(&self) -> &str {
+        match self {
+            StructureError::Unsorted(s)
+            | StructureError::SizeMismatch(s)
+            | StructureError::OutOfRange(s) => s,
         }
     }
 }
 
-impl Error for SprsError {
-    fn description(&self) -> &str {
-        self.descr()
+impl std::fmt::Display for StructureError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Structure Error ({}): {}", self.kind_str(), self.msg())
     }
 }
 
-impl fmt::Display for SprsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.descr().fmt(f)
+impl std::error::Error for StructureError {}
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub struct ShapeMismatchInfo {
+    pub expected: (usize, usize),
+    pub received: (usize, usize),
+}
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub struct SingularMatrixInfo {
+    pub index: usize,
+    pub reason: &'static str,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+#[non_exhaustive]
+pub enum LinalgError {
+    ShapeMismatch(ShapeMismatchInfo),
+    NonSquareMatrix,
+    SingularMatrix(SingularMatrixInfo),
+    ThirdPartyError(isize, &'static str),
+}
+
+impl std::fmt::Display for LinalgError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            LinalgError::ShapeMismatch(shapes) => {
+                write!(
+                    f,
+                    "Shape mismatch: expected ({}, {}), got ({}, {})",
+                    shapes.expected.0,
+                    shapes.expected.1,
+                    shapes.received.0,
+                    shapes.received.1,
+                )
+            }
+            LinalgError::NonSquareMatrix => write!(f, "Non square matrix"),
+            LinalgError::SingularMatrix(info) => {
+                write!(
+                    f,
+                    "Singular matrix at index {} ({})",
+                    info.index, info.reason,
+                )
+            }
+            LinalgError::ThirdPartyError(code, msg) => {
+                write!(f, "Third party error: {} (code {})", msg, code,)
+            }
+        }
     }
 }
+
+impl std::error::Error for LinalgError {}
+
+/// Convenience wrapper around more precise error types. Not returned by
+/// functions in this crate, but can be easily obtained from any error
+/// returned in this crate using `Into` and `From`.
+#[derive(PartialEq, Debug, Clone)]
+#[non_exhaustive]
+pub enum SprsError {
+    Structure(StructureError),
+    Linalg(LinalgError),
+}
+
+impl From<StructureError> for SprsError {
+    fn from(e: StructureError) -> Self {
+        Self::Structure(e)
+    }
+}
+
+impl From<LinalgError> for SprsError {
+    fn from(e: LinalgError) -> Self {
+        Self::Linalg(e)
+    }
+}
+
+impl std::fmt::Display for SprsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Structure(e) => write!(f, "Structure error: {}", e),
+            Self::Linalg(e) => write!(f, "Linalg error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for SprsError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,6 @@ pub use crate::sparse::to_dense::assign_to_dense;
 /// columns.
 pub type Shape = (usize, usize); // FIXME: maybe we could use Ix2 here?
 
-pub type SpRes<T> = Result<T, errors::SprsError>;
-
 /// Configuration enum to ask for symmetry checks in algorithms
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum SymmetryCheck {

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -1,4 +1,6 @@
-///! Sparse matrix addition, subtraction
+//! Sparse matrix addition, subtraction
+
+use crate::errors::StructureError;
 use crate::indexing::SpIndex;
 use crate::sparse::compressed::SpMatView;
 use crate::sparse::csmat::CompressedStorage;
@@ -12,7 +14,6 @@ use ndarray::{
 use num_traits::Num;
 
 use crate::Ix2;
-use crate::SpRes;
 
 /// Sparse matrix addition, with matrices sharing the same storage type
 pub fn add_mat_same_storage<N, I, Iptr, Mat1, Mat2>(
@@ -318,7 +319,7 @@ pub fn csvec_binop<N, I, F>(
     mut lhs: CsVecViewI<N, I>,
     mut rhs: CsVecViewI<N, I>,
     binop: F,
-) -> SpRes<CsVecI<N, I>>
+) -> Result<CsVecI<N, I>, StructureError>
 where
     N: Num,
     F: Fn(&N, &N) -> N,

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1517,11 +1517,11 @@ where
     /// This iterator yields mutable sparse vector views for each outer
     /// dimension. Only the non-zero values can be modified, the
     /// structure is kept immutable.
-    pub fn outer_iterator_mut<'a>(
-        &'a mut self,
-    ) -> impl std::iter::DoubleEndedIterator<Item = CsVecViewMutI<'a, N, I>>
-           + std::iter::ExactSizeIterator<Item = CsVecViewMutI<'a, N, I>>
-           + 'a {
+    pub fn outer_iterator_mut(
+        &mut self,
+    ) -> impl std::iter::DoubleEndedIterator<Item = CsVecViewMutI<N, I>>
+           + std::iter::ExactSizeIterator<Item = CsVecViewMutI<N, I>>
+           + '_ {
         let inner_dim = self.inner_dims();
         let indices = &self.indices[..];
         let data_ptr: *mut N = self.data.as_mut_ptr();

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -25,7 +25,7 @@ use ndarray::{self, Array, ArrayBase, ShapeBuilder};
 use crate::array_backend::Array2;
 use crate::indexing::SpIndex;
 
-use crate::errors::SprsError;
+use crate::errors::StructureError;
 use crate::sparse::binop;
 use crate::sparse::compressed::SpMatView;
 use crate::sparse::permutation::PermViewI;
@@ -150,7 +150,7 @@ where
         indptr: IptrStorage,
         indices: IStorage,
         data: DStorage,
-    ) -> Result<Self, (IptrStorage, IStorage, DStorage, SprsError)> {
+    ) -> Result<Self, (IptrStorage, IStorage, DStorage, StructureError)> {
         let (nrows, ncols) = shape;
         let (inner, outer) = match storage {
             CSR => (ncols, nrows),
@@ -161,7 +161,7 @@ where
                 indptr,
                 indices,
                 data,
-                SprsError::IllegalArguments(
+                StructureError::SizeMismatch(
                     "data and indices have different sizes",
                 ),
             ));
@@ -198,7 +198,7 @@ where
         indptr: IptrStorage,
         mut indices: IStorage,
         mut data: DStorage,
-    ) -> Result<Self, (IptrStorage, IStorage, DStorage, SprsError)>
+    ) -> Result<Self, (IptrStorage, IStorage, DStorage, StructureError)>
     where
         N: Copy,
     {
@@ -212,7 +212,7 @@ where
                 indptr,
                 indices,
                 data,
-                SprsError::IllegalArguments(
+                StructureError::SizeMismatch(
                     "data and indices have different sizes",
                 ),
             ));
@@ -356,7 +356,7 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
         indptr: Vec<Iptr>,
         indices: Vec<I>,
         data: Vec<N>,
-    ) -> Result<Self, SprsError>
+    ) -> Result<Self, StructureError>
     where
         N: Copy,
     {
@@ -398,7 +398,7 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
         indptr: Vec<Iptr>,
         indices: Vec<I>,
         data: Vec<N>,
-    ) -> Result<Self, SprsError>
+    ) -> Result<Self, StructureError>
     where
         N: Copy,
     {
@@ -626,7 +626,7 @@ impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
         indptr: &'a [Iptr],
         indices: &'a [I],
         data: &'a [N],
-    ) -> Result<Self, SprsError> {
+    ) -> Result<Self, StructureError> {
         Self::new_checked(storage, shape, indptr, indices, data)
             .map_err(|(_, _, _, e)| e)
     }
@@ -1281,12 +1281,12 @@ where
     ///   indices and indptr would take more space than the addressable memory
     /// * indices is sorted for each outer slice
     /// * indices are lower than `inner_dims()`
-    pub fn check_compressed_structure(&self) -> Result<(), SprsError> {
+    pub fn check_compressed_structure(&self) -> Result<(), StructureError> {
         let inner = self.inner_dims();
         let outer = self.outer_dims();
 
         if self.indices.len() != self.data.len() {
-            return Err(SprsError::IllegalArguments(
+            return Err(StructureError::SizeMismatch(
                 "Indices and data lengths do not match",
             ));
         }
@@ -2312,7 +2312,7 @@ where
 #[cfg(test)]
 mod test {
     use super::CompressedStorage::{CSC, CSR};
-    use crate::errors::SprsError;
+    use crate::errors::StructureErrorKind;
     use crate::sparse::{CsMat, CsMatI, CsMatView, CsVec};
     use crate::test_data::{mat1, mat1_csc, mat1_times_2};
     use ndarray::{arr2, Array};
@@ -2407,8 +2407,10 @@ mod test {
         let data_ok: &[f64] = &[1., 1., 1.];
         let indptr_fail3: &[usize] = &[0, 2, 1, 3];
         assert_eq!(
-            CsMatView::new_view(CSR, (3, 3), indptr_fail3, indices_ok, data_ok),
-            Err(SprsError::UnsortedIndptr)
+            CsMatView::new_view(CSR, (3, 3), indptr_fail3, indices_ok, data_ok)
+                .unwrap_err()
+                .kind(),
+            StructureErrorKind::Unsorted
         );
     }
 
@@ -2422,8 +2424,10 @@ mod test {
             0.88132896, 0.72527863,
         ];
         assert_eq!(
-            CsMatView::new_view(CSR, (5, 5), indptr, indices, data),
-            Err(SprsError::NonSortedIndices)
+            CsMatView::new_view(CSR, (5, 5), indptr, indices, data)
+                .unwrap_err()
+                .kind(),
+            StructureErrorKind::Unsorted
         );
     }
 

--- a/src/sparse/serde_traits.rs
+++ b/src/sparse/serde_traits.rs
@@ -47,7 +47,7 @@ where
     IStorage: Deref<Target = [I]>,
     DStorage: Deref<Target = [N]>,
 {
-    type Error = SprsError;
+    type Error = StructureError;
     fn try_from(
         val: CsVecBaseShadow<IStorage, DStorage, N, I>,
     ) -> Result<Self, Self::Error> {
@@ -81,7 +81,7 @@ where
     IptrStorage: Deref<Target = [Iptr]>,
     DStorage: Deref<Target = [N]>,
 {
-    type Error = SprsError;
+    type Error = StructureError;
     fn try_from(
         val: CsMatBaseShadow<N, I, IptrStorage, IndStorage, DStorage, Iptr>,
     ) -> Result<Self, Self::Error> {
@@ -113,11 +113,11 @@ impl<Iptr: SpIndex, Storage> TryFrom<IndPtrBaseShadow<Iptr, Storage>>
 where
     Storage: Deref<Target = [Iptr]>,
 {
-    type Error = SprsError;
+    type Error = StructureError;
     fn try_from(
         val: IndPtrBaseShadow<Iptr, Storage>,
     ) -> Result<Self, Self::Error> {
         let IndPtrBaseShadow { storage } = val;
-        Self::new(storage)
+        Self::new_checked(storage).map_err(|(_, e)| e)
     }
 }

--- a/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
+++ b/suitesparse_bindings/sprs_suitesparse_camd/src/lib.rs
@@ -1,4 +1,4 @@
-use sprs::errors::SprsError;
+use sprs::errors::LinalgError;
 use sprs::{CsStructureI, CsStructureViewI, PermOwnedI, SpIndex};
 use suitesparse_camd_sys::*;
 
@@ -19,16 +19,14 @@ const MAX_INT32: usize = std::u32::MAX as usize;
 /// This function will error if the passed matrix is not square.
 pub fn try_camd<I, Iptr>(
     mat: CsStructureViewI<I, Iptr>,
-) -> Result<PermOwnedI<I>, SprsError>
+) -> Result<PermOwnedI<I>, LinalgError>
 where
     I: SpIndex,
     Iptr: SpIndex,
 {
     let n = mat.rows();
     if n != mat.cols() {
-        return Err(SprsError::IllegalArguments(
-            "Input to camd must be square",
-        ));
+        return Err(LinalgError::NonSquareMatrix);
     }
     let mut control = [0.; CAMD_CONTROL];
     let mut info = [0.; CAMD_INFO];
@@ -74,7 +72,7 @@ where
     // CsMat invariants guarantee sorted and non duplicate indices so this
     // should not happen.
     if camd_res != CAMD_OK {
-        return Err(SprsError::NonSortedIndices);
+        panic!("CsMat invariants have been broken");
     }
     Ok(PermOwnedI::new(perm))
 }

--- a/suitesparse_bindings/sprs_suitesparse_ldl/src/lib.rs
+++ b/suitesparse_bindings/sprs_suitesparse_ldl/src/lib.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use num_traits::Num;
-use sprs::errors::SprsError;
+use sprs::errors::LinalgError;
 use sprs::{CsMatI, CsMatViewI, PermOwnedI, SpIndex};
 use suitesparse_ldl_sys::*;
 
@@ -150,7 +150,7 @@ macro_rules! ldl_impl {
             pub fn factor<N, I>(
                 self,
                 mat: CsMatViewI<N, I>,
-            ) -> Result<$Numeric, SprsError>
+            ) -> Result<$Numeric, LinalgError>
             where
                 N: Clone + Into<f64>,
                 I: SpIndex,
@@ -180,7 +180,7 @@ macro_rules! ldl_impl {
             /// # Panics
             ///
             /// * if mat is not symmetric
-            pub fn new<N, I>(mat: CsMatViewI<N, I>) -> Result<Self, SprsError>
+            pub fn new<N, I>(mat: CsMatViewI<N, I>) -> Result<Self, LinalgError>
             where
                 N: Clone + Into<f64>,
                 I: SpIndex,
@@ -202,7 +202,7 @@ macro_rules! ldl_impl {
                 mat: CsMatViewI<N, I>,
                 perm: PermOwnedI<I>,
                 check_perm: sprs::PermutationCheck,
-            ) -> Result<Self, SprsError>
+            ) -> Result<Self, LinalgError>
             where
                 N: Clone + Into<f64>,
                 I: SpIndex,
@@ -221,7 +221,7 @@ macro_rules! ldl_impl {
             pub fn update<N, I>(
                 &mut self,
                 mat: CsMatViewI<N, I>,
-            ) -> Result<(), SprsError>
+            ) -> Result<(), LinalgError>
             where
                 N: Clone + Into<f64>,
                 I: SpIndex,
@@ -254,9 +254,10 @@ macro_rules! ldl_impl {
                     )
                 };
                 if ldl_retcode != n {
-                    // FIXME should return the value of ldl_retcode
-                    // but this would need breaking change in sprs error type
-                    return Err(SprsError::SingularMatrix);
+                    return Err(LinalgError::ThirdPartyError(
+                        ldl_retcode as isize,
+                        "LDL exited with error code",
+                    ));
                 }
                 Ok(())
             }


### PR DESCRIPTION
Recent work has made the structural constraints of sparse matrices and vectors clearer, making it clear that there can be a single enum discriminating all possible structural errors. Having linalg errors in the same error type was clumsy: structural errors happen when creating a matrix, while linalg errors happen much later, when solving systems or performing other linear algebra operations. Therefore, by splitting the types, it should be easier to react to both kinds of errors.

Since the linalg part of this crate is still small, it's expected that I'm missing possible errors, which is why the error type is a non
exhaustive enum.

Additionaly, I took this refactoring as an opportunity to fix #255, using the same pattern used by the `CsMatBase` and `CsVecBase` constructors to return the storage in case of an error.

@mulimoen I'm very interested in your remarks on the design of these new error types.