### PR TITLE
Relax copy bound

### DIFF
--- a/sprs-ldl/src/lib.rs
+++ b/sprs-ldl/src/lib.rs
@@ -390,6 +390,7 @@ impl<N, I: SpIndex> LdlNumeric<N, I> {
     ) -> <<V as DenseVector>::Owned as DenseVector>::Owned
     where
         N: 'a + Copy + Num + std::ops::SubAssign + std::ops::DivAssign,
+        N: for<'r> std::ops::DivAssign<&'r N>,
         V: DenseVector<Scalar = N>,
         <V as DenseVector>::Owned: DenseVectorMut + DenseVector<Scalar = N>,
         for<'b> &'b <V as DenseVector>::Owned: DenseVector<Scalar = N>,

--- a/src/io.rs
+++ b/src/io.rs
@@ -270,7 +270,7 @@ pub fn write_matrix_market<'a, N, I, M, P>(
 ) -> Result<(), io::Error>
 where
     I: 'a + SpIndex + fmt::Display,
-    N: 'a + PrimitiveKind + Copy + fmt::Display,
+    N: 'a + PrimitiveKind + fmt::Display,
     M: IntoIterator<Item = (&'a N, (I, I))> + SparseMat,
     P: AsRef<Path>,
 {
@@ -319,7 +319,7 @@ pub fn write_matrix_market_sym<'a, N, I, M, P>(
 ) -> Result<(), io::Error>
 where
     I: 'a + SpIndex + fmt::Display,
-    N: 'a + PrimitiveKind + Copy + fmt::Display,
+    N: 'a + PrimitiveKind + fmt::Display,
     M: IntoIterator<Item = (&'a N, (I, I))> + SparseMat,
     P: AsRef<Path>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,11 @@ assert_eq!(a, b.to_csc());
 
 pub mod array_backend;
 mod dense_vector;
-mod mul_acc;
 pub mod errors;
 pub mod indexing;
 #[cfg(not(miri))]
 pub mod io;
+mod mul_acc;
 pub mod num_kinds;
 mod range;
 mod sparse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ assert_eq!(a, b.to_csc());
 
 pub mod array_backend;
 mod dense_vector;
+mod mul_acc;
 pub mod errors;
 pub mod indexing;
 #[cfg(not(miri))]
@@ -102,6 +103,7 @@ pub use crate::sparse::{
 };
 
 pub use crate::dense_vector::{DenseVector, DenseVectorMut};
+pub use crate::mul_acc::MulAcc;
 
 pub use crate::sparse::symmetric::is_symmetric;
 

--- a/src/mul_acc.rs
+++ b/src/mul_acc.rs
@@ -1,0 +1,41 @@
+//! Multiply-accumulate (MAC) trait and implementations
+//! It's useful to define our own MAC trait as it's the main primitive we use
+//! in matrix products, and defining it ourselves means we can define an
+//! implementation that does not require cloning, which should prove useful
+//! when defining sparse matrices per blocks (eg BSR, BSC)
+
+/// Trait for types that have a multiply-accumulate operation, as required
+/// in dot products and matrix products.
+///
+/// This trait is automatically implemented for numeric types that are `Copy`,
+/// however the implementation is open for more complex types, to allow them
+/// to provide the most performant implementation. For instance, we could have
+/// a default implementation for numeric types that are `Clone`, but it would
+/// make possibly unnecessary copies.
+pub trait MulAcc {
+    /// Multiply and accumulate in this variable, formally `*self += a * b`.
+    fn mul_acc(&mut self, a: &Self, b: &Self);
+}
+
+impl<N> MulAcc for N
+where
+    N: Copy + num_traits::MulAdd<Output = N>,
+{
+    fn mul_acc(&mut self, a: &Self, b: &Self) {
+        *self = a.mul_add(*b, *self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MulAcc;
+
+    #[test]
+    fn mul_acc_f64() {
+        let mut a = 1f64;
+        let b = 2.;
+        let c = 3.;
+        a.mul_acc(&b, &c);
+        assert_eq!(a, 7.);
+    }
+}

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -367,7 +367,7 @@ pub(crate) mod utils {
         true
     }
 
-    pub fn sort_indices_data_slices<N: Copy, I: SpIndex>(
+    pub fn sort_indices_data_slices<N: Clone, I: SpIndex>(
         indices: &mut [I],
         data: &mut [N],
         buf: &mut Vec<(I, N)>,
@@ -379,13 +379,15 @@ pub(crate) mod utils {
         buf.clear();
         buf.reserve_exact(len);
         for (i, v) in indices.iter().zip(data.iter()) {
-            buf.push((*i, *v));
+            buf.push((*i, v.clone()));
         }
 
         buf.sort_unstable_by_key(|x| x.0);
 
-        for (&(i, x), (ind, v)) in
-            buf.iter().zip(indices.iter_mut().zip(data.iter_mut()))
+        for ((i, x), (ind, v)) in buf
+            .iter()
+            .cloned()
+            .zip(indices.iter_mut().zip(data.iter_mut()))
         {
             *ind = i;
             *v = x;

--- a/src/sparse/kronecker.rs
+++ b/src/sparse/kronecker.rs
@@ -11,14 +11,13 @@ use crate::sparse::prelude::*;
 ///
 /// * if indices are out of bounds for its type
 #[must_use]
-pub fn kronecker_product<
-    N: num_traits::Num + Copy + Default,
-    I: SpIndex,
-    Iptr: SpIndex,
->(
+pub fn kronecker_product<N: Clone + Default, I: SpIndex, Iptr: SpIndex>(
     mut a: CsMatViewI<N, I, Iptr>,
     mut b: CsMatViewI<N, I, Iptr>,
-) -> CsMatI<N, I, Iptr> {
+) -> CsMatI<N, I, Iptr>
+where
+    for<'r> &'r N: std::ops::Mul<&'r N, Output = N>,
+{
     use crate::CompressedStorage::CSR;
     if a.storage() == b.storage() {
         let was_csc = a.is_csc();
@@ -38,8 +37,8 @@ pub fn kronecker_product<
         indptr.push(element_count);
         for a in a.outer_iterator() {
             for b in b.outer_iterator() {
-                for (ai, &a) in a.iter() {
-                    for (bi, &b) in b.iter() {
+                for (ai, a) in a.iter() {
+                    for (bi, b) in b.iter() {
                         indices.push(I::from(ai * b_shape.1 + bi).unwrap());
                         element_count += Iptr::one();
                         values.push(a * b);

--- a/src/sparse/kronecker.rs
+++ b/src/sparse/kronecker.rs
@@ -1,5 +1,41 @@
 use crate::indexing::SpIndex;
 use crate::sparse::prelude::*;
+use num_complex::{Complex32, Complex64};
+
+/// Trait for types that are valid to compute a Kronecker product.
+/// This includes all classic scalar types, but can be extended to matrices
+/// as well, which will enable computing the kronecker product of sparse
+/// by block matrices.
+pub trait Kronecker<B = Self> {
+    type Output;
+    fn kron(&self, b: &B) -> <Self as Kronecker<B>>::Output;
+}
+
+macro_rules! scalar_kronecker {
+    ($scalar: ident) => {
+        impl Kronecker for $scalar {
+            type Output = Self;
+            fn kron(&self, b: &Self) -> Self::Output {
+                self * b
+            }
+        }
+    };
+}
+
+scalar_kronecker!(u8);
+scalar_kronecker!(i8);
+scalar_kronecker!(u16);
+scalar_kronecker!(i16);
+scalar_kronecker!(u32);
+scalar_kronecker!(i32);
+scalar_kronecker!(u64);
+scalar_kronecker!(i64);
+scalar_kronecker!(isize);
+scalar_kronecker!(usize);
+scalar_kronecker!(f32);
+scalar_kronecker!(f64);
+scalar_kronecker!(Complex32);
+scalar_kronecker!(Complex64);
 
 /// Compute the Kronecker product between two matrices
 ///
@@ -11,12 +47,15 @@ use crate::sparse::prelude::*;
 ///
 /// * if indices are out of bounds for its type
 #[must_use]
-pub fn kronecker_product<N: Clone + Default, I: SpIndex, Iptr: SpIndex>(
-    mut a: CsMatViewI<N, I, Iptr>,
-    mut b: CsMatViewI<N, I, Iptr>,
-) -> CsMatI<N, I, Iptr>
+pub fn kronecker_product<Nin, Nout, I, Iptr>(
+    mut a: CsMatViewI<Nin, I, Iptr>,
+    mut b: CsMatViewI<Nin, I, Iptr>,
+) -> CsMatI<Nout, I, Iptr>
 where
-    for<'r> &'r N: std::ops::Mul<&'r N, Output = N>,
+    Nin: Clone + Default + Kronecker<Output = Nout>,
+    Nout: Clone + Default,
+    I: SpIndex,
+    Iptr: SpIndex,
 {
     use crate::CompressedStorage::CSR;
     if a.storage() == b.storage() {
@@ -41,7 +80,7 @@ where
                     for (bi, b) in b.iter() {
                         indices.push(I::from(ai * b_shape.1 + bi).unwrap());
                         element_count += Iptr::one();
-                        values.push(a * b);
+                        values.push(a.kron(b));
                     }
                 }
                 indptr.push(element_count);

--- a/src/sparse/linalg.rs
+++ b/src/sparse/linalg.rs
@@ -14,13 +14,14 @@ pub use self::ordering::reverse_cuthill_mckee;
 /// Diagonal solve
 pub fn diag_solve<'a, N, V1, V2>(diag: V1, mut x: V2)
 where
-    N: 'a + Copy + Num + std::ops::DivAssign,
+    N: 'a + Clone + Num + std::ops::DivAssign,
+    for<'r> N: std::ops::DivAssign<&'r N>,
     V1: DenseVector<Scalar = N>,
     V2: DenseVectorMut + DenseVector<Scalar = N>,
 {
     let n = x.dim();
     assert_eq!(diag.dim(), n);
     for i in 0..n {
-        *x.index_mut(i) /= *diag.index(i);
+        *x.index_mut(i) /= diag.index(i);
     }
 }

--- a/src/sparse/permutation.rs
+++ b/src/sparse/permutation.rs
@@ -298,7 +298,7 @@ pub fn transform_mat_papt<N, I, Iptr>(
     perm: PermViewI<I>,
 ) -> CsMatI<N, I, Iptr>
 where
-    N: Copy + ::std::fmt::Debug,
+    N: Clone + ::std::fmt::Debug,
     I: SpIndex,
     Iptr: SpIndex,
 {
@@ -328,12 +328,12 @@ where
         tmp.clear();
         let outer = mat.outer_view(in_outer.index()).unwrap();
         for (ind, val) in outer.indices().iter().zip(outer.data()) {
-            tmp.push((p_[ind.index()], *val))
+            tmp.push((p_[ind.index()], val.clone()))
         }
         tmp.sort_by_key(|(ind, _)| *ind);
         for (ind, val) in &tmp {
             indices.push(*ind);
-            data.push(*val);
+            data.push(val.clone());
         }
     }
 

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -505,4 +505,46 @@ mod test {
 
         let _ = &a * &b;
     }
+
+    #[test]
+    fn mul_complex() {
+        use num_complex::Complex32;
+        // | 0  1 0   0  |
+        // | 0  0 0   0  |
+        // | i  0 0  1+i |
+        // | 0  0 2i  0  |
+        let a = crate::CsMat::new(
+            (4, 4),
+            vec![0, 1, 1, 3, 4],
+            vec![1, 0, 3, 2],
+            vec![
+                Complex32::new(1., 0.),
+                Complex32::new(0., 1.),
+                Complex32::new(1., 1.),
+                Complex32::new(0., 2.),
+            ],
+        );
+        //                 | 0  1 0      0  |
+        //                 | 0  0 0      0  |
+        //                 | i  0 0     1+i |
+        //                 | 0  0 2i     0  |
+        //
+        // | 0  1 0   0  | | 0  0   0    0  |
+        // | 0  0 0   0  | | 0  0   0    0  |
+        // | i  0 0  1+i | | 0  i -2+2i  0  |
+        // | 0  0 2i  0  | |-2  0   0  -2+2i|
+        let expected = crate::CsMat::new(
+            (4, 4),
+            vec![0, 0, 0, 2, 4],
+            vec![1, 2, 0, 3],
+            vec![
+                Complex32::new(0., 1.),
+                Complex32::new(-2., 2.),
+                Complex32::new(-2., 0.),
+                Complex32::new(-2., 2.),
+            ],
+        );
+        let b = &a * &a;
+        assert_eq!(b, expected);
+    }
 }

--- a/src/sparse/smmp.rs
+++ b/src/sparse/smmp.rs
@@ -4,7 +4,6 @@
 use crate::indexing::SpIndex;
 use crate::sparse::prelude::*;
 use crate::sparse::CompressedStorage::CSR;
-use num_traits::Num;
 #[cfg(feature = "multi_thread")]
 use rayon::prelude::*;
 
@@ -102,6 +101,10 @@ pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
     for (a_row, a_range) in a.indptr().iter_outer_sz().enumerate() {
         let mut length = 0;
 
+        // FIXME are iterators possible here?
+        // TODO benchmark unsafe indexing here. It's possible to get
+        // a subslice using get(a_range). It should also be possible to use
+        // index_unchecked and from_usize_unchecked
         for &a_col in &a.indices()[a_range] {
             let b_row = a_col.index();
             let b_range = b.indptr().outer_inds_sz(b_row);
@@ -147,7 +150,7 @@ pub fn symbolic<Iptr: SpIndex, I: SpIndex>(
 pub fn numeric<
     Iptr: SpIndex,
     I: SpIndex,
-    N: Num + Copy + std::ops::AddAssign,
+    N: crate::MulAcc + num_traits::Zero,
 >(
     a: CsMatViewI<N, I, Iptr>,
     b: CsMatViewI<N, I, Iptr>,
@@ -166,15 +169,18 @@ pub fn numeric<
     }
     for (a_row, mut c_row) in a.outer_iterator().zip(c.outer_iterator_mut()) {
         for (a_col, a_val) in a_row.iter() {
+            // TODO unchecked index
             let b_row = b.outer_view(a_col.index()).unwrap();
             for (b_col, b_val) in b_row.iter() {
                 // TODO unsafe indexing
-                tmp[b_col.index()] += *a_val * *b_val;
+                tmp[b_col.index()].mul_acc(a_val, b_val);
             }
         }
         for (c_col, c_val) in c_row.iter_mut() {
-            *c_val = tmp[c_col];
-            tmp[c_col] = N::zero();
+            // TODO unsafe indexing
+            let mut val = N::zero();
+            std::mem::swap(&mut val, &mut tmp[c_col]);
+            *c_val = val;
         }
     }
 }
@@ -189,7 +195,7 @@ pub fn mul_csr_csr<N, I, Iptr>(
     rhs: CsMatViewI<N, I, Iptr>,
 ) -> CsMatI<N, I, Iptr>
 where
-    N: Num + Copy + std::ops::AddAssign + Send + Sync,
+    N: crate::MulAcc + num_traits::Zero + Clone + Send + Sync,
     I: SpIndex,
     Iptr: SpIndex,
 {
@@ -247,7 +253,7 @@ pub fn mul_csr_csr_with_workspace<N, I, Iptr>(
     tmps: &mut [Box<[N]>],
 ) -> CsMatI<N, I, Iptr>
 where
-    N: Num + Copy + std::ops::AddAssign + Send + Sync,
+    N: crate::MulAcc + num_traits::Zero + Clone + Send + Sync,
     I: SpIndex,
     Iptr: SpIndex,
 {

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1901,6 +1901,33 @@ mod test {
         assert_eq!(res, &[0, 1, 3, 4]);
     }
 
+    #[test]
+    fn add_sub_complex() {
+        use num_complex::Complex32;
+        let vector = CsVec::new(
+            4,
+            vec![1, 2, 3],
+            vec![
+                Complex32::new(0., 1.),
+                Complex32::new(3., 1.),
+                Complex32::new(4., 0.),
+            ],
+        );
+        let doubled = &vector + &vector;
+        let expected = CsVec::new(
+            4,
+            vec![1, 2, 3],
+            vec![
+                Complex32::new(0., 2.),
+                Complex32::new(6., 2.),
+                Complex32::new(8., 0.),
+            ],
+        );
+        assert_eq!(doubled, expected);
+        let subtracted = &doubled - &vector;
+        assert_eq!(subtracted, vector);
+    }
+
     #[cfg(feature = "approx")]
     mod approx {
         use crate::*;

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -29,7 +29,7 @@ impl<I: Default> Default for StackVal<I> {
 
 impl<I> DStack<I>
 where
-    I: Copy,
+    I: Clone,
 {
     /// Create a new double stacked suited for containing at most n elements
     pub fn with_capacity(n: usize) -> Self
@@ -80,7 +80,7 @@ where
     pub fn pop_left(&mut self) -> Option<I> {
         match self.left_head {
             Some(left_head) => {
-                let res = self.stacks[left_head];
+                let res = self.stacks[left_head].clone();
                 self.left_head = if left_head > 0 {
                     Some(left_head - 1)
                 } else {
@@ -97,7 +97,7 @@ where
         if self.right_head >= self.stacks.len() {
             None
         } else {
-            let res = self.stacks[self.right_head];
+            let res = self.stacks[self.right_head].clone();
             self.right_head += 1;
             Some(res)
         }

--- a/tests/block_matrix.rs
+++ b/tests/block_matrix.rs
@@ -1,0 +1,108 @@
+//! Test to demonstrate the possibility of having sparse matrices per block
+use num_traits::Zero;
+
+#[derive(Clone, Default, Debug, PartialEq)]
+struct Mat {
+    data: [[i32; 2]; 2],
+}
+
+impl Mat {
+    fn new(data: [[i32; 2]; 2]) -> Self {
+        Self { data }
+    }
+}
+
+impl Zero for Mat {
+    fn zero() -> Self {
+        Self {
+            data: [[0_i32; 2]; 2],
+        }
+    }
+    fn is_zero(&self) -> bool {
+        self == &Self::zero()
+    }
+}
+
+impl std::ops::Add for Mat {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        let mut out = Self::Output::zero();
+        for i in 0..2 {
+            for j in 0..2 {
+                out.data[i][j] = self.data[i][j] + other.data[i][j]
+            }
+        }
+        out
+    }
+}
+
+impl std::ops::Mul for &Mat {
+    type Output = Mat;
+    fn mul(self, other: Self) -> Self::Output {
+        let mut out = Self::Output::zero();
+        for i in 0..2 {
+            for j in 0..2 {
+                for k in 0..2 {
+                    out.data[i][j] += self.data[i][k] * other.data[k][j];
+                }
+            }
+        }
+        out
+    }
+}
+
+impl sprs::MulAcc for Mat {
+    fn mul_acc(&mut self, a: &Self, b: &Self) {
+        for i in 0..2 {
+            for j in 0..2 {
+                for k in 0..2 {
+                    self.data[i][j] += a.data[i][k] * b.data[k][j];
+                }
+            }
+        }
+    }
+}
+
+#[test]
+/// Performs a multiplication of a sparse block-compressed matrix
+///
+/// Doing this through sparse multiplication gives 2 calls to mul_acc
+/// instead of the 8 expected from a dense matrix multiplication
+fn block_matrix_multiply() {
+    let mat1 = Mat::new([[1, 2], [3, 4]]);
+    let mat2 = Mat::new([[0, -3], [-2, -7]]);
+    assert_eq!(&mat1 * &mat1, Mat::new([[7, 10], [15, 22]]));
+
+    //  0  0  1  2
+    //  0  0  3  4
+    //  1  2  0 -3
+    //  3  4 -2 -7
+    let smat1 = sprs::CsMat::new(
+        (2, 2),
+        vec![0, 1, 3],
+        vec![1, 0, 1],
+        vec![mat1.clone(), mat1, mat2],
+    );
+
+    let mat1 = Mat::new([[2, 0], [7, -4]]);
+    let mat2 = Mat::new([[0, -99], [9, -7]]);
+
+    //  2  0  0  -99
+    //  7 -4  9   -7
+    //  0  0  0    0
+    //  0  0  0    0
+    let smat2 =
+        sprs::CsMat::new((2, 2), vec![0, 2, 2], vec![0, 1], vec![mat1, mat2]);
+
+    //  0   0  0    0
+    //  0   0  0    0
+    // 16  -8 18 -113
+    // 34 -16 36 -325
+    let smat3 = &smat1 * &smat2;
+    assert_eq!(smat3.indptr().raw_storage(), &[0, 0, 2]);
+    assert_eq!(smat3.indices(), &[0, 1]);
+    let data = smat3.data();
+    assert_eq!(data.len(), 2);
+    assert_eq!(data[0], Mat::new([[16, -8], [34, -16]]));
+    assert_eq!(data[1], Mat::new([[18, -113], [36, -325]]));
+}


### PR DESCRIPTION
This pull request removes the `Copy` bound from most functions and methods, fixing #121.

While removing the bound, I tried to ensure there were not too many unnecessary calls to `Clone`, with the idea that this should enable storing more complex data as our scalar type (such as big ints, or heap-allocated matrices to have sparse by blocks matrices) while remaining performant.

The main way the unnecessary clones have been removed is through the introduction of the `MulAcc` trait, which represents the fundamental operation for matrix products. Since it takes its arguments by reference, it should be possible to implement this trait without unnecessary allocations for heab-based scalar types. For convenience, this trait is automatically implemented for all `Copy` types that also implement `num_traits::MulAdd`. This ensures all common scalar types work, and should also help the compiler using the fused-multiply-add instruction when available.

Another pattern that was useful to avoid unnecessary clones was adding bounds such as `for <'r> &'r N: std::ops::Add<&'r N, Output=N>`. These bounds exist for all classic scalar types. However, it can be hard to use them in traits, as evidenced by https://github.com/rust-lang/rust/issues/82779. Because of this issue, implementations of `std::ops::{Add,Sub}` for `CsVecBase` were forced to use one `Clone`.

I have not relaxed the `Copy` bound in `sprs-ldl` yet, I think I would need to add a trait such as `MulSubAcc` similar to `MulAcc` that could be used in solvers. Otherwise I would need to sprinkle the code with calls to `clone()` everywhere.

@mulimoen as usual I'd be very interested in your feedback.