### PR TITLE
Draft: Support generic dense vectors in more APIs

### DIFF
--- a/src/dense_vector.rs
+++ b/src/dense_vector.rs
@@ -15,6 +15,17 @@ pub trait DenseVector<N> {
     fn index(&self, idx: usize) -> &N;
 }
 
+impl<N> DenseVector<N> for [N] {
+    fn dim(&self) -> usize {
+        self.len()
+    }
+
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &N {
+        &self[idx]
+    }
+}
+
 impl<'a, N: 'a> DenseVector<N> for &'a [N] {
     fn dim(&self) -> usize {
         self.len()
@@ -91,6 +102,13 @@ pub trait DenseVectorMut<N>: DenseVector<N> {
     ///
     /// If the index is out of bounds
     fn index_mut(&mut self, idx: usize) -> &mut N;
+}
+
+impl<'a, N: 'a> DenseVectorMut<N> for [N] {
+    #[inline(always)]
+    fn index_mut(&mut self, idx: usize) -> &mut N {
+        &mut self[idx]
+    }
 }
 
 impl<'a, N: 'a> DenseVectorMut<N> for &'a mut [N] {

--- a/src/dense_vector.rs
+++ b/src/dense_vector.rs
@@ -1,0 +1,125 @@
+use crate::Ix1;
+use ndarray::{self, ArrayBase};
+
+/// A trait for types representing dense vectors, useful for expressing
+/// algorithms such as sparse-dense dot product, or linear solves.
+pub trait DenseVector<N> {
+    /// The dimension of the vector
+    fn dim(&self) -> usize;
+
+    /// Random access to an element in the vector.
+    ///
+    /// # Panics
+    ///
+    /// If the index is out of bounds
+    fn index(&self, idx: usize) -> &N;
+}
+
+impl<'a, N: 'a> DenseVector<N> for &'a [N] {
+    fn dim(&self) -> usize {
+        self.len()
+    }
+
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &N {
+        &self[idx]
+    }
+}
+
+impl<'a, N: 'a> DenseVector<N> for &'a mut [N] {
+    fn dim(&self) -> usize {
+        self.len()
+    }
+
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &N {
+        &self[idx]
+    }
+}
+
+impl<N> DenseVector<N> for Vec<N> {
+    fn dim(&self) -> usize {
+        self.len()
+    }
+
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &N {
+        &self[idx]
+    }
+}
+
+impl<'a, N: 'a> DenseVector<N> for &'a Vec<N> {
+    fn dim(&self) -> usize {
+        self.len()
+    }
+
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &N {
+        &self[idx]
+    }
+}
+
+impl<'a, N: 'a> DenseVector<N> for &'a mut Vec<N> {
+    fn dim(&self) -> usize {
+        self.len()
+    }
+
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &N {
+        &self[idx]
+    }
+}
+
+impl<N, S> DenseVector<N> for ArrayBase<S, Ix1>
+where
+    S: ndarray::Data<Elem = N>,
+{
+    fn dim(&self) -> usize {
+        self.shape()[0]
+    }
+
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &N {
+        &self[[idx]]
+    }
+}
+
+pub trait DenseVectorMut<N>: DenseVector<N> {
+    /// Random mutable access to an element in the vector.
+    ///
+    /// # Panics
+    ///
+    /// If the index is out of bounds
+    fn index_mut(&mut self, idx: usize) -> &mut N;
+}
+
+impl<'a, N: 'a> DenseVectorMut<N> for &'a mut [N] {
+    #[inline(always)]
+    fn index_mut(&mut self, idx: usize) -> &mut N {
+        &mut self[idx]
+    }
+}
+
+impl<N> DenseVectorMut<N> for Vec<N> {
+    #[inline(always)]
+    fn index_mut(&mut self, idx: usize) -> &mut N {
+        &mut self[idx]
+    }
+}
+
+impl<'a, N: 'a> DenseVectorMut<N> for &'a mut Vec<N> {
+    #[inline(always)]
+    fn index_mut(&mut self, idx: usize) -> &mut N {
+        &mut self[idx]
+    }
+}
+
+impl<N, S> DenseVectorMut<N> for ArrayBase<S, Ix1>
+where
+    S: ndarray::DataMut<Elem = N>,
+{
+    #[inline(always)]
+    fn index_mut(&mut self, idx: usize) -> &mut N {
+        &mut self[[idx]]
+    }
+}

