### PR TITLE
Add asymmetric operands to pointwise binary ops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,20 +24,20 @@ multi_thread = ["rayon", "num_cpus"]
 num-traits = "0.2.0"
 ndarray = "0.15"
 alga = { version = "0.9.0", optional = true }
-num-complex = "0.2.1"
+num-complex = "0.4.0"
 serde = { version = "1.0.0", optional = true, features = ["derive"] }
 smallvec = "1.4.0"
 rayon = { version = "1.3.0", optional = true }
 num_cpus = { version = "1.13.0", optional = true }
-approx = { version = "0.3.2", optional = true }
+approx = { version = "0.5", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.0"
 tempfile = "3.1.0"
 bincode = "1.2.0"
-tobj = "2.0.0"
+tobj = "3.0"
 image = { version = "0.23.0", default-features = false, features = ["png"] }
-rand = { version = "0.7.3", default-features = false, features = ["small_rng"] }
+rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 
 [[bench]]
 name = "suite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "sprs"
 description = "A sparse matrix library"
 version = "0.10.0"
@@ -32,6 +31,7 @@ num_cpus = { version = "1.13.0", optional = true }
 approx = { version = "0.5", optional = true }
 
 [dev-dependencies]
+num-derive = "0.3"
 bencher = "0.1.0"
 tempfile = "3.1.0"
 bincode = "1.2.0"

--- a/examples/fill_in_reduction.rs
+++ b/examples/fill_in_reduction.rs
@@ -33,7 +33,13 @@ fn small_lap_mat() -> sprs::CsMat<f64> {
 }
 
 fn lap_mat_from_obj(path: &str) -> Result<sprs::CsMat<f64>, tobj::LoadError> {
-    let (objects, _materials) = tobj::load_obj(&Path::new(path), true)?;
+    let (objects, _materials) = tobj::load_obj(
+        &Path::new(path),
+        &tobj::LoadOptions {
+            triangulate: true,
+            ..Default::default()
+        },
+    )?;
     for obj in objects {
         let nb_triangles = obj.mesh.indices.len() / 3;
         let nb_vertices = obj.mesh.positions.len() / 3;

--- a/src/sparse/binop.rs
+++ b/src/sparse/binop.rs
@@ -17,27 +17,42 @@ use num_traits::Num;
 
 use crate::Ix2;
 
-impl<'a, 'b, N, I, Iptr, IpStorage, IStorage, DStorage, IpS2, IS2, DS2>
-    Add<&'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>>
-    for &'a CsMatBase<N, I, IpStorage, IStorage, DStorage, Iptr>
+impl<
+        'a,
+        'b,
+        Lhs,
+        Rhs,
+        Res,
+        I,
+        Iptr,
+        IpStorage,
+        IStorage,
+        DStorage,
+        IpS2,
+        IS2,
+        DS2,
+    > Add<&'b CsMatBase<Rhs, I, IpS2, IS2, DS2, Iptr>>
+    for &'a CsMatBase<Lhs, I, IpStorage, IStorage, DStorage, Iptr>
 where
-    N: num_traits::Zero + PartialEq + Clone + Default,
-    for<'r> &'r N: Add<&'r N, Output = N>,
+    Lhs: num_traits::Zero + PartialEq + Clone + Default,
+    Rhs: num_traits::Zero + PartialEq + Clone + Default,
+    Res: num_traits::Zero + PartialEq + Clone,
+    for<'r> &'r Lhs: Add<&'r Rhs, Output = Res>,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IpStorage: 'a + Deref<Target = [Iptr]>,
     IStorage: 'a + Deref<Target = [I]>,
-    DStorage: 'a + Deref<Target = [N]>,
-    IpS2: 'a + Deref<Target = [Iptr]>,
-    IS2: 'a + Deref<Target = [I]>,
-    DS2: 'a + Deref<Target = [N]>,
+    DStorage: 'a + Deref<Target = [Lhs]>,
+    IpS2: 'b + Deref<Target = [Iptr]>,
+    IS2: 'b + Deref<Target = [I]>,
+    DS2: 'b + Deref<Target = [Rhs]>,
 {
-    type Output = CsMatI<N, I, Iptr>;
+    type Output = CsMatI<Res, I, Iptr>;
 
     fn add(
         self,
-        rhs: &'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>,
-    ) -> CsMatI<N, I, Iptr> {
+        rhs: &'b CsMatBase<Rhs, I, IpS2, IS2, DS2, Iptr>,
+    ) -> Self::Output {
         if self.storage() != rhs.view().storage() {
             return csmat_binop(
                 self.view(),
@@ -49,27 +64,42 @@ where
     }
 }
 
-impl<'a, 'b, N, I, Iptr, IpStorage, IStorage, DStorage, IpS2, IS2, DS2>
-    Sub<&'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>>
-    for &'a CsMatBase<N, I, IpStorage, IStorage, DStorage, Iptr>
+impl<
+        'a,
+        'b,
+        Lhs,
+        Rhs,
+        Res,
+        I,
+        Iptr,
+        IpStorage,
+        IStorage,
+        DStorage,
+        IpS2,
+        IS2,
+        DS2,
+    > Sub<&'b CsMatBase<Rhs, I, IpS2, IS2, DS2, Iptr>>
+    for &'a CsMatBase<Lhs, I, IpStorage, IStorage, DStorage, Iptr>
 where
-    N: num_traits::Zero + PartialEq + Clone + Default,
-    for<'r> &'r N: Sub<&'r N, Output = N>,
+    Lhs: num_traits::Zero + PartialEq + Clone + Default,
+    Rhs: num_traits::Zero + PartialEq + Clone + Default,
+    Res: num_traits::Zero + PartialEq + Clone + Default,
+    for<'r> &'r Lhs: Sub<&'r Rhs, Output = Res>,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IpStorage: 'a + Deref<Target = [Iptr]>,
     IStorage: 'a + Deref<Target = [I]>,
-    DStorage: 'a + Deref<Target = [N]>,
+    DStorage: 'a + Deref<Target = [Lhs]>,
     IpS2: 'a + Deref<Target = [Iptr]>,
     IS2: 'a + Deref<Target = [I]>,
-    DS2: 'a + Deref<Target = [N]>,
+    DS2: 'a + Deref<Target = [Rhs]>,
 {
-    type Output = CsMatI<N, I, Iptr>;
+    type Output = CsMatI<Res, I, Iptr>;
 
     fn sub(
         self,
-        rhs: &'b CsMatBase<N, I, IpS2, IS2, DS2, Iptr>,
-    ) -> CsMatI<N, I, Iptr> {
+        rhs: &'b CsMatBase<Rhs, I, IpS2, IS2, DS2, Iptr>,
+    ) -> Self::Output {
         if self.storage() != rhs.view().storage() {
             return csmat_binop(
                 self.view(),
@@ -82,17 +112,19 @@ where
 }
 
 /// Sparse matrix scalar multiplication, with same storage type
-pub fn mul_mat_same_storage<N, I, Iptr, Mat1, Mat2>(
+pub fn mul_mat_same_storage<Lhs, Rhs, Res, I, Iptr, Mat1, Mat2>(
     lhs: &Mat1,
     rhs: &Mat2,
-) -> CsMatI<N, I, Iptr>
+) -> CsMatI<Res, I, Iptr>
 where
-    N: num_traits::Zero + PartialEq + Clone,
-    for<'r> &'r N: std::ops::Mul<&'r N, Output = N>,
+    Lhs: num_traits::Zero + PartialEq + Clone,
+    Rhs: num_traits::Zero + PartialEq + Clone,
+    Res: num_traits::Zero + PartialEq + Clone,
+    for<'r> &'r Lhs: std::ops::Mul<&'r Rhs, Output = Res>,
     I: SpIndex,
     Iptr: SpIndex,
-    Mat1: SpMatView<N, I, Iptr>,
-    Mat2: SpMatView<N, I, Iptr>,
+    Mat1: SpMatView<Lhs, I, Iptr>,
+    Mat2: SpMatView<Rhs, I, Iptr>,
 {
     csmat_binop(lhs.view(), rhs.view(), |x, y| x * y)
 }
@@ -141,16 +173,18 @@ sparse_scalar_mul!(f64);
 ///
 /// - on incompatible dimensions
 /// - on incomatible storage
-pub fn csmat_binop<N, I, Iptr, F>(
-    lhs: CsMatViewI<N, I, Iptr>,
-    rhs: CsMatViewI<N, I, Iptr>,
+pub fn csmat_binop<Lhs, Rhs, Res, I, Iptr, F>(
+    lhs: CsMatViewI<Lhs, I, Iptr>,
+    rhs: CsMatViewI<Rhs, I, Iptr>,
     binop: F,
-) -> CsMatI<N, I, Iptr>
+) -> CsMatI<Res, I, Iptr>
 where
-    N: num_traits::Zero + PartialEq + Clone,
+    Lhs: num_traits::Zero + PartialEq + Clone,
+    Rhs: num_traits::Zero + PartialEq + Clone,
+    Res: num_traits::Zero + PartialEq + Clone,
     I: SpIndex,
     Iptr: SpIndex,
-    F: Fn(&N, &N) -> N,
+    F: Fn(&Lhs, &Rhs) -> Res,
 {
     let nrows = lhs.rows();
     let ncols = lhs.cols();
@@ -165,7 +199,7 @@ where
     let max_nnz = lhs.nnz() + rhs.nnz();
     let mut out_indptr = vec![Iptr::zero(); lhs.outer_dims() + 1];
     let mut out_indices = vec![I::zero(); max_nnz];
-    let mut out_data = vec![N::zero(); max_nnz];
+    let mut out_data = vec![Res::zero(); max_nnz];
 
     let nnz = csmat_binop_same_storage_raw(
         lhs,
@@ -191,19 +225,21 @@ where
 /// sharing the same storage. The output arrays are assumed to be preallocated
 ///
 /// Returns the nnz count
-pub fn csmat_binop_same_storage_raw<N, I, Iptr, F>(
-    lhs: CsMatViewI<N, I, Iptr>,
-    rhs: CsMatViewI<N, I, Iptr>,
+pub fn csmat_binop_same_storage_raw<Lhs, Rhs, Res, I, Iptr, F>(
+    lhs: CsMatViewI<Lhs, I, Iptr>,
+    rhs: CsMatViewI<Rhs, I, Iptr>,
     binop: F,
     out_indptr: &mut [Iptr],
     out_indices: &mut [I],
-    out_data: &mut [N],
+    out_data: &mut [Res],
 ) -> usize
 where
-    N: num_traits::Zero + PartialEq,
+    Lhs: num_traits::Zero + PartialEq,
+    Rhs: num_traits::Zero + PartialEq,
+    Res: num_traits::Zero + PartialEq,
     I: SpIndex,
     Iptr: SpIndex,
-    F: Fn(&N, &N) -> N,
+    F: Fn(&Lhs, &Rhs) -> Res,
 {
     assert_eq!(lhs.cols(), rhs.cols());
     assert_eq!(lhs.rows(), rhs.rows());
@@ -218,11 +254,11 @@ where
     for (dim, (lv, rv)) in iter {
         for elem in lv.iter().nnz_or_zip(rv.iter()) {
             let (ind, binop_val) = match elem {
-                Left((ind, val)) => (ind, binop(val, &N::zero())),
-                Right((ind, val)) => (ind, binop(&N::zero(), val)),
+                Left((ind, val)) => (ind, binop(val, &Rhs::zero())),
+                Right((ind, val)) => (ind, binop(&Lhs::zero(), val)),
                 Both((ind, lval, rval)) => (ind, binop(lval, rval)),
             };
-            if binop_val != N::zero() {
+            if binop_val != Res::zero() {
                 out_indices[nnz] = I::from_usize_unchecked(ind);
                 out_data[nnz] = binop_val;
                 nnz += 1;
@@ -239,18 +275,22 @@ where
 /// The matrices must have the same ordering, a `CSR` matrix must be
 /// added with a matrix with `C`-like ordering, a `CSC` matrix
 /// must be added with a matrix with `F`-like ordering.
-pub fn add_dense_mat_same_ordering<N, I, Iptr, Mat, D>(
+pub fn add_dense_mat_same_ordering<Lhs, Rhs, Res, I, Iptr, Mat, D>(
     lhs: &Mat,
     rhs: &ArrayBase<D, Ix2>,
-    alpha: N,
-    beta: N,
-) -> Array<N, Ix2>
+    alpha: Lhs,
+    beta: Rhs,
+) -> Array<Res, Ix2>
 where
-    N: Num + Copy,
+    Lhs: Num + Add<Rhs, Output = Res>,
+    Rhs: Num,
+    Res: Num + Copy,
+    for<'r> &'r Lhs: Mul<Output = Lhs>,
+    for<'r> &'r Rhs: Mul<Output = Rhs>,
     I: SpIndex,
     Iptr: SpIndex,
-    Mat: SpMatView<N, I, Iptr>,
-    D: ndarray::Data<Elem = N>,
+    Mat: SpMatView<Lhs, I, Iptr>,
+    D: ndarray::Data<Elem = Rhs>,
 {
     let shape = (rhs.shape()[0], rhs.shape()[1]);
     let is_clike_layout = super::utils::fastest_axis(rhs.view()) == Axis(1);
@@ -262,7 +302,7 @@ where
     csmat_binop_dense_raw(
         lhs.view(),
         rhs.view(),
-        |&x, &y| alpha * x + beta * y,
+        |x, y| &alpha * x + &beta * y,
         res.view_mut(),
     );
     res
@@ -274,17 +314,31 @@ where
 /// The matrices must have the same ordering, a `CSR` matrix must be
 /// multiplied with a matrix with `C`-like ordering, a `CSC` matrix
 /// must be multiplied with a matrix with `F`-like ordering.
-pub fn mul_dense_mat_same_ordering<N, I, Iptr, Mat, D>(
+pub fn mul_dense_mat_same_ordering<
+    Lhs,
+    Rhs,
+    Res,
+    Alpha,
+    ByProd,
+    I,
+    Iptr,
+    Mat,
+    D,
+>(
     lhs: &Mat,
     rhs: &ArrayBase<D, Ix2>,
-    alpha: N,
-) -> Array<N, Ix2>
+    alpha: Alpha,
+) -> Array<Res, Ix2>
 where
-    N: Num + Copy,
+    Lhs: Num,
+    Rhs: Num,
+    Res: Num + Clone,
+    Alpha: Copy + for<'r> Mul<&'r Lhs, Output = ByProd>,
+    ByProd: for<'r> Mul<&'r Rhs, Output = Res>,
     I: SpIndex,
     Iptr: SpIndex,
-    Mat: SpMatView<N, I, Iptr>,
-    D: ndarray::Data<Elem = N>,
+    Mat: SpMatView<Lhs, I, Iptr>,
+    D: ndarray::Data<Elem = Rhs>,
 {
     let shape = (rhs.shape()[0], rhs.shape()[1]);
     let is_clike_layout = super::utils::fastest_axis(rhs.view()) == Axis(1);
@@ -296,7 +350,7 @@ where
     csmat_binop_dense_raw(
         lhs.view(),
         rhs.view(),
-        |&x, &y| alpha * x * y,
+        |x, y| alpha * x * y,
         res.view_mut(),
     );
     res
@@ -313,16 +367,18 @@ where
 /// `lhs = CSR` with `rhs` and `out` with `Axis(1)` as the fastest dimension,
 /// or
 /// `lhs = CSC` with `rhs` and `out` with `Axis(0)` as the fastest dimension,
-pub fn csmat_binop_dense_raw<'a, N, I, Iptr, F>(
-    lhs: CsMatViewI<'a, N, I, Iptr>,
-    rhs: ArrayView<'a, N, Ix2>,
+pub fn csmat_binop_dense_raw<'a, Lhs, Rhs, Res, I, Iptr, F>(
+    lhs: CsMatViewI<'a, Lhs, I, Iptr>,
+    rhs: ArrayView<'a, Rhs, Ix2>,
     binop: F,
-    mut out: ArrayViewMut<'a, N, Ix2>,
+    mut out: ArrayViewMut<'a, Res, Ix2>,
 ) where
-    N: 'a + Num,
+    Lhs: 'a + Num,
+    Rhs: 'a + Num,
+    Res: Num,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
-    F: Fn(&N, &N) -> N,
+    F: Fn(&Lhs, &Rhs) -> Res,
 {
     if lhs.cols() != rhs.shape()[1]
         || lhs.cols() != out.shape()[1]
@@ -351,11 +407,11 @@ pub fn csmat_binop_dense_raw<'a, N, I, Iptr, F>(
             .iter_mut()
             .zip(rrow.iter().enumerate().nnz_or_zip(lrow.iter()))
         {
-            let (oval, lr_elems) = items;
-            let binop_val = match lr_elems {
-                Left((_, val)) => binop(val, &N::zero()),
-                Right((_, val)) => binop(&N::zero(), val),
-                Both((_, lval, rval)) => binop(lval, rval),
+            let (oval, rl_elems) = items;
+            let binop_val = match rl_elems {
+                Left((_, val)) => binop(&Lhs::zero(), val),
+                Right((_, val)) => binop(val, &Rhs::zero()),
+                Both((_, rval, lval)) => binop(lval, rval),
             };
             *oval = binop_val;
         }
@@ -369,14 +425,15 @@ pub fn csmat_binop_dense_raw<'a, N, I, Iptr, F>(
 /// to zero when e.g. only `lhs` has a non-zero at a given location).
 ///
 /// The function thus has a correct behavior iff `binop(0, 0) == 0`.
-pub fn csvec_binop<N, I, F>(
-    mut lhs: CsVecViewI<N, I>,
-    mut rhs: CsVecViewI<N, I>,
+pub fn csvec_binop<Lhs, Rhs, Res, I, F>(
+    mut lhs: CsVecViewI<Lhs, I>,
+    mut rhs: CsVecViewI<Rhs, I>,
     binop: F,
-) -> Result<CsVecI<N, I>, StructureError>
+) -> Result<CsVecI<Res, I>, StructureError>
 where
-    N: Num,
-    F: Fn(&N, &N) -> N,
+    Lhs: Num,
+    Rhs: Num,
+    F: Fn(&Lhs, &Rhs) -> Res,
     I: SpIndex,
 {
     csvec_fix_zeros(&mut lhs, &mut rhs);
@@ -388,8 +445,8 @@ where
     res.reserve_exact(max_nnz);
     for elem in lhs.iter().nnz_or_zip(rhs.iter()) {
         let (ind, binop_val) = match elem {
-            Left((ind, val)) => (ind, binop(val, &N::zero())),
-            Right((ind, val)) => (ind, binop(&N::zero(), val)),
+            Left((ind, val)) => (ind, binop(val, &Rhs::zero())),
+            Right((ind, val)) => (ind, binop(&Lhs::zero(), val)),
             Both((ind, lval, rval)) => (ind, binop(lval, rval)),
         };
         res.append(ind, binop_val);
@@ -397,9 +454,9 @@ where
     Ok(res)
 }
 
-fn csvec_fix_zeros<N, I: SpIndex>(
-    lhs: &mut CsVecViewI<N, I>,
-    rhs: &mut CsVecViewI<N, I>,
+fn csvec_fix_zeros<Lhs, Rhs, I: SpIndex>(
+    lhs: &mut CsVecViewI<Lhs, I>,
+    rhs: &mut CsVecViewI<Rhs, I>,
 ) {
     if rhs.dim() == 0 {
         rhs.dim = lhs.dim;
@@ -561,7 +618,7 @@ mod test {
     #[test]
     fn csr_mul_dense_rowmaj() {
         let a = Array::from_elem((3, 3), 1.);
-        let b = CsMat::eye(3);
+        let b = CsMat::<f64>::eye(3);
 
         let c = super::mul_dense_mat_same_ordering(&b, &a, 1.);
 
@@ -576,7 +633,7 @@ mod test {
         // with the same fastest axis as input
         let a = Array::from_elem((6, 6), 1.0);
         let a = a.slice(ndarray::s![..;2, ..;2]);
-        let b = CsMat::eye(3);
+        let b = CsMat::<f64>::eye(3);
 
         let c = super::mul_dense_mat_same_ordering(&b, &a, 1.0);
         assert!(c.is_standard_layout());
@@ -587,7 +644,7 @@ mod test {
         use ndarray::ShapeBuilder;
         let a = Array::from_elem((6, 6).f(), 1.0);
         let a = a.slice(ndarray::s![..;2, ..;2]);
-        let b = CsMat::eye_csc(3);
+        let b = CsMat::<f64>::eye_csc(3);
 
         let c = super::mul_dense_mat_same_ordering(&b, &a, 1.0);
         assert!(c.t().is_standard_layout());
@@ -605,7 +662,7 @@ mod test {
         super::csmat_binop_dense_raw(
             csr.view(),
             a.view(),
-            |_, _| 0.0,
+            |_: &f32, _: &f32| 0.0,
             out.view_mut(),
         );
 
@@ -615,7 +672,7 @@ mod test {
         super::csmat_binop_dense_raw(
             csc.view(),
             a.view(),
-            |_, _| 0.0,
+            |_: &f32, _: &f32| 0.0,
             out.view_mut(),
         );
     }
@@ -632,7 +689,7 @@ mod test {
         super::csmat_binop_dense_raw(
             csr.view(),
             a.view(),
-            |_, _| 0.0,
+            |_: &f32, _: &f32| 0.0,
             out.view_mut(),
         );
 
@@ -643,7 +700,7 @@ mod test {
         super::csmat_binop_dense_raw(
             csc.view(),
             a.view(),
-            |_, _| 0.0,
+            |_: &f32, _: &f32| 0.0,
             out.view_mut(),
         );
     }

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1864,6 +1864,7 @@ impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Add<&'b ArrayBase<DS2, Ix2>>
     for &'a CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
     N: 'a + Copy + Num + Default,
+    for<'r> &'r N: Mul<Output = N>,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IpS: 'a + Deref<Target = [Iptr]>,
@@ -1876,20 +1877,21 @@ where
     fn add(self, rhs: &'b ArrayBase<DS2, Ix2>) -> Array<N, Ix2> {
         let is_standard_layout =
             utils::fastest_axis(rhs.view()) == ndarray::Axis(1);
+        let neuter_element = N::one();
         match (self.storage(), is_standard_layout) {
             (CSR, true) | (CSC, false) => binop::add_dense_mat_same_ordering(
                 self,
                 rhs,
-                N::one(),
-                N::one(),
+                neuter_element,
+                neuter_element,
             ),
             (CSR, false) | (CSC, true) => {
                 let lhs = self.to_other_storage();
                 binop::add_dense_mat_same_ordering(
                     &lhs,
                     rhs,
-                    N::one(),
-                    N::one(),
+                    neuter_element,
+                    neuter_element,
                 )
             }
         }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -25,7 +25,9 @@ use std::hash::Hash;
 /// ```
 use std::iter::{Enumerate, FilterMap, IntoIterator, Peekable, Sum, Zip};
 use std::marker::PhantomData;
-use std::ops::{Add, Deref, DerefMut, Index, IndexMut, Mul, Neg, Sub};
+use std::ops::{
+    Add, Deref, DerefMut, DivAssign, Index, IndexMut, Mul, MulAssign, Neg, Sub,
+};
 use std::slice::{Iter, IterMut};
 
 use num_traits::{Float, Num, Signed, Zero};
@@ -892,7 +894,7 @@ where
     where
         V: DenseVector<Scalar = N>,
         N: Sum,
-        for<'r> &'r N: std::ops::Mul<&'r N, Output = N>,
+        for<'r> &'r N: Mul<&'r N, Output = N>,
     {
         assert_eq!(self.dim(), rhs.dim());
         self.iter()
@@ -904,7 +906,7 @@ where
     pub fn squared_l2_norm(&self) -> N
     where
         N: Sum,
-        for<'r> &'r N: std::ops::Mul<&'r N, Output = N>,
+        for<'r> &'r N: Mul<&'r N, Output = N>,
     {
         self.data.iter().map(|x| x * x).sum()
     }
@@ -913,7 +915,7 @@ where
     pub fn l2_norm(&self) -> N
     where
         N: Float + Sum,
-        for<'r> &'r N: std::ops::Mul<&'r N, Output = N>,
+        for<'r> &'r N: Mul<&'r N, Output = N>,
     {
         self.squared_l2_norm().sqrt()
     }
@@ -1049,7 +1051,7 @@ where
     pub fn unit_normalize(&mut self)
     where
         N: Float + Sum,
-        for<'r> &'r N: std::ops::Mul<&'r N, Output = N>,
+        for<'r> &'r N: Mul<&'r N, Output = N>,
     {
         let norm_sq = self.squared_l2_norm();
         if norm_sq > N::zero() {
@@ -1134,7 +1136,7 @@ impl<Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2> Add<CsVecBase<IS2, DS2, Rhs, I>>
 where
     Lhs: Num,
     Rhs: Num,
-    for<'r> &'r Lhs: std::ops::Add<&'r Rhs, Output = Res>,
+    for<'r> &'r Lhs: Add<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [Lhs]>,
@@ -1153,7 +1155,7 @@ impl<'a, Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2>
 where
     Lhs: Num,
     Rhs: Num,
-    for<'r> &'r Lhs: std::ops::Add<&'r Rhs, Output = Res>,
+    for<'r> &'r Lhs: Add<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [Lhs]>,
@@ -1172,7 +1174,7 @@ impl<'a, Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2> Add<CsVecBase<IS2, DS2, Rhs, I>>
 where
     Lhs: Num,
     Rhs: Num,
-    for<'r> &'r Lhs: std::ops::Add<&'r Rhs, Output = Res>,
+    for<'r> &'r Lhs: Add<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [Lhs]>,
@@ -1191,7 +1193,7 @@ impl<'a, 'b, Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2>
 where
     Lhs: Num,
     Rhs: Num,
-    for<'r> &'r Lhs: std::ops::Add<&'r Rhs, Output = Res>,
+    for<'r> &'r Lhs: Add<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [Lhs]>,
@@ -1210,7 +1212,7 @@ impl<'a, 'b, Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2>
 where
     Lhs: Num,
     Rhs: Num,
-    for<'r> &'r Lhs: std::ops::Sub<&'r Rhs, Output = Res>,
+    for<'r> &'r Lhs: Sub<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [Lhs]>,
@@ -1239,10 +1241,10 @@ where
     }
 }
 
-impl<N, I, IStorage, DStorage> std::ops::MulAssign<N>
+impl<N, I, IStorage, DStorage> MulAssign<N>
     for CsVecBase<IStorage, DStorage, N, I>
 where
-    N: Clone + std::ops::MulAssign<N>,
+    N: Clone + MulAssign<N>,
     I: SpIndex,
     IStorage: Deref<Target = [I]>,
     DStorage: DerefMut<Target = [N]>,
@@ -1254,10 +1256,10 @@ where
     }
 }
 
-impl<N, I, IStorage, DStorage> std::ops::DivAssign<N>
+impl<N, I, IStorage, DStorage> DivAssign<N>
     for CsVecBase<IStorage, DStorage, N, I>
 where
-    N: Clone + std::ops::DivAssign<N>,
+    N: Clone + DivAssign<N>,
     I: SpIndex,
     IStorage: Deref<Target = [I]>,
     DStorage: DerefMut<Target = [N]>,
@@ -1318,7 +1320,7 @@ where
 impl<N, I> Zero for CsVecI<N, I>
 where
     N: Num + Clone,
-    for<'r> &'r N: std::ops::Add<Output = N>,
+    for<'r> &'r N: Add<Output = N>,
     I: SpIndex,
 {
     fn zero() -> Self {
@@ -1339,7 +1341,7 @@ mod alga_impls {
     impl<N, I> AbstractMagma<Additive> for CsVecI<N, I>
     where
         N: Num + Clone,
-        for<'r> &'r N: std::ops::Add<Output = N>,
+        for<'r> &'r N: Add<Output = N>,
         I: SpIndex,
     {
         fn operate(&self, right: &Self) -> Self {
@@ -1350,7 +1352,7 @@ mod alga_impls {
     impl<N, I> Identity<Additive> for CsVecI<N, I>
     where
         N: Num + Clone,
-        for<'r> &'r N: std::ops::Add<Output = N>,
+        for<'r> &'r N: Add<Output = N>,
         I: SpIndex,
     {
         fn identity() -> Self {
@@ -1361,7 +1363,7 @@ mod alga_impls {
     impl<N, I> AbstractSemigroup<Additive> for CsVecI<N, I>
     where
         N: Num + Clone,
-        for<'r> &'r N: std::ops::Add<Output = N>,
+        for<'r> &'r N: Add<Output = N>,
         I: SpIndex,
     {
     }
@@ -1369,7 +1371,7 @@ mod alga_impls {
     impl<N, I> AbstractMonoid<Additive> for CsVecI<N, I>
     where
         N: Num + Copy,
-        for<'r> &'r N: std::ops::Add<Output = N>,
+        for<'r> &'r N: Add<Output = N>,
         I: SpIndex,
     {
     }
@@ -1391,7 +1393,7 @@ mod alga_impls {
     impl<N, I> AbstractQuasigroup<Additive> for CsVecI<N, I>
     where
         N: Num + Clone + Neg<Output = N>,
-        for<'r> &'r N: std::ops::Add<Output = N>,
+        for<'r> &'r N: Add<Output = N>,
         I: SpIndex,
     {
     }
@@ -1399,7 +1401,7 @@ mod alga_impls {
     impl<N, I> AbstractLoop<Additive> for CsVecI<N, I>
     where
         N: Num + Copy + Neg<Output = N>,
-        for<'r> &'r N: std::ops::Add<Output = N>,
+        for<'r> &'r N: Add<Output = N>,
         I: SpIndex,
     {
     }
@@ -1407,7 +1409,7 @@ mod alga_impls {
     impl<N, I> AbstractGroup<Additive> for CsVecI<N, I>
     where
         N: Num + Copy + Neg<Output = N>,
-        for<'r> &'r N: std::ops::Add<Output = N>,
+        for<'r> &'r N: Add<Output = N>,
         I: SpIndex,
     {
     }
@@ -1415,7 +1417,7 @@ mod alga_impls {
     impl<N, I> AbstractGroupAbelian<Additive> for CsVecI<N, I>
     where
         N: Num + Copy + Neg<Output = N>,
-        for<'r> &'r N: std::ops::Add<Output = N>,
+        for<'r> &'r N: Add<Output = N>,
         I: SpIndex,
     {
     }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1204,7 +1204,8 @@ where
 impl<'a, 'b, N, I, IS1, DS1, IS2, DS2> Sub<&'b CsVecBase<IS2, DS2, N, I>>
     for &'a CsVecBase<IS1, DS1, N, I>
 where
-    N: Num + Clone + for<'r> std::ops::SubAssign<&'r N>,
+    N: Num,
+    for<'r> &'r N: std::ops::Sub<Output = N>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [N]>,
@@ -1214,16 +1215,15 @@ where
     type Output = CsVecI<N, I>;
 
     fn sub(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> Self::Output {
-        binop::csvec_binop(self.view(), rhs.view(), |x, y| {
-            let mut res = x.clone();
-            res -= y;
-            res
-        })
-        .unwrap()
+        binop::csvec_binop(self.view(), rhs.view(), |x, y| x - y).unwrap()
     }
 }
 
-impl<N: Num + Clone + Neg<Output = N>, I: SpIndex> Neg for CsVecI<N, I> {
+impl<N, I> Neg for CsVecI<N, I>
+where
+    N: Num + Clone + Neg<Output = N>,
+    I: SpIndex,
+{
     type Output = Self;
 
     fn neg(mut self) -> Self::Output {

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1094,7 +1094,7 @@ where
 {
     type Output = CsVecI<N, I>;
 
-    fn mul(self, rhs: &CsMatBase<N, I, IpS2, IS2, DS2, Iptr>) -> CsVecI<N, I> {
+    fn mul(self, rhs: &CsMatBase<N, I, IpS2, IS2, DS2, Iptr>) -> Self::Output {
         (&self.row_view() * rhs).outer_view(0).unwrap().to_owned()
     }
 }
@@ -1120,7 +1120,7 @@ where
 {
     type Output = CsVecI<N, I>;
 
-    fn mul(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> CsVecI<N, I> {
+    fn mul(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> Self::Output {
         if self.is_csr() {
             prod::csr_mul_csvec(self.view(), rhs.view())
         } else {
@@ -1132,7 +1132,8 @@ where
 impl<N, I, IS1, DS1, IS2, DS2> Add<CsVecBase<IS2, DS2, N, I>>
     for CsVecBase<IS1, DS1, N, I>
 where
-    N: Num + Clone + for<'r> std::ops::AddAssign<&'r N>,
+    N: Num,
+    for<'r> &'r N: std::ops::Add<Output = N>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [N]>,
@@ -1141,7 +1142,7 @@ where
 {
     type Output = CsVecI<N, I>;
 
-    fn add(self, rhs: CsVecBase<IS2, DS2, N, I>) -> CsVecI<N, I> {
+    fn add(self, rhs: CsVecBase<IS2, DS2, N, I>) -> Self::Output {
         &self + &rhs
     }
 }
@@ -1149,7 +1150,8 @@ where
 impl<'a, N, I, IS1, DS1, IS2, DS2> Add<&'a CsVecBase<IS2, DS2, N, I>>
     for CsVecBase<IS1, DS1, N, I>
 where
-    N: Num + Clone + for<'r> std::ops::AddAssign<&'r N>,
+    N: Num,
+    for<'r> &'r N: std::ops::Add<Output = N>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [N]>,
@@ -1158,7 +1160,7 @@ where
 {
     type Output = CsVecI<N, I>;
 
-    fn add(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> CsVecI<N, I> {
+    fn add(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> Self::Output {
         &self + rhs
     }
 }
@@ -1166,7 +1168,8 @@ where
 impl<'a, N, I, IS1, DS1, IS2, DS2> Add<CsVecBase<IS2, DS2, N, I>>
     for &'a CsVecBase<IS1, DS1, N, I>
 where
-    N: Num + Clone + for<'r> std::ops::AddAssign<&'r N>,
+    N: Num,
+    for<'r> &'r N: std::ops::Add<Output = N>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [N]>,
@@ -1175,7 +1178,7 @@ where
 {
     type Output = CsVecI<N, I>;
 
-    fn add(self, rhs: CsVecBase<IS2, DS2, N, I>) -> CsVecI<N, I> {
+    fn add(self, rhs: CsVecBase<IS2, DS2, N, I>) -> Self::Output {
         self + &rhs
     }
 }
@@ -1183,7 +1186,8 @@ where
 impl<'a, 'b, N, I, IS1, DS1, IS2, DS2> Add<&'b CsVecBase<IS2, DS2, N, I>>
     for &'a CsVecBase<IS1, DS1, N, I>
 where
-    N: Num + Clone + for<'r> std::ops::AddAssign<&'r N>,
+    N: Num,
+    for<'r> &'r N: std::ops::Add<Output = N>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
     DS1: Deref<Target = [N]>,
@@ -1192,13 +1196,8 @@ where
 {
     type Output = CsVecI<N, I>;
 
-    fn add(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> CsVecI<N, I> {
-        binop::csvec_binop(self.view(), rhs.view(), |x, y| {
-            let mut res = x.clone();
-            res += y;
-            res
-        })
-        .unwrap()
+    fn add(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> Self::Output {
+        binop::csvec_binop(self.view(), rhs.view(), |x, y| x + y).unwrap()
     }
 }
 
@@ -1214,7 +1213,7 @@ where
 {
     type Output = CsVecI<N, I>;
 
-    fn sub(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> CsVecI<N, I> {
+    fn sub(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> Self::Output {
         binop::csvec_binop(self.view(), rhs.view(), |x, y| {
             let mut res = x.clone();
             res -= y;
@@ -1313,7 +1312,8 @@ where
 
 impl<N, I> Zero for CsVecI<N, I>
 where
-    N: Num + Clone + for<'r> std::ops::AddAssign<&'r N>,
+    N: Num + Clone,
+    for<'r> &'r N: std::ops::Add<Output = N>,
     I: SpIndex,
 {
     fn zero() -> Self {
@@ -1333,7 +1333,8 @@ mod alga_impls {
 
     impl<N, I> AbstractMagma<Additive> for CsVecI<N, I>
     where
-        N: Num + Clone + for<'r> std::ops::AddAssign<&'r N>,
+        N: Num + Clone,
+        for<'r> &'r N: std::ops::Add<Output = N>,
         I: SpIndex,
     {
         fn operate(&self, right: &Self) -> Self {
@@ -1343,7 +1344,8 @@ mod alga_impls {
 
     impl<N, I> Identity<Additive> for CsVecI<N, I>
     where
-        N: Num + Clone + for<'r> std::ops::AddAssign<&'r N>,
+        N: Num + Clone,
+        for<'r> &'r N: std::ops::Add<Output = N>,
         I: SpIndex,
     {
         fn identity() -> Self {
@@ -1353,14 +1355,16 @@ mod alga_impls {
 
     impl<N, I> AbstractSemigroup<Additive> for CsVecI<N, I>
     where
-        N: Num + Clone + for<'r> std::ops::AddAssign<&'r N>,
+        N: Num + Clone,
+        for<'r> &'r N: std::ops::Add<Output = N>,
         I: SpIndex,
     {
     }
 
     impl<N, I> AbstractMonoid<Additive> for CsVecI<N, I>
     where
-        N: Num + Copy + for<'r> std::ops::AddAssign<&'r N>,
+        N: Num + Copy,
+        for<'r> &'r N: std::ops::Add<Output = N>,
         I: SpIndex,
     {
     }
@@ -1381,28 +1385,32 @@ mod alga_impls {
 
     impl<N, I> AbstractQuasigroup<Additive> for CsVecI<N, I>
     where
-        N: Num + Clone + for<'r> std::ops::AddAssign<&'r N> + Neg<Output = N>,
+        N: Num + Clone + Neg<Output = N>,
+        for<'r> &'r N: std::ops::Add<Output = N>,
         I: SpIndex,
     {
     }
 
     impl<N, I> AbstractLoop<Additive> for CsVecI<N, I>
     where
-        N: Num + Copy + for<'r> std::ops::AddAssign<&'r N> + Neg<Output = N>,
+        N: Num + Copy + Neg<Output = N>,
+        for<'r> &'r N: std::ops::Add<Output = N>,
         I: SpIndex,
     {
     }
 
     impl<N, I> AbstractGroup<Additive> for CsVecI<N, I>
     where
-        N: Num + Copy + for<'r> std::ops::AddAssign<&'r N> + Neg<Output = N>,
+        N: Num + Copy + Neg<Output = N>,
+        for<'r> &'r N: std::ops::Add<Output = N>,
         I: SpIndex,
     {
     }
 
     impl<N, I> AbstractGroupAbelian<Additive> for CsVecI<N, I>
     where
-        N: Num + Copy + for<'r> std::ops::AddAssign<&'r N> + Neg<Output = N>,
+        N: Num + Copy + Neg<Output = N>,
+        for<'r> &'r N: std::ops::Add<Output = N>,
         I: SpIndex,
     {
     }

--- a/src/sparse/vec.rs
+++ b/src/sparse/vec.rs
@@ -1129,92 +1129,97 @@ where
     }
 }
 
-impl<N, I, IS1, DS1, IS2, DS2> Add<CsVecBase<IS2, DS2, N, I>>
-    for CsVecBase<IS1, DS1, N, I>
+impl<Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2> Add<CsVecBase<IS2, DS2, Rhs, I>>
+    for CsVecBase<IS1, DS1, Lhs, I>
 where
-    N: Num,
-    for<'r> &'r N: std::ops::Add<Output = N>,
+    Lhs: Num,
+    Rhs: Num,
+    for<'r> &'r Lhs: std::ops::Add<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
-    DS1: Deref<Target = [N]>,
+    DS1: Deref<Target = [Lhs]>,
     IS2: Deref<Target = [I]>,
-    DS2: Deref<Target = [N]>,
+    DS2: Deref<Target = [Rhs]>,
 {
-    type Output = CsVecI<N, I>;
+    type Output = CsVecI<Res, I>;
 
-    fn add(self, rhs: CsVecBase<IS2, DS2, N, I>) -> Self::Output {
+    fn add(self, rhs: CsVecBase<IS2, DS2, Rhs, I>) -> Self::Output {
         &self + &rhs
     }
 }
 
-impl<'a, N, I, IS1, DS1, IS2, DS2> Add<&'a CsVecBase<IS2, DS2, N, I>>
-    for CsVecBase<IS1, DS1, N, I>
+impl<'a, Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2>
+    Add<&'a CsVecBase<IS2, DS2, Rhs, I>> for CsVecBase<IS1, DS1, Lhs, I>
 where
-    N: Num,
-    for<'r> &'r N: std::ops::Add<Output = N>,
+    Lhs: Num,
+    Rhs: Num,
+    for<'r> &'r Lhs: std::ops::Add<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
-    DS1: Deref<Target = [N]>,
+    DS1: Deref<Target = [Lhs]>,
     IS2: Deref<Target = [I]>,
-    DS2: Deref<Target = [N]>,
+    DS2: Deref<Target = [Rhs]>,
 {
-    type Output = CsVecI<N, I>;
+    type Output = CsVecI<Res, I>;
 
-    fn add(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> Self::Output {
+    fn add(self, rhs: &CsVecBase<IS2, DS2, Rhs, I>) -> Self::Output {
         &self + rhs
     }
 }
 
-impl<'a, N, I, IS1, DS1, IS2, DS2> Add<CsVecBase<IS2, DS2, N, I>>
-    for &'a CsVecBase<IS1, DS1, N, I>
+impl<'a, Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2> Add<CsVecBase<IS2, DS2, Rhs, I>>
+    for &'a CsVecBase<IS1, DS1, Lhs, I>
 where
-    N: Num,
-    for<'r> &'r N: std::ops::Add<Output = N>,
+    Lhs: Num,
+    Rhs: Num,
+    for<'r> &'r Lhs: std::ops::Add<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
-    DS1: Deref<Target = [N]>,
+    DS1: Deref<Target = [Lhs]>,
     IS2: Deref<Target = [I]>,
-    DS2: Deref<Target = [N]>,
+    DS2: Deref<Target = [Rhs]>,
 {
-    type Output = CsVecI<N, I>;
+    type Output = CsVecI<Res, I>;
 
-    fn add(self, rhs: CsVecBase<IS2, DS2, N, I>) -> Self::Output {
+    fn add(self, rhs: CsVecBase<IS2, DS2, Rhs, I>) -> Self::Output {
         self + &rhs
     }
 }
 
-impl<'a, 'b, N, I, IS1, DS1, IS2, DS2> Add<&'b CsVecBase<IS2, DS2, N, I>>
-    for &'a CsVecBase<IS1, DS1, N, I>
+impl<'a, 'b, Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2>
+    Add<&'b CsVecBase<IS2, DS2, Rhs, I>> for &'a CsVecBase<IS1, DS1, Lhs, I>
 where
-    N: Num,
-    for<'r> &'r N: std::ops::Add<Output = N>,
+    Lhs: Num,
+    Rhs: Num,
+    for<'r> &'r Lhs: std::ops::Add<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
-    DS1: Deref<Target = [N]>,
+    DS1: Deref<Target = [Lhs]>,
     IS2: Deref<Target = [I]>,
-    DS2: Deref<Target = [N]>,
+    DS2: Deref<Target = [Rhs]>,
 {
-    type Output = CsVecI<N, I>;
+    type Output = CsVecI<Res, I>;
 
-    fn add(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> Self::Output {
+    fn add(self, rhs: &CsVecBase<IS2, DS2, Rhs, I>) -> Self::Output {
         binop::csvec_binop(self.view(), rhs.view(), |x, y| x + y).unwrap()
     }
 }
 
-impl<'a, 'b, N, I, IS1, DS1, IS2, DS2> Sub<&'b CsVecBase<IS2, DS2, N, I>>
-    for &'a CsVecBase<IS1, DS1, N, I>
+impl<'a, 'b, Lhs, Rhs, Res, I, IS1, DS1, IS2, DS2>
+    Sub<&'b CsVecBase<IS2, DS2, Rhs, I>> for &'a CsVecBase<IS1, DS1, Lhs, I>
 where
-    N: Num,
-    for<'r> &'r N: std::ops::Sub<Output = N>,
+    Lhs: Num,
+    Rhs: Num,
+    for<'r> &'r Lhs: std::ops::Sub<&'r Rhs, Output = Res>,
     I: SpIndex,
     IS1: Deref<Target = [I]>,
-    DS1: Deref<Target = [N]>,
+    DS1: Deref<Target = [Lhs]>,
     IS2: Deref<Target = [I]>,
-    DS2: Deref<Target = [N]>,
+    DS2: Deref<Target = [Rhs]>,
 {
-    type Output = CsVecI<N, I>;
+    type Output = CsVecI<Res, I>;
 
-    fn sub(self, rhs: &CsVecBase<IS2, DS2, N, I>) -> Self::Output {
+    fn sub(self, rhs: &CsVecBase<IS2, DS2, Rhs, I>) -> Self::Output {
         binop::csvec_binop(self.view(), rhs.view(), |x, y| x - y).unwrap()
     }
 }

--- a/tests/asymmetric_operands.rs
+++ b/tests/asymmetric_operands.rs
@@ -1,0 +1,83 @@
+//! Test to demonstrate asymmetric operands for binary operators using a custom type
+
+use {
+    sprs::CsVec,
+    std::ops::{Add, Sub},
+};
+
+#[macro_use]
+extern crate num_derive;
+
+#[derive(Debug, PartialEq, Num, One, Zero, NumOps)]
+struct ExampleLhs(i16);
+#[derive(Debug, PartialEq, Num, One, Zero, NumOps)]
+struct ExampleRhs(i32);
+#[derive(Debug, PartialEq, Num, One, Zero, NumOps)]
+struct ExampleRes(i64);
+
+macro_rules! impl_asymmetric_op {
+    ($trait:tt, $func:ident, $op:tt) => {
+        impl $trait<ExampleRhs> for ExampleLhs {
+            type Output = ExampleRes;
+
+            fn $func(self, rhs: ExampleRhs) -> Self::Output {
+                &self $op &rhs
+            }
+        }
+
+        impl<'a, 'b> $trait<&'b ExampleRhs> for &'a ExampleLhs {
+            type Output = ExampleRes;
+
+            fn $func(self, rhs: &'b ExampleRhs) -> Self::Output {
+                let ExampleLhs(lhs) = *self;
+                let ExampleRhs(rhs) = *rhs;
+                ExampleRes(lhs as i64 $op rhs as i64)
+            }
+        }
+    };
+}
+
+impl_asymmetric_op!(Add, add, +);
+impl_asymmetric_op!(Sub, sub, -);
+
+#[test]
+fn asymmetric_operands_add() {
+    let vec_a = CsVec::new(4, vec![0, 2], vec![ExampleLhs(1), ExampleLhs(1)]);
+    let vec_b = CsVec::new(
+        4,
+        vec![0, 1, 2],
+        vec![ExampleRhs(1), ExampleRhs(1), ExampleRhs(1)],
+    );
+
+    let expected_output = CsVec::new(
+        4,
+        vec![0, 1, 2],
+        vec![ExampleRes(2), ExampleRes(1), ExampleRes(2)],
+    );
+    assert_eq!(
+        vec_a + vec_b,
+        expected_output,
+        "testing vector sum with asymmetric operands"
+    );
+}
+
+#[test]
+fn asymmetric_operands_sub() {
+    let vec_a = CsVec::new(4, vec![0, 2], vec![ExampleLhs(1), ExampleLhs(1)]);
+    let vec_b = CsVec::new(
+        4,
+        vec![0, 1, 2],
+        vec![ExampleRhs(1), ExampleRhs(1), ExampleRhs(1)],
+    );
+
+    let expected_output = CsVec::new(
+        4,
+        vec![0, 1, 2],
+        vec![ExampleRes(0), ExampleRes(-1), ExampleRes(0)],
+    );
+    assert_eq!(
+        &vec_a - &vec_b,
+        expected_output,
+        "testing vector difference with asymmetric operands"
+    );
+}


### PR DESCRIPTION
Alters the existing pointwise addition, subtraction, and multiplication binary operators so that they allow for different left-hand and right-hand side operands.

Note that in some cases this can lead to minor backwards incompatibilities due to the need to specify the type of one operand as it cannot be inferred automatically (e.g. when using an "eye" matrix). Please consider bumping the minor version number if merging.