### PR TITLE
CsVec constructors

### DIFF
--- a/benches/sorting.rs
+++ b/benches/sorting.rs
@@ -35,7 +35,7 @@ fn create_csmat_from_unsorted(bench: &mut Bencher) {
         let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
         indices.shuffle(&mut rng);
         let values = values.clone();
-        let _v = CsVec::new(N, indices, values);
+        let _v = CsVec::new_sorted(N, indices, values).unwrap();
     });
 }
 

--- a/benches/sorting.rs
+++ b/benches/sorting.rs
@@ -35,7 +35,7 @@ fn create_csmat_from_unsorted(bench: &mut Bencher) {
         let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
         indices.shuffle(&mut rng);
         let values = values.clone();
-        let _v = CsVec::new_sorted(N, indices, values).unwrap();
+        let _v = CsVec::new_from_unsorted(N, indices, values).unwrap();
     });
 }
 

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -309,7 +309,7 @@ where
     IStorage: DerefMut<Target = [I]>,
     DStorage: DerefMut<Target = [N]>,
 {
-    fn new_sorted_checked(
+    fn new_from_unsorted_checked(
         storage: CompressedStorage,
         shape: (usize, usize),
         indptr: IptrStorage,
@@ -369,38 +369,36 @@ where
 
     /// Try create a `CSR` matrix which acts as an owner of its data.
     ///
-    /// A `CSC` matrix can be created with `new_sorted_csc()`.
+    /// A `CSC` matrix can be created with `new_from_unsorted_csc()`.
     ///
     /// If necessary, the indices will be sorted in place.
-    pub fn new_sorted(
+    pub fn new_from_unsorted(
         shape: Shape,
         indptr: IptrStorage,
         indices: IStorage,
         data: DStorage,
-    ) -> Result<Self, StructureError>
+    ) -> Result<Self, (IptrStorage, IStorage, DStorage, StructureError)>
     where
         N: Copy,
     {
-        Self::new_sorted_checked(CSR, shape, indptr, indices, data)
-            .map_err(|(_, _, _, e)| e)
+        Self::new_from_unsorted_checked(CSR, shape, indptr, indices, data)
     }
 
     /// Try create a `CSC` matrix which acts as an owner of its data.
     ///
-    /// A `CSR` matrix can be created with `new_sorted_csr()`.
+    /// A `CSR` matrix can be created with `new_from_unsorted_csr()`.
     ///
     /// If necessary, the indices will be sorted in place.
-    pub fn new_sorted_csc(
+    pub fn new_from_unsorted_csc(
         shape: Shape,
         indptr: IptrStorage,
         indices: IStorage,
         data: DStorage,
-    ) -> Result<Self, StructureError>
+    ) -> Result<Self, (IptrStorage, IStorage, DStorage, StructureError)>
     where
         N: Copy,
     {
-        Self::new_sorted_checked(CSC, shape, indptr, indices, data)
-            .map_err(|(_, _, _, e)| e)
+        Self::new_from_unsorted_checked(CSC, shape, indptr, indices, data)
     }
 }
 

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -16,13 +16,12 @@ use std::default::Default;
 use std::iter::{Enumerate, Zip};
 use std::mem;
 use std::ops::{Add, Deref, DerefMut, Index, IndexMut, Mul, Sub};
-use std::slice::{self, Iter};
+use std::slice::Iter;
 
 use crate::{Ix1, Ix2, Shape};
 use ndarray::linalg::Dot;
 use ndarray::{self, Array, ArrayBase, ShapeBuilder};
 
-use crate::array_backend::Array2;
 use crate::indexing::SpIndex;
 
 use crate::errors::StructureError;
@@ -2432,8 +2431,7 @@ mod test {
         let indptr_ok = vec![0, 1, 2, 3];
         let indices_ok = vec![0, 1, 2];
         let data_ok: Vec<f64> = vec![1., 1., 1.];
-        assert!(CsMat::new_sorted_checked(
-            CSR,
+        assert!(CsMat::new_from_unsorted(
             (3, 3),
             indptr_ok,
             indices_ok,
@@ -2496,9 +2494,13 @@ mod test {
         let indices_sorted = &[1, 2, 3, 2, 3, 4, 4];
         let indices_shuffled = vec![1, 3, 2, 2, 3, 4, 4];
         let mut data: Vec<i32> = (0..7).collect();
-        let m =
-            CsMat::new_sorted((5, 5), indptr, indices_shuffled, data.clone())
-                .unwrap();
+        let m = CsMat::new_from_unsorted(
+            (5, 5),
+            indptr,
+            indices_shuffled,
+            data.clone(),
+        )
+        .unwrap();
         assert_eq!(m.indices(), indices_sorted);
         data.swap(1, 2);
         assert_eq!(m.data(), &data[..]);

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1740,41 +1740,6 @@ pub mod raw {
     }
 }
 
-impl<'a, N: 'a, I: 'a + SpIndex, Iptr: 'a + SpIndex>
-    CsMatBase<N, I, Vec<Iptr>, &'a [I], &'a [N], Iptr>
-{
-    /// Create a borrowed row or column `CsMat` matrix from raw data,
-    /// without checking their validity
-    ///
-    /// # Safety
-    /// This is unsafe because algorithms are free to assume
-    /// that properties guaranteed by
-    /// [`check_compressed_structure`](Self::check_compressed_structure) are enforced.
-    /// For instance, non out-of-bounds indices can be relied upon to
-    /// perform unchecked slice access.
-    pub unsafe fn new_vecview_raw(
-        storage: CompressedStorage,
-        nrows: usize,
-        ncols: usize,
-        indptr: *const Iptr,
-        indices: *const I,
-        data: *const N,
-    ) -> CsMatVecView_<'a, N, I, Iptr> {
-        let indptr = slice::from_raw_parts(indptr, 2);
-        let nnz = indptr[1].index_unchecked();
-        CsMatVecView_ {
-            storage,
-            nrows,
-            ncols,
-            indptr: crate::IndPtrBase::new_trusted(Array2 {
-                data: [indptr[0], indptr[1]],
-            }),
-            indices: slice::from_raw_parts(indices, nnz),
-            data: slice::from_raw_parts(data, nnz),
-        }
-    }
-}
-
 impl<'a, 'b, N, I, Iptr, IpStorage, IStorage, DStorage, IpS2, IS2, DS2>
     Add<&'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>>
     for &'a CsMatBase<N, I, IpStorage, IStorage, DStorage, Iptr>

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1076,10 +1076,12 @@ where
     ) -> impl std::iter::DoubleEndedIterator<Item = CsVecViewI<N, I>>
            + std::iter::ExactSizeIterator<Item = CsVecViewI<N, I>>
            + '_ {
-        self.indptr.iter_outer_sz().map(move |range| CsVecViewI {
-            dim: self.inner_dims(),
-            indices: &self.indices[range.clone()],
-            data: &self.data[range],
+        self.indptr.iter_outer_sz().map(move |range| {
+            CsVecViewI::new_trusted(
+                self.inner_dims(),
+                &self.indices[range.clone()],
+                &self.data[range],
+            )
         })
     }
 
@@ -1100,11 +1102,7 @@ where
             let indices = &self.indices[range.clone()];
             let data = &self.data[range];
             // CsMat invariants imply CsVec invariants
-            let vec = CsVecBase {
-                dim: self.inner_dims(),
-                indices,
-                data,
-            };
+            let vec = CsVecBase::new_trusted(self.inner_dims(), indices, data);
             (outer_ind_perm, vec)
         })
     }
@@ -1147,11 +1145,11 @@ where
         }
         let range = self.indptr.outer_inds_sz(i);
         // CsMat invariants imply CsVec invariants
-        Some(CsVecViewI {
-            dim: self.inner_dims(),
-            indices: &self.indices[range.clone()],
-            data: &self.data[range],
-        })
+        Some(CsVecViewI::new_trusted(
+            self.inner_dims(),
+            &self.indices[range.clone()],
+            &self.data[range],
+        ))
     }
 
     /// Get the diagonal of a sparse matrix
@@ -1176,11 +1174,7 @@ where
         }
         data_vec.shrink_to_fit();
         index_vec.shrink_to_fit();