--- a/src/dense_vector.rs
+++ b/src/dense_vector.rs
@@ -186,6 +186,58 @@ where
     }
 }
 
+impl<'a, N, S> DenseVector for &'a ArrayBase<S, Ix1>
+where
+    S: ndarray::Data<Elem = N>,
+    N: 'a + Zero + Clone,
+{
+    type Owned = ndarray::Array<N, Ix1>;
+    type Scalar = N;
+
+    fn dim(&self) -> usize {
+        self.shape()[0]
+    }
+
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &N {
+        &self[[idx]]
+    }
+
+    fn zeros(dim: usize) -> Self::Owned {
+        ndarray::Array::zeros(dim)
+    }
+
+    fn to_owned(&self) -> Self::Owned {
+        ArrayBase::to_owned(self)
+    }
+}
+
+impl<'a, N, S> DenseVector for &'a mut ArrayBase<S, Ix1>
+where
+    S: ndarray::Data<Elem = N>,
+    N: 'a + Zero + Clone,
+{
+    type Owned = ndarray::Array<N, Ix1>;
+    type Scalar = N;
+
+    fn dim(&self) -> usize {
+        self.shape()[0]
+    }
+
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &N {
+        &self[[idx]]
+    }
+
+    fn zeros(dim: usize) -> Self::Owned {
+        ndarray::Array::zeros(dim)
+    }
+
+    fn to_owned(&self) -> Self::Owned {
+        ArrayBase::to_owned(self)
+    }
+}
+
 /// Trait for dense vectors that can be modified, useful for expressing
 /// algorithms which compute a resulting dense vector, such as solvers.
 ///
@@ -239,6 +291,17 @@ where
     }
 }
 
