### PR TITLE
Triplet matrix conversion to compressed storage with given Iptr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       if: matrix.os == 'ubuntu-18.04'
 
     - name: Test (suitesparse integration)
-      run: cargo test -p sprs-ldl --features "sprs_suitesparse_ldl sprs_suitesparse_camd" -Zpackage-features
+      run: cargo test -p sprs-ldl --features "sprs-ldl/sprs_suitesparse_ldl sprs-ldl/sprs_suitesparse_camd"
       if: matrix.os == 'ubuntu-18.04' && matrix.build == 'nightly'
 
   benches:

--- a/src/io.rs
+++ b/src/io.rs
@@ -508,7 +508,7 @@ mod test {
     fn read_write_read_matrix_market_via_csc() {
         let path = "data/matrix_market/simple.mm";
         let mat = read_matrix_market::<f64, usize, _>(path).unwrap();
-        let csc = mat.to_csc();
+        let csc: CsMat<_> = mat.to_csc();
         let tmp_dir = tempdir().unwrap();
         let save_path = tmp_dir.path().join("simple_csc.mm");
         write_matrix_market(&save_path, &csc).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ It features a sparse matrix type, [**`CsMat`**](struct.CsMatBase.html), and a sp
 Matrix construction:
 
 ```rust
-use sprs::TriMat;
+use sprs::{CsMat, TriMat};
 
 let mut a = TriMat::new((4, 4));
 a.add_triplet(0, 0, 3.0_f64);
@@ -35,7 +35,7 @@ a.add_triplet(3, 0, -2.0);
 
 // This matrix type does not allow computations, and must to
 // converted to a compatible sparse type, using for example
-let b = a.to_csr();
+let b: CsMat<_> = a.to_csr();
 ```
 
 Constructing matrix using the more efficient direct sparse constructor

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -3010,7 +3010,7 @@ mod test {
         m1.add_triplet(0, 1, 6);
         m1.add_triplet(0, 8, 5);
         m1.add_triplet(4, 2, 4);
-        let mut m1 = m1.to_csr();
+        let mut m1: CsMat<_> = m1.to_csr();
 
         m1 *= 2;
         for (&v, (j, i)) in m1.iter() {
@@ -3033,7 +3033,7 @@ mod test {
         m1.add_triplet(0, 1, 6);
         m1.add_triplet(0, 8, 5);
         m1.add_triplet(4, 2, 4);
-        let mut m1 = m1.to_csr();
+        let mut m1: CsMat<_> = m1.to_csr();
 
         m1 /= 2;
         for (&v, (j, i)) in m1.iter() {
@@ -3050,7 +3050,7 @@ mod test {
 
     #[test]
     fn issue_99() {
-        let a = crate::TriMat::<i32>::new((10, 1)).to_csc();
+        let a = crate::TriMat::<i32>::new((10, 1)).to_csc::<usize>();
         let b = crate::TriMat::<i32>::new((1, 9)).to_csr();
         let _c = &a * &b;
     }
@@ -3260,7 +3260,7 @@ mod approx_impls {
         fn different_shapes() {
             let mut m1 = TriMat::new((3, 2));
             m1.add_triplet(1, 1, 8_u8);
-            let m1 = m1.to_csr();
+            let m1: CsMat<_> = m1.to_csr();
             let mut m2 = TriMat::new((2, 3));
             m2.add_triplet(1, 1, 8_u8);
             let m2 = m2.to_csr();
@@ -3280,7 +3280,7 @@ mod approx_impls {
             m1.add_triplet(0, 8, 5_u8);
             m1.add_triplet(4, 2, 4_u8);
 
-            let m1 = m1.to_csr();
+            let m1: CsMat<_> = m1.to_csr();
             let m2 = m1.clone();
 
             ::approx::assert_abs_diff_eq!(m1, m2, epsilon = 0);
@@ -3299,7 +3299,7 @@ mod approx_impls {
             m1.add_triplet(0, 8, 5.0);
             m1.add_triplet(4, 2, 4.0);
 
-            let m1 = m1.to_csr();
+            let m1: CsMat<_> = m1.to_csr();
             let m2 = m1.clone();
 
             ::approx::assert_abs_diff_eq!(m1, m2);
@@ -3326,7 +3326,7 @@ mod approx_impls {
             m1.add_triplet(0, 1, 6.0);
             m1.add_triplet(0, 8, 5.0);
             m1.add_triplet(4, 2, 4.0);
-            let m1 = m1.to_csr();
+            let m1: CsMat<_> = m1.to_csr();
 
             let mut m2 = TriMat::new((6, 9));
             m2.add_triplet(1, 1, 8.0_f32);

--- a/src/sparse/triplet.rs
+++ b/src/sparse/triplet.rs
@@ -257,7 +257,7 @@ where
     }
 
     /// Create a CSC matrix from this triplet matrix
-    pub fn to_csc(&self) -> CsMatI<N, I>
+    pub fn to_csc<Iptr: SpIndex>(&self) -> CsMatI<N, I, Iptr>
     where
         N: Clone + Num,
     {
@@ -265,7 +265,7 @@ where
     }
 
     /// Create a CSR matrix from this triplet matrix
-    pub fn to_csr(&self) -> CsMatI<N, I>
+    pub fn to_csr<Iptr: SpIndex>(&self) -> CsMatI<N, I, Iptr>
     where
         N: Clone + Num,
     {

--- a/src/sparse/triplet_iter.rs
+++ b/src/sparse/triplet_iter.rs
@@ -108,7 +108,7 @@ where
     DI: Clone + Iterator<Item = &'a N>,
 {
     /// Consume `TriMatIter` and produce a CSC matrix
-    pub fn into_csc(self) -> CsMatI<N, I>
+    pub fn into_csc<Iptr: SpIndex>(self) -> CsMatI<N, I, Iptr>
     where
         N: Num,
     {
@@ -116,7 +116,7 @@ where
     }
 
     /// Consume `TriMatIter` and produce a CSR matrix
-    pub fn into_csr(self) -> CsMatI<N, I>
+    pub fn into_csr<Iptr: SpIndex>(self) -> CsMatI<N, I, Iptr>
     where
         N: Num,
     {
@@ -124,7 +124,10 @@ where
     }
 
     /// Consume `TriMatIter` and produce a `CsMat` matrix with the chosen storage
-    pub fn into_cs(self, storage: crate::CompressedStorage) -> CsMatI<N, I>
+    pub fn into_cs<Iptr: SpIndex>(
+        self,
+        storage: crate::CompressedStorage,
+    ) -> CsMatI<N, I, Iptr>
     where
         N: Num,
     {
@@ -157,7 +160,7 @@ where
         };
 
         let mut slot = 0;
-        let mut indptr = vec![I::zero(); outer_dims + 1];
+        let mut indptr = vec![Iptr::zero(); outer_dims + 1];
         let mut cur_outer = I::zero();
 
         for rec in 0..nnz_max {
@@ -175,7 +178,7 @@ where
             let new_outer = outer_idx(&rc[rec]);
 
             while new_outer > cur_outer {
-                indptr[cur_outer.index() + 1] = I::from_usize(slot);
+                indptr[cur_outer.index() + 1] = Iptr::from_usize(slot);
                 cur_outer += I::one();
             }
         }
@@ -186,7 +189,7 @@ where
         }
         // fill indptr up to the end
         while I::from_usize(outer_dims) > cur_outer {
-            indptr[cur_outer.index() + 1] = I::from_usize(slot);
+            indptr[cur_outer.index() + 1] = Iptr::from_usize(slot);
             cur_outer += I::one();
         }
 


### PR DESCRIPTION
It would be good to convert triplet matrix to a cs with chosen `Iptr` type.
There might be a way to let `Iptr = I` as default?