-        CsVecI {
-            dim: smallest_dim,
-            indices: index_vec,
-            data: data_vec,
-        }
+        CsVecI::new_trusted(smallest_dim, index_vec, data_vec)
     }
 
     /// Iteration over all entries on the diagonal
@@ -1449,11 +1443,11 @@ where
         }
         let range = self.indptr.outer_inds_sz(i);
         // CsMat invariants imply CsVec invariants
-        Some(CsVecBase {
-            dim: self.inner_dims(),
-            indices: &self.indices[range.clone()],
-            data: &mut self.data[range],
-        })
+        Some(CsVecBase::new_trusted(
+            self.inner_dims(),
+            &self.indices[range.clone()],
+            &mut self.data[range],
+        ))
     }
 
     /// Get a mutable reference to the element located at row i and column j.
@@ -1542,11 +1536,7 @@ where
                 )
             };
 
-            CsVecViewMutI {
-                dim: inner_dim,
-                indices: &indices[range],
-                data,
-            }
+            CsVecViewMutI::new_trusted(inner_dim, &indices[range], data)
         })
     }
 

--- a/src/sparse/serde_traits.rs
+++ b/src/sparse/serde_traits.rs
@@ -52,7 +52,7 @@ where
         val: CsVecBaseShadow<IStorage, DStorage, N, I>,
     ) -> Result<Self, Self::Error> {
         let CsVecBaseShadow { dim, indices, data } = val;
-        Self::new_(dim, indices, data).map_err(|(_, _, e)| e)
+        Self::try_new(dim, indices, data).map_err(|(_, _, e)| e)
     }
 }
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -486,6 +486,7 @@ where
     }
 }
 
