### PR TITLE
sparse by dense parallel products #298

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 
 [features]
 default = ["alga", "multi_thread"]
-multi_thread = ["rayon", "num_cpus"]
+multi_thread = ["rayon", "num_cpus", "ndarray/rayon"]
 
 [dependencies]
 num-traits = "0.2.0"

--- a/src/sparse/csmat.rs
+++ b/src/sparse/csmat.rs
@@ -1901,7 +1901,7 @@ where
 impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Mul<&'b ArrayBase<DS2, Ix2>>
     for &'a CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
-    N: 'a + crate::MulAcc + num_traits::Zero + Clone,
+    N: 'a + crate::MulAcc + num_traits::Zero + Clone + Send + Sync,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IpS: 'a + Deref<Target = [Iptr]>,
@@ -1962,7 +1962,13 @@ where
 impl<'a, 'b, N, I, IpS, IS, DS, DS2> Dot<CsMatBase<N, I, IpS, IS, DS>>
     for ArrayBase<DS2, Ix2>
 where
-    N: 'a + Clone + crate::MulAcc + num_traits::Zero + std::fmt::Debug,
+    N: 'a
+        + Clone
+        + crate::MulAcc
+        + num_traits::Zero
+        + std::fmt::Debug
+        + Send
+        + Sync,
     I: 'a + SpIndex,
     IpS: 'a + Deref<Target = [I]>,
     IS: 'a + Deref<Target = [I]>,
@@ -2013,7 +2019,7 @@ where
 impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Dot<ArrayBase<DS2, Ix2>>
     for CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
-    N: 'a + Clone + crate::MulAcc + num_traits::Zero,
+    N: 'a + Clone + crate::MulAcc + num_traits::Zero + Send + Sync,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IpS: 'a + Deref<Target = [Iptr]>,
@@ -2031,7 +2037,7 @@ where
 impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Mul<&'b ArrayBase<DS2, Ix1>>
     for &'a CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
-    N: 'a + Clone + crate::MulAcc + num_traits::Zero,
+    N: 'a + Clone + crate::MulAcc + num_traits::Zero + Send + Sync,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IpS: 'a + Deref<Target = [Iptr]>,
@@ -2072,7 +2078,7 @@ where
 impl<'a, 'b, N, I, Iptr, IpS, IS, DS, DS2> Dot<ArrayBase<DS2, Ix1>>
     for CsMatBase<N, I, IpS, IS, DS, Iptr>
 where
-    N: 'a + Clone + crate::MulAcc + num_traits::Zero,
+    N: 'a + Clone + crate::MulAcc + num_traits::Zero + Send + Sync,
     I: 'a + SpIndex,
     Iptr: 'a + SpIndex,
     IpS: 'a + Deref<Target = [Iptr]>,


### PR DESCRIPTION
Using `ndarray` parallel iterators this is the naive conversion of the sparse by dense products to a multithreaded implementation. Ideally, there is a `rayon` `into_par_iter` implemenation for the existing `CsMat::outer_iterator` for some of these to be more optimal. In the current implementation, some sparse matrix by dense vector products are still going to be single threaded.