+impl<'a, N, S> DenseVectorMut for &'a mut ArrayBase<S, Ix1>
+where
+    S: ndarray::DataMut<Elem = N>,
+    N: 'a + Zero + Clone,
+{
+    #[inline(always)]
+    fn index_mut(&mut self, idx: usize) -> &mut N {
+        &mut self[[idx]]
+    }
+}
+
 mod seal {
     pub trait Sealed {}
 
@@ -250,6 +313,14 @@ mod seal {
     impl<'a, N: 'a> Sealed for &'a mut Vec<N> {}
     impl<N, S: ndarray::Data<Elem = N>> Sealed
         for ndarray::ArrayBase<S, crate::Ix1>
+    {
+    }
+    impl<'a, N: 'a, S: ndarray::Data<Elem = N>> Sealed
+        for &'a ndarray::ArrayBase<S, crate::Ix1>
+    {
+    }
+    impl<'a, N: 'a, S: ndarray::Data<Elem = N>> Sealed
+        for &'a mut ndarray::ArrayBase<S, crate::Ix1>
     {
     }
 }

--- a/src/dense_vector.rs
+++ b/src/dense_vector.rs
@@ -4,7 +4,10 @@ use num_traits::identities::Zero;
 
 /// A trait for types representing dense vectors, useful for expressing
 /// algorithms such as sparse-dense dot product, or linear solves.
-pub trait DenseVector {
+///
+/// This trait is sealed, and cannot be implemented outside of the `sprs`
+/// crate.
+pub trait DenseVector: seal::Sealed {
     type Owned;
     type Scalar;
 
@@ -183,6 +186,11 @@ where
     }
 }
 
+/// Trait for dense vectors that can be modified, useful for expressing
+/// algorithms which compute a resulting dense vector, such as solvers.
+///
+/// This trait is sealed, and cannot be implemented outside of the `sprs`
+/// crate.
 pub trait DenseVectorMut: DenseVector {
     /// Random mutable access to an element in the vector.
     ///
@@ -228,5 +236,20 @@ where
     #[inline(always)]
     fn index_mut(&mut self, idx: usize) -> &mut N {
         &mut self[[idx]]
+    }
+}
+
+mod seal {
+    pub trait Sealed {}
+
+    impl<N> Sealed for [N] {}
+    impl<'a, N: 'a> Sealed for &'a [N] {}
+    impl<'a, N: 'a> Sealed for &'a mut [N] {}
+    impl<N> Sealed for Vec<N> {}
+    impl<'a, N: 'a> Sealed for &'a Vec<N> {}
+    impl<'a, N: 'a> Sealed for &'a mut Vec<N> {}
+    impl<N, S: ndarray::Data<Elem = N>> Sealed
+        for ndarray::ArrayBase<S, crate::Ix1>
+    {
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ assert_eq!(a, b.to_csc());
 */
 
 pub mod array_backend;
+mod dense_vector;
 pub mod errors;
 pub mod indexing;
 #[cfg(not(miri))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,8 @@ pub use crate::sparse::{
     TriMatIter, TriMatView, TriMatViewI, TriMatViewMut, TriMatViewMutI,
 };
 
+pub use crate::dense_vector::{DenseVector, DenseVectorMut};
+
 pub use crate::sparse::symmetric::is_symmetric;
 
 pub use crate::sparse::permutation::{

--- a/src/sparse/linalg.rs
+++ b/src/sparse/linalg.rs
@@ -1,9 +1,9 @@
+use crate::{DenseVector, DenseVectorMut};
 ///! Sparse linear algebra
 ///!
 ///! This module contains solvers for sparse linear systems. Currently
 ///! there are solver for sparse triangular systems and symmetric systems.
 use num_traits::Num;
-use std::iter::IntoIterator;
 
 pub mod etree;
 pub mod ordering;
@@ -12,13 +12,15 @@ pub mod trisolve;
 pub use self::ordering::reverse_cuthill_mckee;
 
 /// Diagonal solve
-pub fn diag_solve<'a, N, I1, I2>(diag: I1, x: I2)
+pub fn diag_solve<'a, N, V1, V2>(diag: V1, mut x: V2)
 where
-    N: 'a + Copy + Num,
-    I1: IntoIterator<Item = &'a N>,
-    I2: IntoIterator<Item = &'a mut N>,
+    N: 'a + Copy + Num + std::ops::DivAssign,
+    V1: DenseVector<Scalar = N>,
+    V2: DenseVectorMut + DenseVector<Scalar = N>,
 {
-    for (xv, dv) in x.into_iter().zip(diag.into_iter()) {
-        *xv = *xv / *dv;
+    let n = x.dim();
+    assert_eq!(diag.dim(), n);
+    for i in 0..n {
+        *x.index_mut(i) /= *diag.index(i);
     }
 }

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -1,4 +1,4 @@
-use crate::dense_vector::DenseVectorMut;
+use crate::dense_vector::{DenseVector, DenseVectorMut};
 use crate::errors::{LinalgError, SingularMatrixInfo};
 use crate::indexing::SpIndex;
 use crate::sparse::CsMatViewI;
@@ -12,7 +12,7 @@ fn check_solver_dimensions<N, I, Iptr, V>(
     rhs: &V,
 ) where
     N: Copy + Num,
-    V: DenseVectorMut<N>,
+    V: DenseVector<N> + ?Sized,
     I: SpIndex,
     Iptr: SpIndex,
 {
@@ -403,6 +403,10 @@ mod test {
 
         super::lsolve_csc_dense_rhs(l.view(), &mut x).unwrap();
         assert_eq!(x, vec![3, 1, 1]);
+
+        let x: &mut [i32] = &mut [3, 5, 3];
+        super::lsolve_csc_dense_rhs(l.view(), &mut x[..]).unwrap();
+        assert_eq!(x, &[3, 1, 1]);
     }
 
     #[test]

--- a/src/sparse/linalg/trisolve.rs
+++ b/src/sparse/linalg/trisolve.rs
@@ -12,7 +12,7 @@ fn check_solver_dimensions<N, I, Iptr, V>(
     rhs: &V,
 ) where
     N: Copy + Num,
-    V: DenseVector<N> + ?Sized,
+    V: DenseVector<Scalar = N> + ?Sized,
     I: SpIndex,
     Iptr: SpIndex,
 {
@@ -38,7 +38,7 @@ pub fn lsolve_csr_dense_rhs<N, I, Iptr, V>(
 ) -> Result<(), LinalgError>
 where
     N: Copy + Num + std::ops::SubAssign,
-    V: DenseVectorMut<N>,
+    V: DenseVectorMut<Scalar = N>,
     I: SpIndex,
     Iptr: SpIndex,
 {
@@ -94,7 +94,7 @@ pub fn lsolve_csc_dense_rhs<N, I, Iptr, V>(
 ) -> Result<(), LinalgError>
 where
     N: Copy + Num + std::ops::SubAssign,
-    V: DenseVectorMut<N>,
+    V: DenseVectorMut<Scalar = N>,
     I: SpIndex,
     Iptr: SpIndex,
 {
@@ -124,7 +124,7 @@ fn lspsolve_csc_process_col<N, I, V>(
 ) -> Result<(), LinalgError>
 where
     N: Copy + Num + std::ops::SubAssign,
-    V: DenseVectorMut<N>,
+    V: DenseVectorMut<Scalar = N>,
     I: SpIndex,
 {
     if let Some(&diag_val) = col.get(col_ind) {
@@ -168,7 +168,7 @@ pub fn usolve_csc_dense_rhs<N, I, Iptr, V>(
 ) -> Result<(), LinalgError>
 where
     N: Copy + Num + std::ops::SubAssign,
-    V: DenseVectorMut<N>,
+    V: DenseVectorMut<Scalar = N>,
     I: SpIndex,
     Iptr: SpIndex,
 {
@@ -226,7 +226,7 @@ pub fn usolve_csr_dense_rhs<N, I, Iptr, V>(
 ) -> Result<(), LinalgError>
 where
     N: Copy + Num + std::ops::SubAssign,
-    V: DenseVectorMut<N>,
+    V: DenseVectorMut + DenseVector<Scalar = N>,
     I: SpIndex,
     Iptr: SpIndex,
 {
@@ -296,7 +296,7 @@ pub fn lsolve_csc_sparse_rhs<N, I, Iptr, V>(
 ) -> Result<(), LinalgError>
 where
     N: Copy + Num + std::ops::SubAssign,
-    V: DenseVectorMut<N>,
+    V: DenseVectorMut + DenseVector<Scalar = N>,
     I: SpIndex,
     Iptr: SpIndex,
 {

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -55,8 +55,8 @@ pub fn mul_acc_mat_vec_csc<N, I, Iptr, V, VRes>(
     N: Num + Copy + std::ops::AddAssign,
     I: SpIndex,
     Iptr: SpIndex,
-    V: DenseVector<N>,
-    VRes: DenseVectorMut<N>,
+    V: DenseVector<Scalar = N>,
+    VRes: DenseVectorMut<Scalar = N>,
 {
     let mat = mat.view();
     if mat.cols() != in_vec.dim() || mat.rows() != res_vec.dim() {
@@ -85,8 +85,8 @@ pub fn mul_acc_mat_vec_csr<N, I, Iptr, V, VRes>(
     N: Num + Copy + std::ops::AddAssign,
     I: SpIndex,
     Iptr: SpIndex,
-    V: DenseVector<N>,
-    VRes: DenseVectorMut<N>,
+    V: DenseVector<Scalar = N>,
+    VRes: DenseVectorMut<Scalar = N>,
 {
     if mat.cols() != in_vec.dim() || mat.rows() != res_vec.dim() {
         panic!("Dimension mismatch");

--- a/src/sparse/prod.rs
+++ b/src/sparse/prod.rs
@@ -1,8 +1,8 @@
+use crate::dense_vector::{DenseVector, DenseVectorMut};
 use crate::indexing::SpIndex;
 use crate::sparse::compressed::SpMatView;
 ///! Sparse matrix product
 use crate::sparse::prelude::*;
-use crate::sparse::vec::DenseVector;
 use crate::Ix2;
 use ndarray::{ArrayView, ArrayViewMut, Axis};
 use num_traits::Num;
@@ -47,18 +47,19 @@ where
 
 /// Multiply a sparse CSC matrix with a dense vector and accumulate the result
 /// into another dense vector
-pub fn mul_acc_mat_vec_csc<N, I, Iptr, V>(
+pub fn mul_acc_mat_vec_csc<N, I, Iptr, V, VRes>(
     mat: CsMatViewI<N, I, Iptr>,
     in_vec: V,
-    res_vec: &mut [N],
+    mut res_vec: VRes,
 ) where
-    N: Num + Copy,
+    N: Num + Copy + std::ops::AddAssign,
     I: SpIndex,
     Iptr: SpIndex,
     V: DenseVector<N>,
+    VRes: DenseVectorMut<N>,
 {
     let mat = mat.view();
-    if mat.cols() != in_vec.dim() || mat.rows() != res_vec.len() {
+    if mat.cols() != in_vec.dim() || mat.rows() != res_vec.dim() {
         panic!("Dimension mismatch");
     }
     if !mat.is_csc() {
@@ -69,24 +70,25 @@ pub fn mul_acc_mat_vec_csc<N, I, Iptr, V>(
         let multiplier = in_vec.index(col_ind);
         for (row_ind, &value) in vec.iter() {
             // TODO: unsafe access to value? needs bench
-            res_vec[row_ind] = res_vec[row_ind] + *multiplier * value;
+            *res_vec.index_mut(row_ind) += *multiplier * value;
         }
     }
 }
 
 /// Multiply a sparse CSR matrix with a dense vector and accumulate the result
 /// into another dense vector
-pub fn mul_acc_mat_vec_csr<N, I, Iptr, V>(
+pub fn mul_acc_mat_vec_csr<N, I, Iptr, V, VRes>(
     mat: CsMatViewI<N, I, Iptr>,
     in_vec: V,
-    res_vec: &mut [N],
+    mut res_vec: VRes,
 ) where
-    N: Num + Copy,
+    N: Num + Copy + std::ops::AddAssign,
     I: SpIndex,
     Iptr: SpIndex,
     V: DenseVector<N>,
+    VRes: DenseVectorMut<N>,
 {
-    if mat.cols() != in_vec.dim() || mat.rows() != res_vec.len() {
+    if mat.cols() != in_vec.dim() || mat.rows() != res_vec.dim() {
         panic!("Dimension mismatch");
     }
     if !mat.is_csr() {
@@ -94,13 +96,10 @@ pub fn mul_acc_mat_vec_csr<N, I, Iptr, V>(
     }
 
     for (row_ind, vec) in mat.outer_iterator().enumerate() {
-        // this unwrap is ok because we did the check before to ensure
-        // mat.row() == res_vec.len() and now the row_ind is within the
-        // range of [0, mat.row). So it should be safe.
-        let tv = res_vec.get_mut(row_ind).unwrap();
+        let tv = res_vec.index_mut(row_ind);
         for (col_ind, &value) in vec.iter() {
             // TODO: unsafe access to value? needs bench
-            *tv = *tv + *in_vec.index(col_ind) * value;
+            *tv += *in_vec.index(col_ind) * value;
         }
     }
 }
@@ -328,7 +327,7 @@ mod test {
         mat_dense2,
     };
     use ndarray::linalg::Dot;
-    use ndarray::{arr2, s, Array, Array2, Dimension, ShapeBuilder};
+    use ndarray::{arr1, arr2, s, Array, Array2, Dimension, ShapeBuilder};
 
     #[test]
     fn test_csvec_dot_by_binary_search() {
@@ -369,6 +368,31 @@ mod test {
     }
 
     #[test]
+    fn mul_csc_vec_ndarray() {
+        let indptr: &[usize] = &[0, 2, 4, 5, 6, 7];
+        let indices: &[usize] = &[2, 3, 3, 4, 2, 1, 3];
+        let data: &[f64] = &[
+            0.35310881, 0.42380633, 0.28035896, 0.58082095, 0.53350123,
+            0.88132896, 0.72527863,
+        ];
+
+        let mat = CsMatView::new_csc((5, 5), indptr, indices, data);
+        let vector = arr1(&[0.1f64, 0.2, -0.1, 0.3, 0.9]);
+        let mut res_vec = Array::zeros(5);
+        mul_acc_mat_vec_csc(mat, vector, res_vec.view_mut());
+
+        let expected_output =
+            vec![0., 0.26439869, -0.01803924, 0.75120319, 0.11616419];
+
+        let epsilon = 1e-7; // TODO: get better values and increase precision
+
+        assert!(res_vec
+            .iter()
+            .zip(expected_output.iter())
+            .all(|(x, y)| (*x - *y).abs() < epsilon));
+    }
+
+    #[test]
     fn mul_csr_vec() {
         let indptr: &[usize] = &[0, 3, 3, 5, 6, 7];
         let indices: &[usize] = &[1, 2, 3, 2, 3, 4, 4];
@@ -384,6 +408,31 @@ mod test {
 
         let expected_output =
             vec![0.22527496, 0., 0.17814121, 0.35319787, 0.51482166];
+
+        let epsilon = 1e-7; // TODO: get better values and increase precision
+
+        assert!(res_vec
+            .iter()
+            .zip(expected_output.iter())
+            .all(|(x, y)| (*x - *y).abs() < epsilon));
+    }
+
+    #[test]
+    fn mul_csr_vec_ndarray() {
+        let indptr: &[usize] = &[0, 3, 3, 5, 6, 7];
+        let indices: &[usize] = &[1, 2, 3, 2, 3, 4, 4];
+        let data: &[f64] = &[
+            0.75672424, 0.1649078, 0.30140296, 0.10358244, 0.6283315,
+            0.39244208, 0.57202407,
+        ];
+
+        let mat = CsMatView::new((5, 5), indptr, indices, data);
+        let vec = arr1(&[0.1f64, 0.2, -0.1, 0.3, 0.9]);
+        let mut res_vec = Array::zeros(5);
+        mul_acc_mat_vec_csr(mat, vec.view(), res_vec.view_mut());
+
+        let expected_output =
+            [0.22527496, 0., 0.17814121, 0.35319787, 0.51482166];
 
         let epsilon = 1e-7; // TODO: get better values and increase precision
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -897,7 +897,7 @@ where
     /// If the dimension of the vectors do not match.
     pub fn dot_dense<T>(&self, rhs: T) -> N
     where
-        T: DenseVector<N>,
+        T: DenseVector<Scalar = N>,
         N: Num + Copy + Sum,
     {
         assert_eq!(self.dim(), rhs.dim());
@@ -962,7 +962,7 @@ where
     pub fn scatter<V>(&self, out: &mut V)
     where
         N: Clone,
-        V: DenseVectorMut<N> + ?Sized,
+        V: DenseVectorMut<Scalar = N> + ?Sized,
     {
         for (ind, val) in self.iter() {
             *out.index_mut(ind) = val.clone();

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -959,9 +959,10 @@ where
     }
 
     /// Fill a dense vector with our values
-    pub fn scatter<V: DenseVectorMut<N>>(&self, out: &mut V)
+    pub fn scatter<V>(&self, out: &mut V)
     where
         N: Clone,
+        V: DenseVectorMut<N> + ?Sized,
     {
         for (ind, val) in self.iter() {
             *out.index_mut(ind) = val.clone();
@@ -1862,6 +1863,9 @@ mod test {
         let mut res = Array::zeros(4);
         vector.scatter(&mut res);
         assert_eq!(res, ndarray::arr1(&[0, 1, 3, 4]));
+        let res: &mut [i32] = &mut [0; 4];
+        vector.scatter(res);
+        assert_eq!(res, &[0, 1, 3, 4]);
     }
 
     #[cfg(feature = "approx")]


### PR DESCRIPTION
Lots of APIs were using slices as their input, particularly when using
output buffers. However, this was not a good fit for linear algebra,
since consumers of the APIs are more likely to be using eg an array from
ndarray.

Here we extend the `DenseVector` trait with a mutable version to be able
to use it on output parameters. Since these are sealed traits we should
be able to add unsafe indexing if necessary without a breaking change.
It should also be possible to support eg nalgebra in the future without
too much trouble.

This should improve the situation discussed in #93, though it's
probably not done yet.