+/// # Constructor methods
 impl<N, I: SpIndex, DStorage, IStorage> CsVecBase<IStorage, DStorage, N, I>
 where
     DStorage: std::ops::Deref<Target = [N]>,
@@ -555,6 +556,17 @@ where
     /// - if `indices` and `data` lengths differ
     /// - if the vector contains out of bounds indices
     /// - if indices are out of order
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use sprs::*;
+    /// // Creating a sparse owned vector
+    /// let owned = CsVec::new(10, vec![0, 4], vec![-4, 2]);
+    /// // Creating a sparse borrowing vector with `I = u16`
+    /// let borrow = CsVecViewI::new(10, &[0_u16, 4], &[-4, 2]);
+    /// // Creating a general sparse vector with different storage types
+    /// let mixed = CsVecBase::new(10, &[0_u64, 4] as &[_], vec![-4, 2]);
+    /// ```
     pub fn new(n: usize, indices: IStorage, data: DStorage) -> Self {
         Self::try_new(n, indices, data)
             .map_err(|(_, _, e)| e)
@@ -768,8 +780,8 @@ where
     }
 
     /// Check the sparse structure, namely that:
-    /// - indices is sorted
-    /// - indices are lower than dims()
+    /// - indices are sorted
+    /// - all indices are less than dims()
     pub fn check_structure(&self) -> Result<(), StructureError> {
         // Make sure indices can be converted to usize
         for i in self.indices.iter() {

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -545,11 +545,7 @@ where
                 ));
             }
         }
-        Ok(Self {
-            dim: n,
-            indices,
-            data,
-        })
+        Ok(Self::new_trusted(n, indices, data))
     }
 
     /// Create a sparse vector
@@ -645,11 +641,7 @@ where
 impl<N, I: SpIndex> CsVecI<N, I> {
     /// Create an empty `CsVec`, which can be used for incremental construction
     pub fn empty(dim: usize) -> Self {
-        Self {
-            dim,
-            indices: Vec::new(),
-            data: Vec::new(),
-        }
+        Self::new_trusted(dim, vec![], vec![])
     }
 
     /// Append an element to the sparse vector. Used for incremental
@@ -702,11 +694,7 @@ where
 {
     /// Get a view of this vector.
     pub fn view(&self) -> CsVecViewI<N, I> {
-        CsVecViewI {
-            dim: self.dim,
-            indices: &self.indices[..],
-            data: &self.data[..],
-        }
+        CsVecViewI::new_trusted(self.dim, &self.indices[..], &self.data)
     }
 
     /// Convert the sparse vector to a dense one
@@ -813,11 +801,7 @@ where
     where
         N: Clone,
     {
-        CsVecI {
-            dim: self.dim,
-            indices: self.indices.to_vec(),
-            data: self.data.to_vec(),
-        }
+        CsVecI::new_trusted(self.dim, self.indices.to_vec(), self.data.to_vec())
     }
 
     /// Clone the vector with another integer type for its indices
@@ -836,11 +820,7 @@ where
             .map(|i| I2::from_usize(i.index_unchecked()))
             .collect();
         let data = self.data.iter().cloned().collect();
-        CsVecI {
-            dim: self.dim,
-            indices,
-            data,
-        }
+        CsVecI::new_trusted(self.dim, indices, data)
     }
 
     /// View this vector as a matrix with only one row.
@@ -1084,11 +1064,11 @@ where
     }
 
     pub fn view_mut(&mut self) -> CsVecViewMutI<N, I> {
-        CsVecViewMutI {
-            dim: self.dim,
-            indices: &self.indices[..],
-            data: &mut self.data[..],
-        }
+        CsVecViewMutI::new_trusted(
+            self.dim,
+            &self.indices[..],
+            &mut self.data[..],
+        )
     }
 
     /// Access element at given index, with logarithmic complexity
@@ -1410,11 +1390,11 @@ mod alga_impls {
         I: SpIndex,
     {
         fn two_sided_inverse(&self) -> Self {
-            Self {
-                data: self.data.iter().map(|x| -*x).collect(),
-                indices: self.indices.clone(),
-                dim: self.dim,
-            }
+            Self::new_trusted(
+                self.dim,
+                self.indices.clone(),
+                self.data.iter().map(|x| -*x).collect(),
+            )
         }
     }
 

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -616,7 +616,7 @@ where
     /// Creates a sparse vector
     ///
     /// Will sort indices and data if necessary
-    pub fn new_sorted(
+    pub fn new_from_unsorted(
         n: usize,
         indices: IStorage,
         data: DStorage,


### PR DESCRIPTION
This is the vector analouge to #274 

The new API consists of
* `new`: Constructors which panics on failure
* `try_new`: Returns all buffers and the error
* `new_sorted`: A constructors that may sort the indices and data
* `new_unchecked`: Does zero checking of constraints

Internal:
* `new_trusted`: The internal version of `new_unchecked`

A bunch of the other constructors were removed. These can be expressed in some form of the above. The `unsafe` view constructors are removed in preference to `new_unchecked`, where the caller must ensure valid lifetimes

Fixes #273