### PR TITLE
Bump ndarray

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         include:
         - build: msrv
           os: ubuntu-18.04
-          rust: 1.42.0
+          rust: 1.49.0
         - build: stable
           os: ubuntu-18.04
           rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ multi_thread = ["rayon", "num_cpus"]
 
 [dependencies]
 num-traits = "0.2.0"
-ndarray = ">=0.11.0,<0.15"
+ndarray = "0.15"
 alga = { version = "0.9.0", optional = true }
 num-complex = "0.2.1"
 serde = { version = "1.0.0", optional = true, features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See the [changelog](changelog.rst).
 
 ## Minimum Supported Rust Version
 
-The minimum supported Rust version currently is 1.42. Prior to a 1.0 version,
+The minimum supported Rust version currently is 1.49. Prior to a 1.0 version,
 bumping the MSRV will not be considered a breaking change, but breakage will
 be avoided on a best effort basis.
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 - Unreleased
   - ``MulAcc`` is generalised to allow different output types from input
+  - Bump `ndarray` to `0.15`. This requires a bump in MSRV to `1.49`
 
 - 0.10.0
   - support more scalar types for scalar/matrix multiplication

--- a/examples/heat.rs
+++ b/examples/heat.rs
@@ -109,7 +109,7 @@ fn gauss_seidel(
 ) -> Result<(usize, f64), f64> {
     assert!(mat.rows() == mat.cols());
     assert!(mat.rows() == x.shape()[0]);
-    let mut error = (&mat * &x - rhs).scalar_sum().sqrt();
+    let mut error = (&mat * &x - rhs).sum().sqrt();
     for it in 0..max_iter {
         for (row_ind, vec) in mat.outer_iterator().enumerate() {
             let mut sigma = 0.;
@@ -128,7 +128,7 @@ fn gauss_seidel(
             x[[row_ind]] = (cur_rhs - sigma) / diag;
         }
 
-        error = (&mat * &x - rhs).scalar_sum().sqrt();
+        error = (&mat * &x - rhs).sum().sqrt();
         // error corresponds to the state before iteration, but
         // that shouldn't be a problem
         if error < eps {

--- a/sprs-ldl/Cargo.toml
+++ b/sprs-ldl/Cargo.toml
@@ -32,4 +32,4 @@ path = "../suitesparse_bindings/sprs_suitesparse_camd"
 optional = true
 
 [dev-dependencies]
-ndarray = ">=0.11.0,<0.15"
+ndarray = ">=0.11.0,<0.16"


### PR DESCRIPTION
`ndarray` had a version bump, but we are still compatible with all versions. This is not a breaking change.